### PR TITLE
Initialize Register::Definition by value instead of by reference

### DIFF
--- a/sparta/sparta/functional/Register.hpp
+++ b/sparta/sparta/functional/Register.hpp
@@ -704,7 +704,7 @@ public:
      * marked as read-only regardless of any read-write fields containing those
      * bits
      */
-    RegisterBase(TreeNode *parent, const Definition def)
+    RegisterBase(TreeNode *parent, const Definition & def)
         : TreeNode(nullptr,
                    NULL_TO_EMPTY_STR(def.name),
                    NULL_TO_EMPTY_STR(def.group),
@@ -751,7 +751,7 @@ public:
         }
 
         // Add all fields
-        for(const auto & fdp : def_.fields){
+        for(auto & fdp : def_.fields){
             addField(fdp);
         }
 
@@ -949,7 +949,7 @@ public:
      * \return References to the same const Definition object supplied at
      * construction.
      */
-    const Definition getDefinition() const {
+    const Definition& getDefinition() const {
         return def_;
     }
 
@@ -1353,7 +1353,7 @@ private:
     }
 
     /*!
-     * \brief Register definition given at construction (not copied)
+     * \brief Register definition given at construction
      */
     const Definition def_;
 

--- a/sparta/sparta/functional/Register.hpp
+++ b/sparta/sparta/functional/Register.hpp
@@ -220,23 +220,23 @@ public:
         {
             setExpectedParent_(&reg);
 
-            sparta_assert(def.name != 0, "Register::Field::Definition::name cannot be empty");
+            sparta_assert(def_.name != 0, "Register::Field::Definition::name cannot be empty");
 
-            if(def.high_bit < def.low_bit){
+            if(def_.high_bit < def_.low_bit){
                 throw SpartaException("Register Field ")
-                    << getLocation() << " definition contains high bit (" << def.high_bit
-                    << ") less than a low bit (" << def.low_bit << ")";
+                    << getLocation() << " definition contains high bit (" << def_.high_bit
+                    << ") less than a low bit (" << def_.low_bit << ")";
             }
 
-            if(def.low_bit >= reg.getNumBits()){
+            if(def_.low_bit >= reg.getNumBits()){
                 throw SpartaException("Register Field ")
-                    << getLocation() << " definition contains a low bit (" << def.low_bit
+                    << getLocation() << " definition contains a low bit (" << def_.low_bit
                     << ") greater than or equal to the number of bits in the register ("
                     << reg.getNumBits() << ")";
             }
-            if(def.high_bit >= reg.getNumBits()){
+            if(def_.high_bit >= reg.getNumBits()){
                 throw SpartaException("Register Field ")
-                    << getLocation() << " definition contains a high bit (" << def.high_bit
+                    << getLocation() << " definition contains a high bit (" << def_.high_bit
                     << ") greater than or equal to the number of bits in the register ("
                     << reg.getNumBits() << ")";
             }

--- a/sparta/sparta/functional/Register.hpp
+++ b/sparta/sparta/functional/Register.hpp
@@ -704,16 +704,16 @@ public:
      * marked as read-only regardless of any read-write fields containing those
      * bits
      */
-    RegisterBase(TreeNode *parent, const Definition *def)
+    RegisterBase(TreeNode *parent, const Definition def)
         : TreeNode(nullptr,
-                   NULL_TO_EMPTY_STR(def->name),
-                   NULL_TO_EMPTY_STR(def->group),
-                   def->group_idx,
-                   NULL_TO_EMPTY_STR(def->desc),
+                   NULL_TO_EMPTY_STR(def.name),
+                   NULL_TO_EMPTY_STR(def.group),
+                   def.group_idx,
+                   NULL_TO_EMPTY_STR(def.desc),
                    false),
           def_(def),
-          bits_(def->bytes * 8),
-          mask_(computeWriteMask_(def)),
+          bits_(def.bytes * 8),
+          mask_(computeWriteMask_(&def_)),
           post_write_noti_(this,
                            "post_write",
                            "Notification immediately after the register has been written",
@@ -727,37 +727,36 @@ public:
             setExpectedParent_(parent);
         }
 
-        sparta_assert(def, "Cannot construct a register with a null definition");
-        sparta_assert(def->name != 0, "Cannot have a null name in a register definition");
+        sparta_assert(def.name != 0, "Cannot have a null name in a register definition");
 
-        if(!strcmp(def->group, GROUP_NAME_NONE) && (def->group_num != GROUP_NUM_NONE)){
+        if(!strcmp(def_.group, GROUP_NAME_NONE) && (def.group_num != GROUP_NUM_NONE)){
             throw SpartaException("Attempted to add register \"")
-                << getLocation() << "\" which had group number " << def->group_num
+                << getLocation() << "\" which had group number " << def.group_num
                 << " but had group name \"\". A group name is required if a group number is specified.";
         }
 
-        if(strcmp(def->group, GROUP_NAME_NONE) && (def->group_num == GROUP_NUM_NONE)){
+        if(strcmp(def.group, GROUP_NAME_NONE) && (def.group_num == GROUP_NUM_NONE)){
             throw SpartaException("Attempted to add register \"")
                 << getLocation() << "\" which had group number GROUP_NUM_NONE"
-                << " but had group name \"" << def->group
+                << " but had group name \"" << def.group
                 << "\". A group number is required if a group name is specified.\"" << GROUP_NAME_NONE << "\"";
         }
 
         // Ensure byte-size is valid
-        static_assert(std::is_unsigned<decltype(def->bytes)>::value == true);
-        if(!isPowerOf2(def->bytes) || def->bytes == 0){
+        static_assert(std::is_unsigned<decltype(def.bytes)>::value == true);
+        if(!isPowerOf2(def.bytes) || def.bytes == 0){
             throw SpartaException("Register \"")
                 << getName() << "\" size in bytes must be a power of 2 larger than 0, is "
-                << def->bytes;
+                << def.bytes;
         }
 
         // Add all fields
-        for(auto & fdp : def->fields){
+        for(const auto & fdp : def_.fields){
             addField(fdp);
         }
 
         // Add all aliases
-        const char* const * ap = def->aliases;
+        const char* const * ap = def_.aliases;
         if(ap != 0){
             while(*ap != 0){
                 addAlias(*ap); // From sparta::TreeNode
@@ -789,11 +788,11 @@ public:
      */
     void reset(bool unmasked=true) {
         // Poke the whole value, one-byte at a time
-        for(size_type i=0; i<def_->bytes; i++){
+        for(size_type i=0; i<def_.bytes; i++){
             if(unmasked){
-                pokeUnmasked(def_->initial_value[i], i);
+                pokeUnmasked(def_.initial_value[i], i);
             }else{
-                poke(def_->initial_value[i], i);
+                poke(def_.initial_value[i], i);
             }
         }
     }
@@ -829,13 +828,13 @@ public:
     /*!
      * \brief Gets the ID of this register as specified in its definition
      */
-    ident_type getID() const { return def_->id; }
+    ident_type getID() const { return def_.id; }
 
     /*!
      * \brief Gets the group number of this register as specified in its
      * definition
      */
-    group_num_type getGroupNum() const { return def_->group_num; }
+    group_num_type getGroupNum() const { return def_.group_num; }
 
     /*!
      * \brief Gets the name of the group to which this register belongs
@@ -844,19 +843,19 @@ public:
      */
     std::string getGroupName() const {
         // Return group. Guaranteed not to be null by Register::Register
-        return def_->group;
+        return def_.group;
     }
 
     /*!
      * \brief Gets the group index of this register as specified in its
      * definition
      */
-    group_idx_type getGroupIdx() const { return def_->group_idx; }
+    group_idx_type getGroupIdx() const { return def_.group_idx; }
 
     /*!
      * \brief Gets the size of this register's value in bytes
      */
-    size_type getNumBytes() const { return def_->bytes; }
+    size_type getNumBytes() const { return def_.bytes; }
 
     /*!
      * \brief Gets the size of this register's value in bits
@@ -888,8 +887,8 @@ public:
             return true;
         }
 
-        auto itr = std::find(def_->bank_membership.begin(), def_->bank_membership.end(), bank);
-        return itr != def_->bank_membership.end();
+        auto itr = std::find(def_.bank_membership.begin(), def_.bank_membership.end(), bank);
+        return itr != def_.bank_membership.end();
     }
 
     /*!
@@ -899,7 +898,7 @@ public:
      * had 0 elements in its definition's bank membership vector)
      */
     bool isBanked() const {
-        return def_->bank_membership.size() != 0;
+        return def_.bank_membership.size() != 0;
     }
 
     /*!
@@ -919,7 +918,7 @@ public:
      * \return ID of register of which this is a subset if any. If none,
      * returns INVALID_ID
      */
-    ident_type getSubsetOf() const { return def_->subset_of; }
+    ident_type getSubsetOf() const { return def_.subset_of; }
 
     /*!
      * \brief Returns the byte offset into the compound Register of which
@@ -930,19 +929,19 @@ public:
      * (getSubsetOf() == INVALID_ID), returns
      * returns INVALID_ID
      */
-    size_type getSubsetOffset() const { return def_->subset_offset; }
+    size_type getSubsetOffset() const { return def_.subset_offset; }
 
     /*!
      * \brief Returns the hint flags for this type.
      * \see HintFlag
      */
-    Definition::HintsT getHintFlags() const { return def_->hints; }
+    Definition::HintsT getHintFlags() const { return def_.hints; }
 
     /*!
      * \brief Returns the regdomain for this type.
      * \see RegdomainFlag
      */
-    Definition::RegDomainT getRegDomain() const { return def_->regdomain; }
+    Definition::RegDomainT getRegDomain() const { return def_.regdomain; }
 
     /*!
      * \brief Gets the definition supplied during the construciton of this
@@ -950,8 +949,8 @@ public:
      * \return References to the same const Definition object supplied at
      * construction.
      */
-    const Definition& getDefinition() const {
-        return *def_;
+    const Definition getDefinition() const {
+        return def_;
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -1356,7 +1355,7 @@ private:
     /*!
      * \brief Register definition given at construction (not copied)
      */
-    const Definition* def_;
+    const Definition def_;
 
     /*!
      * \brief All Fields allocated by this set. These fields are deleted
@@ -1464,10 +1463,10 @@ inline bool operator!=(const RegisterBase::Definition &a,
 class Register : public RegisterBase
 {
 public:
-    Register(TreeNode *parent, const Definition *def, ArchData *adata) :
+    Register(TreeNode *parent, const Definition def, ArchData *adata) :
         RegisterBase(parent, def),
-        dview_(adata, def->id, def->bytes, def->subset_of, def->subset_offset, def->initial_value),
-        prior_val_dview_(adata, DataView::INVALID_ID, def->bytes),
+        dview_(adata, def.id, def.bytes, def.subset_of, def.subset_offset, def.initial_value),
+        prior_val_dview_(adata, DataView::INVALID_ID, def.bytes),
         post_write_noti_data_(this, &prior_val_dview_, &dview_),
         post_read_noti_data_(this, &dview_)
     {

--- a/sparta/sparta/functional/RegisterBankTable.hpp
+++ b/sparta/sparta/functional/RegisterBankTable.hpp
@@ -506,7 +506,7 @@ protected:
     void insertRegisterInBank_(RegisterT *r, GroupVector& bank)
     {
         sparta_assert(r != nullptr);
-        const auto &rdef = r->getDefinition();
+        const auto rdef = r->getDefinition();
         while(rdef.group_num >= bank.size()){
             bank.push_back(RegisterMap());
         }

--- a/sparta/sparta/functional/RegisterSet.hpp
+++ b/sparta/sparta/functional/RegisterSet.hpp
@@ -897,7 +897,7 @@ private:
     {
         sparta_assert(false == adata_.isLaidOut());// Cannot addRegister_ after the ArchData has been layed out
         sparta_assert(reg_proxies_.size() == 0); // Cannot addRegister_ once a proxy has been added
-        auto r = new RegisterT(nullptr, rdef, &adata_);
+        auto r = new RegisterT(nullptr, *rdef, &adata_);
 
         // Attempt to insert the register into the bank table
         banks_.addRegister(r); // Throws if unable to add


### PR DESCRIPTION
In the Register class's constructor, Register::Definition is initialized by reference and a copy of the register definition object is not made. This requires that the register definitions be maintained somewhere outside of the Register class. 

To be able to initialize a Register using a definition read in from a file, all of the variables used to initialize that register have to be held onto. This use case could be simplified if Register::Definition was initialized by value so that the Register class maintained a copy of the register definition data itself.