### PR TITLE
SpartaSharedPointer: Fix for issue #17, #48, and #53

### DIFF
--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -97,7 +97,7 @@ namespace sparta
          * Construct a new Reference Pointer and take initial
          * ownership of the given object pointer.
          */
-        explicit SpartaSharedPointer(PointerT * p = nullptr) :
+        explicit SpartaSharedPointer(PointerT * p = nullptr) noexcept :
             ref_count_(new RefCount(p))
         { }
 
@@ -105,7 +105,7 @@ namespace sparta
          * \brief Constructor for SpartaSharedPointer<T> ptr = nullptr;
          * \param nullptr_t
          */
-        constexpr SpartaSharedPointer(std::nullptr_t) :
+        constexpr SpartaSharedPointer(std::nullptr_t) noexcept :
             ref_count_(new RefCount(nullptr))
         { }
 
@@ -115,7 +115,7 @@ namespace sparta
          *
          * The two reference pointers now share the common memory
          */
-        SpartaSharedPointer(const SpartaSharedPointer & orig) :
+        SpartaSharedPointer(const SpartaSharedPointer & orig) noexcept :
             memory_block_(orig.memory_block_),
             ref_count_(orig.ref_count_)
         {
@@ -129,7 +129,7 @@ namespace sparta
          * This SpartaSharedPointer now replaces orig.  Orig becomes a
          * nullptr with no references
          */
-        SpartaSharedPointer(SpartaSharedPointer && orig) :
+        SpartaSharedPointer(SpartaSharedPointer && orig) noexcept :
             memory_block_(orig.memory_block_),
             ref_count_(orig.ref_count_)
         {
@@ -150,7 +150,8 @@ namespace sparta
          *
          * The two reference pointers now share the common memory
          */
-        SpartaSharedPointer & operator=(const SpartaSharedPointer & orig) {
+        SpartaSharedPointer & operator=(const SpartaSharedPointer & orig)
+        {
             sparta_assert(&orig != this);
             unlink_();
             memory_block_ = orig.memory_block_;

--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -631,7 +631,7 @@ namespace sparta
                 }
                 else {
                     if(SPARTA_EXPECT_FALSE(allocated_ > water_mark_)) {
-                        if(!water_mark_warning_) {
+                        if(SPARTA_EXPECT_FALSE(!water_mark_warning_)) {
                             watermark_warning_callback_(*this);
                             water_mark_warning_ = true;
                         }

--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -30,7 +30,7 @@ namespace sparta
      * void foo()
      * {
      *    sparta::SpartaSharedPointer<int> ptr(new int);
-     *    int * t = new int(0);   // Totally unsafe, BTW
+     *    int * t = new int(0);   // Don't do this, BTW
      *    sparta::SpartaSharedPointer<int> ptr2(t);
      *
      *    ptr2 = ptr;
@@ -56,7 +56,7 @@ namespace sparta
         {
             explicit RefCount(PointerT * _p,
                               bool perform_delete = true) :
-                count(1),
+                count(_p != nullptr ? 1 : 0),
                 p(_p),
                 perform_delete_(perform_delete)
             {}
@@ -88,7 +88,7 @@ namespace sparta
 
     public:
         //! Expected typedef for the resource type.
-        typedef PointerT element_type;
+        using element_type = PointerT;
 
         /**
          * \brief Construct a Reference Pointer with the given memory object
@@ -122,6 +122,22 @@ namespace sparta
             ++ref_count_->count;
         }
 
+        /**
+         * \brief Take ownership of a reference pointer
+         * \param orig The original pointer
+         *
+         * This SpartaSharedPointer now replaces orig.  Orig becomes a
+         * nullptr with no references
+         */
+        SpartaSharedPointer(SpartaSharedPointer && orig) :
+            memory_block_(orig.memory_block_),
+            ref_count_(orig.ref_count_)
+        {
+            // DO NOT unlink.
+            orig.memory_block_ = nullptr;
+            orig.ref_count_ = new RefCount(nullptr);
+        }
+
         //! \brief Detach this shared pointer; if last, delete underlying object
         ~SpartaSharedPointer() {
             unlink_();
@@ -140,6 +156,25 @@ namespace sparta
             memory_block_ = orig.memory_block_;
             ref_count_ = orig.ref_count_;
             ++ref_count_->count;
+            return *this;
+        }
+
+        /**
+         * \brief Assignment move operator
+         * \param orig The original pointer to be moved
+         * \return Reference to this
+         *
+         * The rvalue is assigned into this class, with this class
+         * unlinking itself from it's original pointer
+         */
+        SpartaSharedPointer & operator=(SpartaSharedPointer && orig)
+        {
+            sparta_assert(&orig != this);
+            unlink_();
+            memory_block_ = orig.memory_block_;
+            ref_count_    = orig.ref_count_;
+            orig.memory_block_ = nullptr;
+            orig.ref_count_ = new RefCount(nullptr);
             return *this;
         }
 
@@ -204,6 +239,15 @@ namespace sparta
             memory_block_  = nullptr;
         }
 
+        /**
+         * \brief Get the current reference count
+         * \return The current reference count
+         */
+        uint32_t use_count() const {
+            sparta_assert(ref_count_ != nullptr);
+            return ref_count_->count;
+        }
+
         // Allocation helpers
 
         /*!
@@ -217,11 +261,54 @@ namespace sparta
          * prevent others from using this class with std types like
          * std::shared_ptr, std::vector, etc.  Also, this class *is
          * not* thread safe.  Do not expect it to work in a threaded
-         * application.  Also, the allocator *must outlive* any
-         * simulator componentry that uses objects allocated by this
-         * allocator.  If not, random seg faults will plague the
-         * developer.  Suggested use is to make this allocator global,
-         * with user-defined atomic operations if desired.
+         * application where multiple threads are
+         * allocating/deallocating with the same
+         * sparta::SpartaSharedPointerAllocator instance.
+         *
+         * Also, the allocator *must outlive* any simulator
+         * componentry that uses objects allocated by this allocator.
+         * If not, random seg faults will plague the developer.
+         * Suggested use is to make this allocator global, with
+         * user-defined atomic operations if desired.
+         *
+         * A suggestion for Sparta developers using these allocators
+         * is to create an `Allocator` class type that derives from
+         * sparta::TreeNode and place that class somewhere in the
+         * simulation under root:
+         *
+         * \code
+         *
+         * // Define a specific TreeNode that is just allocators
+         * class OurAllocators : public sparta::TreeNode
+         * {
+         * public:
+         *      // Constructors and what-not...
+         *
+         *      // Allocators
+         *      using MyAllocator = sparta::SpartaSharedPointer<MyClassIUseALot>::SpartaSharedPointerAllocator;
+         *      MyAllocator my_allocator(100, 200);  // whatever params you chose
+         * };
+         *
+         * \endcode
+         *
+         * And in the modeler's block, they would retrive the
+         * `OurAllocators` node and get the allocator:
+         *
+         * \code
+         *
+         * class MyDevice : public sparta::Unit
+         * {
+         * public:
+         *     MyDevice(sparta::TreeNode * my_container, sparta::ParameterSet *) :
+         *         my_allocator_(customUtilToFindTheAllocatorTreeNode(my_container)->my_allocator)
+         *     {}
+         *
+         * private:
+         *
+         *     OurAllocators::MyAllocator & my_allocator_;
+         * };
+         *
+         * \endcode
          *
          * The class is not intended to be used directly, but rather
          * in compliment with the allocator method
@@ -312,6 +399,13 @@ namespace sparta
         {
         public:
 
+            //! Handy typedef
+            using element_type = PointerT;
+
+            //! Used for defining a custom watermark callback.
+            //! Default is to print a warning
+            using WaterMarkWarningCallback = std::function<void (const SpartaSharedPointerAllocator &)>;
+
             /**
              * \brief Construct this allocator with num_blocks of initial memory
              * \param max_num_blocks The maximum number of blocks this allocator is allowed to use
@@ -326,7 +420,8 @@ namespace sparta
             SpartaSharedPointerAllocator(const size_t max_num_blocks,
                                          const size_t water_mark) :
                 memory_blocks_(max_num_blocks),
-                water_mark_(water_mark)
+                water_mark_(water_mark),
+                watermark_warning_callback_(waterMarkWarningCallback_)
             {
                 sparta_assert(water_mark <= max_num_blocks,
                               "The water_mark on SpartaSharedPointerAllocator should be less than or " <<
@@ -395,6 +490,17 @@ namespace sparta
                 }
 
                 return allocated_objs;
+            }
+
+            /**
+             * \brief Set a custom watermark callback
+             *
+             * \param callback The callback to use when the allocator hits the watermark
+             *
+             * The callback will be called only once after the watermark was hit.
+             */
+            void registerCustomWaterMarkCallback(const WaterMarkWarningCallback & callback) {
+                watermark_warning_callback_ = callback;
             }
 
         private:
@@ -525,11 +631,7 @@ namespace sparta
                 else {
                     if(SPARTA_EXPECT_FALSE(allocated_ > water_mark_)) {
                         if(!water_mark_warning_) {
-                            std::cerr << "WARNING: The watermark for this allocator has been surpassed: \n\n\t"
-                                      << __PRETTY_FUNCTION__
-                                      << "\n\n"
-                                      << "\t\tNumber blocks preallocated: " << memory_blocks_.capacity()
-                                      << "\n\t\tWatermark                 : " << water_mark_ << std::endl;
+                            watermark_warning_callback_(*this);
                             water_mark_warning_ = true;
                         }
 
@@ -550,6 +652,15 @@ namespace sparta
                 return block;
             }
 
+            // Default watermark warning callback
+            static void waterMarkWarningCallback_(const SpartaSharedPointerAllocator & allocator) {
+                std::cerr << "WARNING: The watermark for this allocator has been surpassed: \n\n\t"
+                          << __PRETTY_FUNCTION__
+                          << "\n\n"
+                          << "\t\tNumber blocks preallocated: " << allocator.memory_blocks_.capacity()
+                          << "\n\t\tWatermark                 : " << allocator.water_mark_ << std::endl;
+            }
+
             /**
              * \brief Return the block of memory back to the "pool"
              * \param block The block to return
@@ -566,12 +677,13 @@ namespace sparta
                 ++free_idx_;
             }
 
-            MemBlockVector          memory_blocks_;
-            std::vector<MemBlock*>  free_blocks_;
-            size_t                  free_idx_ = 0;
-            size_t                  allocated_  = 0;
-            const size_t            water_mark_;
-            bool                    water_mark_warning_ = false;
+            MemBlockVector           memory_blocks_;
+            std::vector<MemBlock*>   free_blocks_;
+            size_t                   free_idx_ = 0;
+            size_t                   allocated_  = 0;
+            const size_t             water_mark_;
+            bool                     water_mark_warning_ = false;
+            WaterMarkWarningCallback watermark_warning_callback_;
         };
 
     private:

--- a/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
+++ b/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
@@ -108,7 +108,73 @@ void testBasicSpartaSharedPointer()
 
 }
 
+void testMoveSupport()
+{
+    MyType * orig_type;
+    sparta::SpartaSharedPointer<MyType> ptr(orig_type = new MyType);
+    sparta::SpartaSharedPointer<MyType> ptr2(ptr);
+    EXPECT_TRUE(ptr != nullptr);
+    EXPECT_EQUAL(ptr.use_count(), 2);
+    EXPECT_TRUE(ptr.get() == orig_type);
+
+    // Move construct with the first pointer.  The first pointer
+    // should be null after the move
+    sparta::SpartaSharedPointer<MyType> ptr3(std::move(ptr));
+    EXPECT_TRUE(ptr == nullptr);
+    EXPECT_EQUAL(ptr.use_count(), 0);
+    EXPECT_TRUE(ptr3.get() == orig_type);
+    EXPECT_EQUAL(ptr3.use_count(), 2);
+
+    // Move assign with the third pointer.  The third pointer
+    // should be null after the move
+    MyType * untouched_ptr;
+    sparta::SpartaSharedPointer<MyType> untouched(untouched_ptr = new MyType);
+    sparta::SpartaSharedPointer<MyType> ptr4(untouched);
+    EXPECT_EQUAL(ptr4.use_count(), 2);
+    EXPECT_TRUE(ptr4.get() == untouched.get());
+    EXPECT_TRUE(ptr4 == untouched);
+    EXPECT_EQUAL(untouched.use_count(), 2);
+
+    // now, move ptr3.  Ptr4 should leave untouched alone and nullify
+    // ptr3.
+    ptr4 = std::move(ptr3);
+
+    EXPECT_TRUE(ptr3 == nullptr);
+    EXPECT_EQUAL(ptr3.use_count(), 0);
+    EXPECT_TRUE(ptr4.get() == orig_type);
+    EXPECT_EQUAL(ptr4.use_count(), 2);
+
+    EXPECT_EQUAL(untouched.use_count(), 1);
+    EXPECT_EQUAL(untouched.get(), untouched_ptr);
+
+    // Try moving bogus ones
+    sparta::SpartaSharedPointer<MyType> ptr5 = nullptr;
+    sparta::SpartaSharedPointer<MyType> ptr6(std::move(ptr5));
+
+    sparta::SpartaSharedPointer<MyType> ptr7 = nullptr;
+    sparta::SpartaSharedPointer<MyType> ptr8;
+    ptr8 = std::move(ptr7);
+
+    EXPECT_EQUAL(ptr5.use_count(), 0);
+    EXPECT_EQUAL(ptr6.use_count(), 0);
+    EXPECT_EQUAL(ptr7.use_count(), 0);
+    EXPECT_EQUAL(ptr8.use_count(), 0);
+
+    EXPECT_EQUAL(ptr5.get(), nullptr);
+    EXPECT_EQUAL(ptr6.get(), nullptr);
+    EXPECT_EQUAL(ptr7.get(), nullptr);
+    EXPECT_EQUAL(ptr8.get(), nullptr);
+
+}
+
 #define COUNT 10
+
+bool warning_issued = false;
+void waterMarkCallback(const decltype(trivial_type_allocator) & allocator)
+{
+    std::cout << __PRETTY_FUNCTION__ << ": watermark hit" << std::endl;
+    warning_issued = true;
+}
 
 void testMemoryAllocation(const bool test_warning,
                           const bool test_error)
@@ -158,12 +224,14 @@ void testMemoryAllocation(const bool test_warning,
     outstand_objects = trivial_type_allocator.getOutstandingAllocatedObjects();
     EXPECT_EQUAL(outstand_objects.size(), 0);
 
+
     if(test_warning)
     {
         // Test the watermark
         const size_t max = 10;
         const size_t water = 8;
         sparta::SpartaSharedPointer<MyType>::SpartaSharedPointerAllocator limited_allocator(max, water);
+        limited_allocator.registerCustomWaterMarkCallback(waterMarkCallback);
         for(uint32_t i = 0; i < max; ++i) {
             sparta::SpartaSharedPointer<MyType> ptr =
                 sparta::allocate_sparta_shared_pointer<MyType>(limited_allocator, 30);
@@ -173,6 +241,7 @@ void testMemoryAllocation(const bool test_warning,
         for(auto & p : ptrs) {
             p.reset();
         }
+        EXPECT_TRUE(warning_issued);
     }
 
     if(test_error) {
@@ -281,6 +350,7 @@ int main()
 {
     testBasicSpartaSharedPointer();
     testBasicAllocationSupport();
+    testMoveSupport();
     for(uint32_t i = 0; i < 100; ++i) {
         testMemoryAllocation(i == 0, i == 0);
     }


### PR DESCRIPTION
Fix for Issue #17: updated the comments to illustrate how to create a safe Allocator
Fix for issue #48: Added a means for a developer to add a watermark callback to the Allocator
Fix for Issue #53: Added move support for construction and assignment.