### PR TITLE
PairDefinition use requires a type named `type`. Change it to 'SpartaPairDefinitionType'.

### DIFF
--- a/sparta/example/CoreModel/src/ExampleInst.hpp
+++ b/sparta/example/CoreModel/src/ExampleInst.hpp
@@ -28,8 +28,8 @@ namespace core_example
     class ExampleInst {
     public:
 
-        // The modeler needs to alias a type called "type" to the Pair Definition class  of itself
-        using type = ExampleInstPairDef;
+        // The modeler needs to alias a type called "SpartaPairDefinitionType" to the Pair Definition class  of itself
+        using SpartaPairDefinitionType = ExampleInstPairDef;
 
         enum class Status : std::uint16_t{
             FETCHED = 0,
@@ -137,7 +137,6 @@ namespace core_example
             is_speculative_ = spec;
         }
 
-        std::string getMnemonicAsString() const { return std::string(static_inst_.mnemonic); }
         const char* getMnemonic() const { return static_inst_.mnemonic; }
         uint32_t getOpCode() const { return static_inst_.encoding; }
         uint64_t getVAdr() const { return vaddr_; }

--- a/sparta/example/CoreModel/src/LSU.hpp
+++ b/sparta/example/CoreModel/src/LSU.hpp
@@ -109,8 +109,8 @@ namespace core_example
         class MemoryAccessInfo {
         public:
 
-            // The modeler needs to alias a type called "type" to the Pair Definition class of itself
-            using type = MemoryAccessInfoPairDef;
+            // The modeler needs to alias a type called "SpartaPairDefinitionType" to the Pair Definition class of itself
+            using SpartaPairDefinitionType = MemoryAccessInfoPairDef;
 
             enum class MMUState : std::uint32_t {
                 NO_ACCESS = 0,
@@ -215,8 +215,8 @@ namespace core_example
         class LoadStoreInstInfo
         {
         public:
-            // The modeler needs to alias a type called "type" to the Pair Definition class  of itself
-            using type = LoadStoreInstInfoPairDef;
+            // The modeler needs to alias a type called "SpartaPairDefinitionType" to the Pair Definition class  of itself
+            using SpartaPairDefinitionType = LoadStoreInstInfoPairDef;
             enum class IssuePriority : std::uint16_t
             {
                 HIGHEST = 0,

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -404,15 +404,15 @@ namespace sparta{
          * The only way to check this is to find out if this DataT type has a type alias inside
          * its namespace which is derived from sparta::PairDefinition class which in turn must be templatized
          * on the actual Collectable class or the DataT type itself, that we want to collect.
-         * That is why we have a type named "type" inside the Actual Collectable class which refers to its
+         * That is why we have a type named "SpartaPairDefinitionType" inside the Actual Collectable class which refers to its
          * PairDefinition type.
-         * For the same reason, we have a type named "type" inside the Pair Definition class which refers
+         * For the same reason, we have a type named "SpartaPairDefinitionType" inside the Pair Definition class which refers
          * to its Actual Collectable type.
-         * The std::enable_if template switching basically checks if the DataType has a type named "type",
+         * The std::enable_if template switching basically checks if the DataType has a type named "SpartaPairDefinitionType",
          * which is actually a PairDefinition of itself, a Pair Collectable Entity, or not.
-         * The only way to check if DataType has a type "type" which is Pair Definition of itself, a
+         * The only way to check if DataType has a type "SpartaPairDefinitionType" which is Pair Definition of itself, a
          * Collectable Entity or not, is by using SFINAE(Substitution Failure Is Not An Error).
-         * It checks if DataType has a type "type" in its namespace which derives from sparta::PairDefinition
+         * It checks if DataType has a type "SpartaPairDefinitionType" in its namespace which derives from sparta::PairDefinition
          * which is templatized on the the DataType itself.
          * If this exact piece of code is substituted to form a well-formed code, this template overload is
          * selected by compiler. If this does not work, then the compiler creates an ill-formed code.
@@ -427,14 +427,14 @@ namespace sparta{
         template<typename DataT, SchedulingPhase collection_phase>
         class Collectable<DataT, collection_phase, MetaStruct::enable_if_t<
             std::is_base_of<sparta::PairDefinition<MetaStruct::remove_any_pointer_t<DataT>>,
-                typename MetaStruct::remove_any_pointer_t<DataT>::type>::value>> :
-                    public sparta::PairCollector<typename MetaStruct::remove_any_pointer_t<DataT>::type>,
+                typename MetaStruct::remove_any_pointer_t<DataT>::SpartaPairDefinitionType>::value>> :
+                    public sparta::PairCollector<typename MetaStruct::remove_any_pointer_t<DataT>::SpartaPairDefinitionType>,
                         public CollectableTreeNode {
             // Aliasing the actual Datatype of the collectable being collected as Data_t
-            typedef typename MetaStruct::remove_any_pointer<DataT>::type Data_t;
+            typedef MetaStruct::remove_any_pointer_t<DataT> Data_t;
 
             // Aliasing the Datatype of the Pair Definition of the collectable being collected as PairDef_t
-            typedef typename Data_t::type PairDef_t;
+            typedef typename Data_t::SpartaPairDefinitionType PairDef_t;
 
             // Making a bunch of APIs of PairCollector class being available to us with the using directive
             using PairCollector<PairDef_t>::getNameStrings;

--- a/sparta/sparta/pairs/SpartaKeyPairs.hpp
+++ b/sparta/sparta/pairs/SpartaKeyPairs.hpp
@@ -2015,7 +2015,7 @@ namespace sparta {
         template<typename T, typename... Args>
         MetaStruct::enable_if_t<!std::is_abstract<T>::value, void>
         processIfAbstractBaseType_(Args &&... args) {
-            T::type::nestedPairCallback(this, std::forward<Args>(args)...);
+            T::SpartaPairDefinitionType::nestedPairCallback(this, std::forward<Args>(args)...);
         }
 
         //! Type is Virtual Abstract.
@@ -2061,7 +2061,7 @@ namespace sparta {
             explicit UnrollTypeList_(const T & ptr, Args &&... args) :
                 UnrollTypeList_<T, MetaTypeList::type_list<Tail...>, Args...>(
                     ptr, std::forward<Args>(args)...) {
-                Head::type::nestedPairCallback(ptr, std::forward<Args>(args)...);
+                Head::SpartaPairDefinitionType::nestedPairCallback(ptr, std::forward<Args>(args)...);
             }
         };
 

--- a/sparta/sparta/pevents/NestedPeventCollector.hpp
+++ b/sparta/sparta/pevents/NestedPeventCollector.hpp
@@ -33,13 +33,13 @@ namespace pevents {
     class NestedPeventCollector :
         public sparta::PairCollector<
             typename MetaStruct::remove_any_pointer<
-                DataT>::type::type>, public PeventCollectorTreeNode {
+                DataT>::type::SpartaPairDefinitionType>, public PeventCollectorTreeNode {
 
         // Aliasing the actual Datatype of the collectable being collected as Data_t
         typedef typename MetaStruct::remove_any_pointer<DataT>::type Data_t;
 
         // Aliasing the Datatype of the Pair Definition of the collectable being collected as PairDef_t
-        typedef typename Data_t::type PairDef_t;
+        typedef typename Data_t::SpartaPairDefinitionType PairDef_t;
 
         using PairCollector<PairDef_t>::getPEventLogVector;
         using PairCollector<PairDef_t>::turnOn_;

--- a/sparta/test/NestedPEvents/NestedPEventHelper_test.cpp
+++ b/sparta/test/NestedPEvents/NestedPEventHelper_test.cpp
@@ -77,7 +77,7 @@ inline std::ostream & operator << (std::ostream & os, const EnumClass & obj) {
 class DPPairDef;
 class DrawPacket {
 public:
-    using type = DPPairDef;
+    using SpartaPairDefinitionType = DPPairDef;
     DrawPacket(uint16_t val1, uint32_t val2, double val3,
         const EnumClass & val4, uint64_t val5, std::string val6) :
         val_1_(val1), val_2_(val2), val_3_(val3),
@@ -118,7 +118,7 @@ class Derived_1PairDef;
 //! Class Derived_1.
 class Derived_1 : public Base {
 public:
-    using type = Derived_1PairDef;
+    using SpartaPairDefinitionType = Derived_1PairDef;
     Derived_1(uint16_t val1, uint32_t val2,
         double val3, std::string val4,
             const std::shared_ptr<DrawPacket> & ptr) :
@@ -155,7 +155,7 @@ class Derived_2PairDef;
 //! Class Derived_2.
 class Derived_2 : public Base {
 public:
-    using type = Derived_2PairDef;
+    using SpartaPairDefinitionType = Derived_2PairDef;
     Derived_2(uint16_t val1, uint32_t val2) :
         val_1_(val1), val_2_(val2) {}
     uint16_t getVal1() const { return val_1_; }
@@ -182,7 +182,7 @@ class Derived_3PairDef;
 //! Class Derived_3.
 class Derived_3 : public Base {
 public:
-    using type = Derived_3PairDef;
+    using SpartaPairDefinitionType = Derived_3PairDef;
     Derived_3(uint16_t val1, uint32_t val2, double val3, std::string val4, std::string val5) :
         val_1_(val1), val_2_(val2), val_3_(val3), val_4_(val4), val_5_(val5) {}
     uint16_t getVal1() const { return val_1_; }
@@ -217,7 +217,7 @@ class Derived_4PairDef;
 //! Class Derived_3.
 class Derived_4 : public Base {
 public:
-    using type = Derived_4PairDef;
+    using SpartaPairDefinitionType = Derived_4PairDef;
 
     Derived_4(bool b_v, uint16_t val1, uint32_t val2, float val3,
         double dv, std::string val4, std::string val5) :
@@ -262,7 +262,7 @@ class CollectedA;
  */
 class A {
 public:
-    using type = CollectedA;
+    using SpartaPairDefinitionType = CollectedA;
     A(uint16_t val, uint16_t lav, uint32_t foo,
         uint64_t bar, const std::string& q,
             const std::shared_ptr<Base> & bp) :
@@ -310,7 +310,7 @@ public:
 class CollectedB;
 class B {
 public:
-    using type = CollectedB;
+    using SpartaPairDefinitionType = CollectedB;
 
     B(const A_Ptr& ptr, uint16_t val, uint16_t lav,
         uint32_t foo, uint64_t bar, const std::string& q,
@@ -362,7 +362,7 @@ public:
 class LambdaCollectPD;
 class LambdaCollect {
 public:
-    using type = LambdaCollectPD;
+    using SpartaPairDefinitionType = LambdaCollectPD;
     LambdaCollect(uint16_t i, uint32_t j, uint32_t k) : i{i}, j{j}, k{k} {}
     uint16_t getI() const { return i; };
     uint32_t getJ() const { return j; };

--- a/sparta/test/PairCollector/Collectable_test.cpp
+++ b/sparta/test/PairCollector/Collectable_test.cpp
@@ -41,7 +41,7 @@
 class Level_1_PairDef;
 class Level_1{
 public:
-    using type = Level_1_PairDef;
+    using SpartaPairDefinitionType = Level_1_PairDef;
     Level_1(uint64_t uid, uint64_t vaddr, uint64_t raddr,
             const std::vector<uint16_t>& vec) :
             uid_(uid), vaddr_(vaddr), raddr_(raddr), vec_(vec) {}
@@ -86,7 +86,7 @@ inline std::ostream& operator << (std::ostream& os, const std::vector<uint16_t>&
 class Level_2_PairDef;
 class Level_2{
 public:
-    using type = Level_2_PairDef;
+    using SpartaPairDefinitionType = Level_2_PairDef;
     enum class TargetUnit : std::uint8_t{
         ALU0,
         ALU1,
@@ -161,7 +161,7 @@ public:
 class Level_3_PairDef;
 class Level_3{
 public:
-    using type = Level_3_PairDef;
+    using SpartaPairDefinitionType = Level_3_PairDef;
     enum class MMUState : std::uint8_t {
         NO_ACCESS,
         MISS,
@@ -241,7 +241,7 @@ public:
 class Level_4_PairDef;
 class Level_4{
 public:
-    using type = Level_4_PairDef;
+    using SpartaPairDefinitionType = Level_4_PairDef;
     enum class IssuePriority : std::uint8_t {
         HIGHEST,
         CACHE_RELOAD,   // Receive mss ack, waiting for cache re-access
@@ -339,7 +339,7 @@ public:
 class Level_5_PairDef;
 class Level_5{
 public:
-    using type = Level_5_PairDef;
+    using SpartaPairDefinitionType = Level_5_PairDef;
     enum class Mnemonic : std::uint8_t {
         ADC,
         CLZ,
@@ -408,7 +408,7 @@ public:
 class Level_6_PairDef;
 class Level_6{
 public:
-    using type = Level_6_PairDef;
+    using SpartaPairDefinitionType = Level_6_PairDef;
     Level_6(const Level_5_Ptr& ptr, uint16_t randomValue) :
             level_5_ptr_(ptr), randomValue_(randomValue) {}
     const Level_5_Ptr & getNestedPtr() const { return level_5_ptr_; }
@@ -438,7 +438,7 @@ public:
 class Level_7_PairDef;
 class Level_7{
 public:
-    using type = Level_7_PairDef;
+    using SpartaPairDefinitionType = Level_7_PairDef;
     Level_7(const Level_6_Ptr& ptr, uint16_t randomValue,
             bool a, uint64_t b) :
             level_6_ptr_(ptr), randomValue_(randomValue),
@@ -474,7 +474,7 @@ public:
 class Level_8_PairDef;
 class Level_8{
 public:
-    using type = Level_8_PairDef;
+    using SpartaPairDefinitionType = Level_8_PairDef;
     Level_8(const Level_7_Ptr& ptr, uint16_t randomValue,
             uint32_t a, uint32_t b) :
             level_7_ptr_(ptr), randomValue_(randomValue),


### PR DESCRIPTION
@klingaard , this is the small adjustment that you requested.