### PR TITLE
Initialize the whole BitArray by data value

### DIFF
--- a/sparta/sparta/utils/BitArray.hpp
+++ b/sparta/sparta/utils/BitArray.hpp
@@ -64,7 +64,11 @@ namespace sparta {
                 }
 
                 initializeStorage_(roundUpTo_(array_size, sizeof(data_type)));
-                std::memcpy(data_, data, std::min(data_size, array_size));
+                size_t offset = 0;
+                do {
+                    std::memcpy(data_ + offset, data, std::min(data_size, array_size - offset));
+                    offset += std::min(data_size, array_size - offset);
+                } while (offset < array_size);
             }
 
             /**

--- a/sparta/sparta/utils/BitArray.hpp
+++ b/sparta/sparta/utils/BitArray.hpp
@@ -219,7 +219,7 @@ namespace sparta {
                 sparta_assert(data_ == nullptr);
 
                 if (data_size > SMALL_OPTIMIZATION_SIZE) {
-                    data_ls_.reserve(data_size);
+                    data_ls_.resize(data_size, 0);
                     data_ = &data_ls_[0];
                 } else {
                     data_ = data_ss_;

--- a/sparta/sparta/utils/BitArray.hpp
+++ b/sparta/sparta/utils/BitArray.hpp
@@ -64,11 +64,7 @@ namespace sparta {
                 }
 
                 initializeStorage_(roundUpTo_(array_size, sizeof(data_type)));
-                size_t offset = 0;
-                do {
-                    std::memcpy(data_ + offset, data, std::min(data_size, array_size - offset));
-                    offset += std::min(data_size, array_size - offset);
-                } while (offset < array_size);
+                std::memcpy(data_, data, std::min(data_size, array_size));
             }
 
             /**

--- a/sparta/test/Register/Register_test.cpp
+++ b/sparta/test/Register/Register_test.cpp
@@ -84,6 +84,9 @@ Register::Definition reg_defs[] = {
                                                                                                                   {"b63_00",  "B", 0,  63,  false} },  {},      nullptr,            Register::INVALID_ID, 0, (const uint8_t*) ALTERNATING_DEFAULT, 0, 0 },
     { 14, "wm_04",    Register::GROUP_NUM_NONE, "",  Register::GROUP_IDX_NONE, "mask spans u64s",           16, { {"b65_13",  "A", 13, 65,  true },
                                                                                                                   {"b67_64",  "B", 64, 67,  false} },  {},      nullptr,            Register::INVALID_ID, 0, (const uint8_t*) ALTERNATING_DEFAULT, 0, 0 },
+
+    // Test very huge register
+    { 15, "huge",     Register::GROUP_NUM_NONE, "",  Register::GROUP_IDX_NONE, "register that is 32 bytes", 32, {},      {},      nullptr,            Register::INVALID_ID, 0, nullptr, 0, 0 },
     Register::DEFINITION_END
 };
 
@@ -515,7 +518,7 @@ int main()
 
     // Child Register lookup:
     // by name
-    RegisterBase *large=0, *med=0, *notareg=0, *sprxxa=0, *sprxxb, *small=0;
+    RegisterBase *large=0, *med=0, *notareg=0, *sprxxa=0, *sprxxb, *small=0, *huge=0;
     EXPECT_NOTHROW(large = rset->getRegister("large"));
     EXPECT_NOTEQUAL(large, nullptr); // (also tests the tester by comparing w/ nullptr on right)
     EXPECT_NOTEQUAL(nullptr, large); // (also tests the tester by comparing w/ nullptr on left)
@@ -530,6 +533,8 @@ int main()
     EXPECT_NOTEQUAL(sprxxb, (Register*)nullptr);
     EXPECT_NOTHROW(small = rset->getRegister("small"));
     EXPECT_NOTEQUAL(small, (Register*)nullptr);
+    EXPECT_NOTHROW(huge = rset->getRegister("huge"));
+    EXPECT_NOTEQUAL(huge, (Register*)nullptr);
 
     EXPECT_EQUAL(rset->getRegister("reg1")->getGroupNum(), 1);
     EXPECT_EQUAL(rset->getRegister("medium")->getGroupNum(), 2);
@@ -537,11 +542,13 @@ int main()
     EXPECT_EQUAL(rset->getRegister("large")->getHintFlags(), HINT_READ_ONLY);
     EXPECT_EQUAL(rset->getRegister("sprXXa")->getGroupNum(), 4);
     EXPECT_EQUAL(rset->getRegister("small")->getGroupNum(), Register::GROUP_NUM_NONE);
+    EXPECT_EQUAL(rset->getRegister("huge")->getGroupNum(), Register::GROUP_NUM_NONE);
     EXPECT_EQUAL(rset->getRegister("reg1")->getGroup(), "A");
     EXPECT_EQUAL(rset->getRegister("medium")->getGroup(), "B");
     EXPECT_EQUAL(rset->getRegister("large")->getGroup(), "B");
     EXPECT_EQUAL(rset->getRegister("sprXXa")->getGroup(), "D");
     EXPECT_EQUAL(rset->getRegister("small")->getGroup(), Register::GROUP_NAME_NONE);
+    EXPECT_EQUAL(rset->getRegister("huge")->getGroup(), Register::GROUP_NAME_NONE);
     EXPECT_TRUE(rset->canLookupRegister(1, 0)); // reg1 is in banks {0}
     EXPECT_TRUE(rset->canLookupRegister(2, 0, 6));  // medium is in banks {6}
     EXPECT_FALSE(rset->canLookupRegister(2, 0, 0));
@@ -911,6 +918,7 @@ int main()
     EXPECT_EQUAL(rwo.writes_2, 7);
     EXPECT_EQUAL(rro.reads, 2);
 
+    // Test large register (128b)
     std::cout << "\nWriting to " << large << std::endl;
     EXPECT_EQUAL(large->getNumBits(), (Register::size_type)128);
     EXPECT_NOTHROW((large->write<uint64_t>(0xffffffffffffffff)));
@@ -928,6 +936,25 @@ int main()
     std::cout << " have: " << std::hex << large->read<uint64_t>() << " expect: " << 0xccddeeeeccddffff << std::endl;
     EXPECT_EQUAL((large->read<uint64_t>()), 0xccddeeeeccddffff);
     std::cout << "Large Register: " << std::endl << large->renderSubtree(-1, true);
+
+    // Test huge register (256b)
+    std::cout << "\nWriting to " << huge << std::endl;
+    EXPECT_EQUAL(huge->getNumBits(), (Register::size_type)256);
+    EXPECT_NOTHROW((huge->write<uint64_t>(0xffffffffffffffff)));
+    EXPECT_EQUAL(huge->read<uint64_t>(), 0xffffffffffffffff);
+    EXPECT_NOTHROW((huge->write<uint32_t>(0xeeeeeeee, 1))); // 1-0 (MSB)
+    EXPECT_EQUAL(huge->read<uint32_t>(1), 0xeeeeeeee);
+    EXPECT_NOTHROW((huge->write<uint16_t>(0xdddd, 3))); // 3-0 (MSB)
+    EXPECT_EQUAL(huge->read<uint16_t>(3), 0xdddd);
+    EXPECT_NOTHROW((huge->write<uint16_t>(0xdddd, 1))); // 3-2
+    EXPECT_EQUAL(huge->read<uint16_t>(1), 0xdddd);
+    EXPECT_NOTHROW((huge->write<uint8_t>(0xcc, 7))); // 7-0 (MSB)
+    EXPECT_EQUAL(huge->read<uint8_t>(7), 0xcc);
+    EXPECT_NOTHROW((huge->write<uint8_t>(0xcc, 3))); // 7-4
+    EXPECT_EQUAL(huge->read<uint8_t>(3), 0xcc);
+    std::cout << " have: " << std::hex << huge->read<uint64_t>() << " expect: " << 0xccddeeeeccddffff << std::endl;
+    EXPECT_EQUAL((huge->read<uint64_t>()), 0xccddeeeeccddffff);
+    std::cout << "Huge Register: " << std::endl << huge->renderSubtree(-1, true);
 
     // Test notifications on fields
     auto sprXXa = rset->getRegister("sprXXa");


### PR DESCRIPTION
If `array_size` is greater than `data_size`, only the first `data_size` bytes will be initialized. In a zero-initialized scenario, the reset of BitArray are not correctly initialized. It would be nice to have it and doesn't influence the original functionality.