### PR TITLE
pin duplicate clang requirements to 9

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,8 +35,8 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
     # add duplicate clang dep per https://gitter.im/conda-forge/conda-forge.github.io?at=5e5feaf7ec7f8746aab200c4
-    - clang
-    - clangxx
+    - clang 9
+    - clangxx 9
     - rsync
   host:  # target-arch buildtime deps
     - boost-cpp


### PR DESCRIPTION
Currently, building using clang on linux is a bit of a hack
because conda-forge guys just use gcc and don't have a clang_linux-64
metapackage.  Because of this hack, the pinnings in conda-forge-pinning-feedstock
don't restrict clang on linux and we're now getting clang 10, which
causes build errors in the CI.

This is related to the release of clang 10.0 on conda-forge #95 