### PR TITLE
On default construction of SpartaSharedPointer, do not allocate a ref_count_

### DIFF
--- a/sparta/sparta/utils/SpartaSharedPointer.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointer.hpp
@@ -102,14 +102,14 @@ namespace sparta
          * ownership of the given object pointer.
          */
         explicit SpartaSharedPointer(PointerT * p = nullptr) noexcept :
-            ref_count_(new RefCount(p)){}
+            ref_count_(p == nullptr ? nullptr : new RefCount(p)) {}
 
         /**
          * \brief Constructor for SpartaSharedPointer<T> ptr = nullptr;
          * \param nullptr_t
          */
         constexpr SpartaSharedPointer(std::nullptr_t) noexcept :
-            ref_count_(new RefCount(nullptr)){}
+            ref_count_(nullptr) {}
 
         /**
          * \brief Construct a reference pointer given another reference pointer
@@ -195,7 +195,7 @@ namespace sparta
          * \endcode
          */
         bool operator!() const {
-            return (ref_count_ && ref_count_->p == nullptr);
+            return (ref_count_ == nullptr) || (ref_count_->p == nullptr);
         }
 
         /**
@@ -217,8 +217,7 @@ namespace sparta
          * \return The pointer pointed to by this RefPointer
          */
         PointerT * operator->() const {
-            sparta_assert(ref_count_ != nullptr, "This is a dead SpartaSharedPointer");
-            return ref_count_->p;
+            return (ref_count_ ? ref_count_->p : nullptr);
         }
 
         /**
@@ -226,7 +225,7 @@ namespace sparta
          * \return The pointer pointed to by this RefPointer
          */
         PointerT & operator*() const {
-            sparta_assert(ref_count_ != nullptr, "This is a dead SpartaSharedPointer");
+            sparta_assert(ref_count_ != nullptr, "This is a null SpartaSharedPointer");
             return *(ref_count_->p);
         }
 
@@ -235,8 +234,7 @@ namespace sparta
          * \return The underlying pointer
          */
         PointerT * get() const {
-            sparta_assert(ref_count_ != nullptr, "This is a dead SpartaSharedPointer");
-            return ref_count_->p;
+            return (ref_count_ ? ref_count_->p : nullptr);
         }
 
         /**
@@ -245,7 +243,7 @@ namespace sparta
          */
         void reset(PointerT * p = nullptr) {
             unlink_();
-            ref_count_     = new RefCount(p);
+            ref_count_     = p == nullptr ? nullptr : new RefCount(p);
             memory_block_  = nullptr;
         }
 

--- a/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
+++ b/sparta/test/SpartaSharedPointer/SpartaSharedPointer_test.cpp
@@ -54,6 +54,7 @@ void func(const sparta::SpartaSharedPointer<MyType> & my_ref, const unsigned int
     sparta::SpartaSharedPointer<MyType> another_ref(my_ref);
     sparta::SpartaSharedPointer<MyType> another_ref2;
     EXPECT_TRUE(another_ref2 == nullptr);
+    EXPECT_TRUE(nullptr == another_ref2);
     another_ref2 = my_ref;
     EXPECT_TRUE(another_ref2 != nullptr);
 
@@ -88,6 +89,7 @@ void testBasicSpartaSharedPointer()
 
     sparta::SpartaSharedPointer<MyType> ptr5;
     EXPECT_TRUE(ptr5 == nullptr);
+    EXPECT_TRUE(nullptr == ptr5);
 
     MyType * t2 = new MyType;
     ptr5.reset(t2);
@@ -172,9 +174,9 @@ void testMoveSupport()
     EXPECT_EQUAL(ptr7.use_count(), 0);
     EXPECT_EQUAL(ptr8.use_count(), 0);
 
-    EXPECT_THROW(ptr5.get());
+    EXPECT_NOTHROW(ptr5.get());
     EXPECT_EQUAL(ptr6.get(), nullptr);
-    EXPECT_THROW(ptr7.get());
+    EXPECT_NOTHROW(ptr7.get());
     EXPECT_EQUAL(ptr8.get(), nullptr);
 
     EXPECT_NOTHROW(ptr5 = ptr8);


### PR DESCRIPTION
Fixes a performance issue in SpartaSharedPointer for `nullptr` `SpartaSharedPointer` types.

Regression is clean and SiFive tools regressed fine.