### PR TITLE
pipe_viewer use wx.ClientDC() outside of EVT_PAINT

### DIFF
--- a/helios/pipeViewer/pipe_view/gui/layout_canvas.py
+++ b/helios/pipeViewer/pipe_view/gui/layout_canvas.py
@@ -391,7 +391,7 @@ class Layout_Canvas(wx.ScrolledWindow):
         if self.__hover_preview.show:
             dc.SetFont(self.__fnt_layout)
             self.DoHoverTextDraw(dc)
-        dc = wx.BufferedPaintDC(self, self.__buffer)
+        dc = wx.BufferedDC(wx.ClientDC(self), self.__buffer)
 
     # # Returns Hover Preview
     def GetHoverPreview(self):


### PR DESCRIPTION
in layout_canvas.OnHoverRedraw() we must use wx.BufferedDC(wx.ClentDC())
instead of directly using wx.BufferedPaintDC() because the limited Redraw
can be fired outside of EVT_PAINT

fixes #115 