### PR TITLE
Fixed issue 18: reordered the destruction of taps and resource sets

### DIFF
--- a/sparta/cmake/modules/FindCppcheck.cmake
+++ b/sparta/cmake/modules/FindCppcheck.cmake
@@ -39,7 +39,6 @@ endif ()
 
 find_program (CPPCHECK_BIN NAMES cppcheck)
 find_program (CPPCHECK_HTMLREPORT_BIN NAMES cppcheck-htmlreport)
-set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if (CPPCHECK_BIN)
   message ("-- Adding support for cppcheck")

--- a/sparta/sparta/app/Simulation.hpp
+++ b/sparta/sparta/app/Simulation.hpp
@@ -756,16 +756,16 @@ protected:
     const std::string sim_name_;
 
     /*!
-     * \brief Map of of resources available to this simulation.
-     * This must outlast destruction of the tree root_ and its children
-     */
-    sparta::ResourceSet res_list_;
-
-    /*!
      * \brief User-specified Taps to delete at teardown. These should outlast
      * the entire tree so that they can intercept destruction log messages
      */
     std::vector<std::unique_ptr<sparta::log::Tap>> taps_to_del_;
+
+    /*!
+     * \brief Map of of resources available to this simulation.
+     * This must outlast destruction of the tree root_ and its children
+     */
+    sparta::ResourceSet res_list_;
 
     /*!
      * \brief Scheduler this simulation will use. If no scheduler was given

--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -345,7 +345,7 @@ namespace sparta
                 {
                     std::cerr << "WARNING: Seems that not all of the blocks made it back.  \n'" <<
                         __PRETTY_FUNCTION__ << "'\nAllocated: " << allocated_ <<
-                        "\nReturned: " << free_blocks_.size();
+                        "\nReturned: " << free_blocks_.size() << std::endl;
                 }
             }
 


### PR DESCRIPTION
Also fixed a missing return on a warning and turned off cppcheck compile
command file generation.