### PR TITLE
DataInPort precedence assertion

### DIFF
--- a/sparta/sparta/events/SchedulingPhases.hpp
+++ b/sparta/sparta/events/SchedulingPhases.hpp
@@ -1,8 +1,8 @@
-// <SchedulingPhases> -*- C++ -*-
+// <SchedulingPhases.hpp> -*- C++ -*-
 
 
 /**
- * \file   SchedulingPhases.h
+ * \file   SchedulingPhases.hpp
  *
  * \brief File that defines the phases used in simulation.
  */

--- a/sparta/sparta/ports/Port.hpp
+++ b/sparta/sparta/ports/Port.hpp
@@ -409,6 +409,9 @@ namespace sparta
          */
         void precedes(InPort & consumer)
         {
+            sparta_assert(getScheduleable_().getSchedulingPhase() == consumer.getScheduleable_().getSchedulingPhase(),
+                          "ERROR: You cannot set precedence between two Ports on different phases: "
+                          "producer: " << getLocation() << " consumer: " << consumer.getLocation());
             getScheduleable_().precedes(consumer.getScheduleable_());
         }
 

--- a/sparta/test/Port/Port_test.cpp
+++ b/sparta/test/Port/Port_test.cpp
@@ -168,6 +168,17 @@ void tryDAGIssue_(bool failit)
     sparta::DataOutPort<bool> zero_delay_out1(&ps, "zero_delay_out1", presume_zero_delay);
     sparta::DataInPort<bool>  zero_delay_in2 (&ps, "zero_delay_in2", sparta::SchedulingPhase::Tick, 0);
     sparta::DataOutPort<bool> zero_delay_out2(&ps, "zero_delay_out2", presume_zero_delay);
+
+    // Test a situation (issue #15) where the user presumed a
+    // zero-delay InPort and attempted to set precedence on a non-zero
+    // delay Inport.  This will assert as the zero delay Port is on
+    // the Tick phase and the non-zero delay inport is on the Update
+    // phase (by default in BOTH cases).
+    if(presume_zero_delay) {
+        sparta::DataInPort<bool> one_delay_in (&ps, "one_delay_in", 1);
+        EXPECT_THROW(zero_delay_in2.precedes(one_delay_in));
+    }
+
     zero_delay_in1.registerConsumerEvent(zero_delay_cons);
     zero_delay_out1.registerProducingEvent(zero_delay_prod);
     zero_delay_in2.registerConsumerEvent(zero_delay_prod);


### PR DESCRIPTION
Added a DataInPort precedence assertion ensuring that a modeler does not put a precedence between two InPorts on difference phases.  Before this assert, the DAG would fire, providing a confusing message.