### PR TITLE
Found and fixed a bug in SpartaSharedP's refcounter

### DIFF
--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -56,7 +56,7 @@ namespace sparta
         {
             explicit RefCount(PointerT * _p,
                               bool perform_delete = true) :
-                count(_p != nullptr ? 1 : 0),
+                count(1),
                 p(_p),
                 perform_delete_(perform_delete)
             {}
@@ -80,15 +80,15 @@ namespace sparta
             // an assert).  This function is called by the destructor,
             // which already checks for this.
             --ref_count_->count;
-            if(SPARTA_EXPECT_FALSE(ref_count_->count <= 0))
+            if(SPARTA_EXPECT_FALSE(ref_count_->count == 0))
             {
                 if(memory_block_) {
                     memory_block_->alloc->release_(memory_block_);
                 }
                 else {
                     delete ref_count_;
-                    ref_count_ = 0;
                 }
+                ref_count_ = 0;
             }
         }
 
@@ -268,11 +268,11 @@ namespace sparta
 
         /**
          * \brief Get the current reference count
-         * \return The current reference count
+         * \return The current reference count. 0 if this SpartaSharedPointer points to nullptr
          */
         uint32_t use_count() const {
             sparta_assert(ref_count_ != nullptr, "This is a dead SpartaSharedPointer");
-            return ref_count_->count;
+            return ref_count_->p ? ref_count_->count : 0;
         }
 
         // Allocation helpers

--- a/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
+++ b/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
@@ -106,6 +106,12 @@ void testBasicSpartaSharedPointer()
 
     EXPECT_TRUE(*int_ptr == 5);
 
+
+    sparta::SpartaSharedPointer<MyType> ptr6;
+    {
+        sparta::SpartaSharedPointer<MyType> ptr7(ptr6);
+    }
+
 }
 
 void testMoveSupport()


### PR DESCRIPTION
The count is supposed to be 0 if the pointer is nullptr, but this is a pain
to think about copies, moves, and assignments.  Put it back to using a positive count
and simply have use_count return 0 for nullptr pointer assignments.  Turns out, this is
what shared_ptr does.