### PR TITLE
Fixed issues with Registers not allowing large bitfields.

### DIFF
--- a/sparta/sparta/utils/BitArray.hpp
+++ b/sparta/sparta/utils/BitArray.hpp
@@ -225,7 +225,6 @@ namespace sparta {
                 } else {
                     data_ = data_ss_;
                 }
-                std::fill(data_, data_ + data_size, 0);
 
                 /* Update size after allocating data to maintain the invariant that
                  * data_size_ matches the allocated memory size in case new throws */
@@ -329,7 +328,7 @@ namespace sparta {
             std::vector<data_type> data_ls_;
 
             /** Used to store small arrays */
-            data_type data_ss_[SMALL_OPTIMIZATION_SIZE / sizeof(data_type)];
+            data_type data_ss_[SMALL_OPTIMIZATION_SIZE / sizeof(data_type)] = {0};
 
             /** Points to either data_ls_ or data_ss_ depending on the size of the array */
             data_type *data_ = nullptr;


### PR DESCRIPTION
Re-wrote the regsiter bit field mask generator to properly calculate the
register mask.  Added testing for the specific issue found.