### PR TITLE
Fix Argos uop highlighting

### DIFF
--- a/helios/pipeViewer/pipe_view/model/highlighting_utils.py
+++ b/helios/pipeViewer/pipe_view/model/highlighting_utils.py
@@ -1,25 +1,15 @@
 import re
 
-__uop_uid_regex = re.compile('(?:annotation:)?\s*([0-9a-f]{3}\s+U[0-9]+)')
-
-
-# @profile
-def __AnnotationToUopUid(anno_string):
-    uid_match = __uop_uid_regex.match(anno_string)
-
-    if uid_match is not None:
-        return uid_match.group(1)
-    else:
-        return None
-
+__UOP_UID_REGEX = re.compile(r'.*\buid\(([0-9]+)\)')
 
 # @profile
 def GetUopUid(anno_string):
     if not isinstance(anno_string, str):
         return None
-    uop_uid_str = __AnnotationToUopUid(anno_string)
-    if uop_uid_str is not None:
-        return hash(uop_uid_str)
+
+    uid_match = __UOP_UID_REGEX.match(anno_string)
+
+    if uid_match is not None:
+        return int(uid_match.group(1))
     else:
         return None
-

--- a/helios/pipeViewer/pipe_view/model/layout_context.py
+++ b/helios/pipeViewer/pipe_view/model/layout_context.py
@@ -550,23 +550,27 @@ class Layout_Context(object):
         self.dbhandle.query(time, time, callback, mod_tracking = False)
         return results
 
-    def HighlightUop(self, anno_string):
+    def HighlightUop(self, uid):
         '''
         Highlight the uop with the given annotation string
         '''
-        uop_uid = highlighting_utils.GetUopUid(anno_string)
-        if uop_uid is not None:
-            self.__highlighted_uops.append(uop_uid)
+        if isinstance(uid, str):
+            self.HighlightUop(highlighting_utils.GetUopUid(uid))
 
-    def UnhighlightUop(self, anno_string):
+        if uid is not None:
+            self.__highlighted_uops.append(uid)
+
+    def UnhighlightUop(self, uid):
         '''
         Unhighlight the uop with the given annotation string
         '''
-        uop_uid = highlighting_utils.GetUopUid(anno_string)
-        if uop_uid is not None:
-            if uop_uid in self.__highlighted_uops:
-                self.__highlighted_uops.remove(uop_uid)
-                self.__previously_highlighted_uops.append(uop_uid)
+        if isinstance(uid, str):
+            self.UnhighlightUop(highlighting_utils.GetUopUid(uid))
+
+        if uid is not None:
+            if uid in self.__highlighted_uops:
+                self.__highlighted_uops.remove(uid)
+                self.__previously_highlighted_uops.append(uid)
 
     # # Check if a uop has been highlighted (by UID)
     def IsUopUidHighlighted(self, uop_uid):
@@ -577,12 +581,16 @@ class Layout_Context(object):
         return uop_uid in self.__previously_highlighted_uops
 
     # # Check if a uop has been highlighted (by annotation string)
-    def IsUopHighlighted(self, anno_string):
-        return highlighting_utils.GetUopUid(anno_string) in self.__highlighted_uops
+    def IsUopHighlighted(self, uid):
+        if isinstance(uid, str):
+            return self.IsUopHighlighted(highlighting_utils.GetUopUid(uid))
+        return uid in self.__highlighted_uops
 
     # # Check if a uop has been unhighlighted (by annotation string), but not yet redrawn
-    def WasUopHighlighted(self, anno_string):
-        return highlighting_utils.GetUopUid(anno_string) in self.__previously_highlighted_uops
+    def WasUopHighlighted(self, uid):
+        if isinstance(uid, str):
+            return self.WasUopHighlighted(highlighting_utils.GetUopUid(uid))
+        return uid in self.__previously_highlighted_uops
 
     # # Redraw elements that have changed their highlighting state
     def RedrawHighlightedElements(self):


### PR DESCRIPTION
Update the uop highlighting regex to match on pair-based annotations with a uid() field.

Example: `uid(123456)`