### PR TITLE
Add llvm-tools to conda env

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     # add duplicate clang dep per https://gitter.im/conda-forge/conda-forge.github.io?at=5e5feaf7ec7f8746aab200c4
     - clang 9
     - clangxx 9
+    - llvm-tools 9
     - rsync
     # add runtime requirements for argos to make it easier to script
     # creation of a 'dev' environment that can also run Argos


### PR DESCRIPTION
The llvm-tools package is required for building Dabble under the conda environment on Mac.