### PR TITLE
Added fields to be formatted as hex in Argos display

### DIFF
--- a/helios/pipeViewer/transactiondb/src/Reader.hpp
+++ b/helios/pipeViewer/transactiondb/src/Reader.hpp
@@ -560,7 +560,9 @@ namespace pipeViewer{
                                         pairt.stringVector.emplace_back("");
                                     } else if (field_name == "pc" ||
                                                field_name == "pred_target" ||
-                                               field_name == "vaddr") {
+                                               field_name == "vaddr" ||
+                                               field_name == "va" ||
+                                               field_name == "stf_va") {
                                         // This is a hex field
                                         std::stringstream int_str;
                                         int_str << "0x" << std::hex << int_value;

--- a/helios/pipeViewer/transactiondb/src/Reader.hpp
+++ b/helios/pipeViewer/transactiondb/src/Reader.hpp
@@ -562,7 +562,8 @@ namespace pipeViewer{
                                                field_name == "pred_target" ||
                                                field_name == "vaddr" ||
                                                field_name == "va" ||
-                                               field_name == "stf_va") {
+                                               field_name == "stf_va" ||
+                                               field_name == "pa") {
                                         // This is a hex field
                                         std::stringstream int_str;
                                         int_str << "0x" << std::hex << int_value;


### PR DESCRIPTION
This will be fixed in the future (perhaps part of #133), but for now certain fields are hardcoded to be displayed as hex.  In this PR, va, stf_va, and pa are added as hex fields.