### PR TITLE
Fix duplicate Argos transaction bug

### DIFF
--- a/helios/pipeViewer/transactiondb/src/TransactionDatabaseInterface.hpp
+++ b/helios/pipeViewer/transactiondb/src/TransactionDatabaseInterface.hpp
@@ -412,6 +412,7 @@ private:
                     }
                     td.data[loc_id] = trans_pos;
                     marked_start = true;
+                    marked_ending |= single_tick_entry;
                 }else{
                     // td.tick_offset > start_cycle_offset
                      if(td.tick_offset > start_cycle_offset){

--- a/helios/pipeViewer/transactiondb/src/common.pxd
+++ b/helios/pipeViewer/transactiondb/src/common.pxd
@@ -43,6 +43,7 @@ cdef extern from "TransactionInterval.hpp" namespace "sparta::pipeViewer":
         uint64_t real_ADR
         uint16_t length
         uint8_t *annt
+        uint16_t pairId
         vector[uint16_t] sizeOfVector
         vector[pair[uint64_t, bint]] valueVector
         vector[string] nameVector

--- a/helios/pipeViewer/transactiondb/src/transactiondb.pyx
+++ b/helios/pipeViewer/transactiondb/src/transactiondb.pyx
@@ -138,8 +138,8 @@ cdef class Transaction(object):
                         self.getVirtualAddress(), self.getRealAddress(), \
                         self.getParentTransactionID())
         elif type_flags == PAIR:
-            return '<Pair ID:{0} LOC:{1} [{2},{3}] parent:{4} "{5}">'\
-                .format(self.getTransactionID(), self.getLocationID(), self.getLeft(), self.getRight(),\
+            return '<Pair ID:{0} pairID:{1} LOC:{2} [{3},{4}] parent:{5} "{6}">'\
+                .format(self.getTransactionID(), self.getPairID(), self.getLocationID(), self.getLeft(), self.getRight(),\
                     self.getParentTransactionID(), self.getAnnotation())
         else:
             return '<UnkonwnTransactionType ID:{0} LOC:{1} [{2},{3}] op:{4:#x} v:{5:#x} p:{6:#x} parent:{7}>' \
@@ -203,6 +203,11 @@ cdef class Transaction(object):
         if self.__trans == NULL:
             return None
         return self.__trans.transaction_ID
+
+    def getPairID(self):
+        if self.__trans == NULL:
+            return None
+        return self.__trans.pairId
 
     def getDisplayID(self):
         if self.__trans == NULL:
@@ -648,6 +653,13 @@ cdef class TransactionDatabase:
         decoded_str = bytes_re.sub(r'\1', (py_str_preamble + py_str_body).decode('utf-8'))    # Replace b'xxx' with xxx
         self.__cached_annotations[c_trans.transaction_ID] = decoded_str
         return decoded_str
+
+    def getPairID(self, uint32_t loc):
+        cdef c_TransactionInterval_uint64_const_t* c_trans
+        c_trans = self._getTransaction(loc)
+        if c_trans == NULL:
+            return None
+        return <int>c_trans.pairId
 
     def getTransactionID(self, uint32_t loc):
         cdef c_TransactionInterval_uint64_const_t* c_trans

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -780,7 +780,7 @@ namespace sparta{
                 argos_record_.pairId = getUniquePairID_();
                 argos_record_.nameVector = getNameStrings();
                 argos_record_.sizeOfVector = getSizeOfVector();
-                argos_record_.valueVector = getDataVector();
+                argos_record_.valueVector = last_record_values_;
                 argos_record_.stringVector = getStringVector();
                 argos_record_.length = argos_record_.nameVector.size();
                 argos_record_.delimVector.emplace_back(getArgosFormatGuide());


### PR DESCRIPTION
Changes Collector to write last value instead of current value when closing a record.

This might need additional changes in `writeRecord_()` to be 100% correct because I don't totally understand the interface, but this seems to fix an issue we've been seeing with duplicate records.