### PR TITLE
Update some of the latest steps for MacOS side

### DIFF
--- a/sparta/.gitignore
+++ b/sparta/.gitignore
@@ -8,4 +8,6 @@ test/**/*.cmake
 build*
 [Rr]elease*
 [Dd]ebug*
+[Ff]ast[Dd]ebug*
+cmake-build-*
 *~

--- a/sparta/README.md
+++ b/sparta/README.md
@@ -75,8 +75,9 @@ Open a MacOS Terminal
 1. `brew install yaml-cpp`
 1. `brew install rapidJSON`
 1. `brew install xz`
+1. `brew install zstd`
 1. `brew install cppcheck`
-1. `sudo easy_install Pygments` # Do not use HomeBrew! Needed for cppcheck-htmlreport
+1. `sudo easy_install Pygments==2.5.2` # Do not use HomeBrew! Needed for cppcheck-htmlreport
 1. Install XCode and check for clang: `clang --version`
 
 Clone sparta through https: `git clone https://github.com/sparcians/map.git`


### PR DESCRIPTION
Update Pygments (used for cppcheck) to point to specific version
Update git ignore for fastdebug and cmake-build* (used by some IDEs)
