### PR TITLE
Deploy doxygen documentation to GitHub Pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,38 @@
+# Documentation Workflow for Github Actions
+
+name: Documentation
+
+# Controls when the action will run. Triggers the workflow on push
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Run doxygen command using the runners shell
+    # Doxygen Action: https://github.com/marketplace/actions/doxygen-action
+    - name: Build documentation
+      uses: mattnotmitt/doxygen-action@v1
+      with:
+        working-directory: 'sparta/doc'
+        doxyfile-path: './Doxyfile'
+
+    # Deploy to a gh-pages branch as an orphan (with only latest commit)
+    # GitHub Pages Action: https://github.com/marketplace/actions/github-pages-action
+    - name: Deploy documentation
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: sparta/doc/html
+        force_orphan: true
+        commit_message: '[ci skip] ${{ github.event.head_commit.message }}'

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ MAP is broken into two parts:
 
 [![Linux Build Status](https://img.shields.io/travis/com/sparcians/map/master.svg?label=Linux)](https://travis-ci.com/sparcians/map/branches)
 [![MacOS Build Status](https://dev.azure.com/sparcians/map/_apis/build/status/sparcians.map?branchName=master&label=MacOS)](https://dev.azure.com/sparcians/map/_build/latest?definitionId=1&branchName=master)
+![Documentation](https://github.com/sparcians/map/workflows/Documentation/badge.svg)


### PR DESCRIPTION
Deploy sparta doxygen to **gh-pages** branch (published to GitHub Pages), managed by a GitHub Action workflow that triggers on pushes to master.

Additional steps in GUI config (@klingaard ):
- [ ] Settings/Actions/Enable local and third party Actions for this repository
- [ ] Settings/Options/GitHub Pages/gh-pages branch