### PR TITLE
Mike/simdb

### DIFF
--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -1110,7 +1110,7 @@ void Simulation::saveReports()
             formatters_in_use = report_repository_->getFormattersByFilename();
             db::SimInfoSerializer serializer(SimulationInfo::getInstance());
             serializer.serialize(*stats_db_);
-	    std::cout << "SimDB file is: " << stats_db_->getDatabaseFile() << std::endl;
+            std::cout << "SimDB file is: " << stats_db_->getDatabaseFile() << std::endl;
         }
 
         auto saved_reports = report_repository_->saveReports();

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -1110,6 +1110,7 @@ void Simulation::saveReports()
             formatters_in_use = report_repository_->getFormattersByFilename();
             db::SimInfoSerializer serializer(SimulationInfo::getInstance());
             serializer.serialize(*stats_db_);
+	    std::cout << "SimDB file is: " << stats_db_->getDatabaseFile() << std::endl;
         }
 
         auto saved_reports = report_repository_->saveReports();


### PR DESCRIPTION
Sparta by default always emits a simdb data file.  The default type is sqlite, the default location is /tmp, and the name is auto-generated to be unique (good idea if /tmp is where we really wanted these things to go).  I put a one line change in Simultion.cpp to print out the location of this file to stdout so a user can figure out which one it is.