### PR TITLE
SpartaSharedPointer: completely nullified the moved SpartaSP object

### DIFF
--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -166,6 +166,8 @@ namespace sparta
         {
             sparta_assert(&orig != this);
             sparta_assert(orig.ref_count_ != nullptr,
+                          "Assigning from a dead SpartaSharedPointer");
+            sparta_assert(ref_count_ != nullptr,
                           "Assigning to a dead SpartaSharedPointer");
             unlink_();
             memory_block_ = orig.memory_block_;
@@ -187,6 +189,8 @@ namespace sparta
             sparta_assert(&orig != this);
             sparta_assert(orig.ref_count_ != nullptr,
                           "Moving from a dead SpartaSharedPointer");
+            sparta_assert(ref_count_ != nullptr,
+                          "Move to a dead SpartaSharedPointer");
             unlink_();
             memory_block_ = orig.memory_block_;
             ref_count_    = orig.ref_count_;

--- a/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
+++ b/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
@@ -164,6 +164,9 @@ void testMoveSupport()
     EXPECT_THROW(ptr7.get());
     EXPECT_EQUAL(ptr8.get(), nullptr);
 
+    EXPECT_THROW(ptr5 = ptr8);
+    EXPECT_THROW(ptr5 = std::move(ptr8));
+
 }
 
 #define COUNT 10

--- a/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
+++ b/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
@@ -120,8 +120,8 @@ void testMoveSupport()
     // Move construct with the first pointer.  The first pointer
     // should be null after the move
     sparta::SpartaSharedPointer<MyType> ptr3(std::move(ptr));
-    EXPECT_TRUE(ptr == nullptr);
-    EXPECT_EQUAL(ptr.use_count(), 0);
+
+    EXPECT_THROW(ptr.use_count());
     EXPECT_TRUE(ptr3.get() == orig_type);
     EXPECT_EQUAL(ptr3.use_count(), 2);
 
@@ -139,8 +139,7 @@ void testMoveSupport()
     // ptr3.
     ptr4 = std::move(ptr3);
 
-    EXPECT_TRUE(ptr3 == nullptr);
-    EXPECT_EQUAL(ptr3.use_count(), 0);
+    EXPECT_THROW(ptr3.use_count());
     EXPECT_TRUE(ptr4.get() == orig_type);
     EXPECT_EQUAL(ptr4.use_count(), 2);
 
@@ -155,14 +154,14 @@ void testMoveSupport()
     sparta::SpartaSharedPointer<MyType> ptr8;
     ptr8 = std::move(ptr7);
 
-    EXPECT_EQUAL(ptr5.use_count(), 0);
+    EXPECT_THROW(ptr5.use_count());
     EXPECT_EQUAL(ptr6.use_count(), 0);
-    EXPECT_EQUAL(ptr7.use_count(), 0);
+    EXPECT_THROW(ptr7.use_count());
     EXPECT_EQUAL(ptr8.use_count(), 0);
 
-    EXPECT_EQUAL(ptr5.get(), nullptr);
+    EXPECT_THROW(ptr5.get());
     EXPECT_EQUAL(ptr6.get(), nullptr);
-    EXPECT_EQUAL(ptr7.get(), nullptr);
+    EXPECT_THROW(ptr7.get());
     EXPECT_EQUAL(ptr8.get(), nullptr);
 
 }


### PR DESCRIPTION
Added asserts on accessors to enure a user is NOT working with a dead
SpartaSharedPointer.  This brought the speed of SpartaSharedPointer back
to fast.