### PR TITLE
Turned simdb off; reverted Queue allocation/deallocation fix

### DIFF
--- a/sparta/sparta/resources/Queue.hpp
+++ b/sparta/sparta/resources/Queue.hpp
@@ -562,10 +562,11 @@ namespace sparta
          * any time for this data's position in the queue.
          * \warning appends through via this method are immediately valid.
          */
-        QueueIterator<false> push (const value_type & dat) {
+        QueueIterator<false> push (const value_type & dat)
+        {
             sparta_assert(current_write_idx_ <= vector_size_);
             // can't write more than the allowed items
-            new (queue_data_.get() + current_write_idx_) value_type(dat);
+            queue_data_[current_write_idx_] = dat;
             QueueIterator<false> new_entry(this, current_write_idx_, next_unique_id_);
             ++next_unique_id_;
             ++num_added_;
@@ -655,13 +656,6 @@ namespace sparta
         /// Process any pending invalidations.
         void processInvalidations_()
         {
-            // Destruct the items we are about to invalidate
-            size_type idx = current_zero_pos_;
-            while (idx != current_tail_idx_) {
-                queue_data_[idx].~value_type();
-                idx = incrementIndexValue_(idx);
-            }
-
             // the zero position is the tail pos after a compact.
             current_zero_pos_ = current_tail_idx_;
 

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -1953,7 +1953,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
     //while so downstream SPARTA clients can revert to legacy reporting
     //infrastructure if they really need to.
     if (!feature_config_.isFeatureValueSet("simdb")) {
-        feature_config_.setFeatureValue("simdb", 1);
+        feature_config_.setFeatureValue("simdb", 0);
     }
     sim->setFeatureConfig(&feature_config_);
 


### PR DESCRIPTION
I normally don't like having two issues into one, but I needed to undo the Queue fix to get this change to regress.