### PR TITLE
Argos Zooming Fixes

### DIFF
--- a/helios/pipeViewer/pipe_view/core/src/core.pyx
+++ b/helios/pipeViewer/pipe_view/core/src/core.pyx
@@ -470,7 +470,8 @@ cdef class Renderer(object):
 
         if content_type == 'image':
             # Draw an image
-            dc.DrawBitmap(canvas.GetMongooseImage(), c_x, c_y)
+            #dc.DrawBitmap(image, c_x, c_y)
+            pass
         else: # auto
             # Draw text clipped to this element
 

--- a/helios/pipeViewer/pipe_view/core/src/core.pyx
+++ b/helios/pipeViewer/pipe_view/core/src/core.pyx
@@ -117,9 +117,9 @@ cdef extern from "wx/font.h":
         wxFONTWEIGHT_BOLD,
         wxFONTWEIGHT_MAX
 
-cdef extern from "wx/dc.h":
+cdef extern from "wx/dcgraph.h":
 
-    cdef cppclass wxDC:
+    cdef cppclass wxGCDC:
         void SetFont(wxFont font) # const &
         void SetPen(wxPen pen) # const &
         void SetBrush(wxBrush brush) # const &
@@ -167,17 +167,17 @@ cdef extern from "wx/dc.h":
                   wxCoord ydest,
                   wxCoord width,
                   wxCoord height,
-                  wxDC * source,
+                  wxGCDC * source,
                   wxCoord xsrc,
                   wxCoord ysrc) # Truncated argument list
 
 
 cdef extern from "helpers.h":
     bool wxPyConvertWrappedPtr(PyObject* obj, void **ptr, const wxString& className)
-    wxDC* getDC_wrapped(PyObject* dc) except +
+    wxGCDC* getDC_wrapped(PyObject* dc) except +
     wxFont* getFont_wrapped(PyObject* font) except +
     wxBrush* getBrush_wrapped(PyObject* brush) except +
-    void getTextExtent(wxDC* dc, long* char_width, long* char_height)
+    void getTextExtent(wxGCDC* dc, long* char_width, long* char_height)
 
 def get_argos_version():
     return 1;
@@ -194,7 +194,7 @@ cpdef str extract_value(str s, str key, str separators = '=:', long skip_chars =
         return not_found
     return matches[0][skip_chars:]
 
-cdef wxDC* getDC(dc):
+cdef wxGCDC* getDC(dc):
     return getDC_wrapped(<PyObject*>dc)
 
 cdef wxFont* getFont(font):
@@ -419,7 +419,7 @@ cdef class Renderer(object):
                             schedule_settings = None,
                             short_format = ''):
                             # schedule_settings: (period_width, 0/1/2 (none/dots/boxed))
-        cdef wxDC * c_dc = getDC(dc)
+        cdef wxGCDC * c_dc = getDC(dc)
 
         cdef int c_x
         cdef int c_y
@@ -554,11 +554,12 @@ cdef class Renderer(object):
         """
         Draw elements in the list to the given dc
         """
+
         elements = canvas.GetDrawPairs() # Uses bounds
         xoff, yoff = canvas.GetRenderOffsets()
         _, reason_brushes = canvas.GetBrushes()
 
-        cdef wxDC * c_dc = getDC(dc)
+        cdef wxGCDC * c_dc = getDC(dc)
 
         cdef wxColour c_color
         cdef wxPen c_pen

--- a/helios/pipeViewer/pipe_view/core/src/helpers.h
+++ b/helios/pipeViewer/pipe_view/core/src/helpers.h
@@ -13,6 +13,8 @@
 #include "wxPython/sip.h"
 #include "wxPython/wxpy_api.h"
 
+#include "wx/dcgraph.h"
+
 #ifndef ARGOS_VERSION
 #define ARGOS_VERSION unknown
 #endif
@@ -44,8 +46,8 @@ inline T* getWrappedWXType(PyObject* py_type, const wxString& class_name) {
     static const wxString CLASS_TYPE(#type); \
     return getWrappedWXType<type>(obj, CLASS_TYPE);
 
-inline wxDC* getDC_wrapped(PyObject* dc) {
-    UNWRAP_WX(wxDC, dc)
+inline wxGCDC* getDC_wrapped(PyObject* dc) {
+    UNWRAP_WX(wxGCDC, dc)
 }
 
 inline wxFont* getFont_wrapped(PyObject* font) {
@@ -56,7 +58,7 @@ inline wxBrush* getBrush_wrapped(PyObject* brush) {
     UNWRAP_WX(wxBrush, brush)
 }
 
-inline void getTextExtent(wxDC* dc, long* char_width, long* char_height) {
+inline void getTextExtent(wxGCDC* dc, long* char_width, long* char_height) {
     static const wxString M("m");
     dc->GetTextExtent(M, char_width, char_height);
 }

--- a/helios/pipeViewer/pipe_view/gui/input_decoder.py
+++ b/helios/pipeViewer/pipe_view/gui/input_decoder.py
@@ -330,20 +330,8 @@ class Input_Decoder():
             mouse_over_preview.HandleMouseMove(event.GetPosition(), canvas)
 
     def MouseWheel(self, event, canvas):
-        # schedule scale
-        if event.ControlDown() and not event.AltDown():
-            rotation = event.GetWheelRotation()/event.GetWheelDelta()
-            if rotation > 0:
-                factor = 1.05
-            else:
-                factor = 0.95
-            new_scale = canvas.GetScheduleScale()*factor
-            # cap at 3x
-            if new_scale > 3:
-                new_scale = 3
-            canvas.SetScheduleScale(new_scale)
         # canvas scale
-        elif event.ControlDown() and event.AltDown():
+        if event.GetModifiers() == wx.MOD_CONTROL:
             rotation = event.GetWheelRotation()/event.GetWheelDelta()
             if rotation > 0:
                 factor = 1.05

--- a/helios/pipeViewer/pipe_view/gui/layout_canvas.py
+++ b/helios/pipeViewer/pipe_view/gui/layout_canvas.py
@@ -82,7 +82,6 @@ class Layout_Canvas(wx.ScrolledWindow):
 
         self.__set_renderer_font = False
         self.__schedule_line_draw_style = 4 # classic
-        self.__schedule_scale = 1.0
 
         # used for color highlighting of transactions
         self.__colored_transactions = {}
@@ -215,11 +214,11 @@ class Layout_Canvas(wx.ScrolledWindow):
         y_bound = bounds[1] - self.scrollrate
 
         w_pix, h_pix = self.GetClientSize()
-        percent_bar_x = w_pix / (1.0 * self.__WIDTH)
-        percent_bar_y = h_pix / (1.0 * self.__HEIGHT)
+        percent_bar_x = w_pix / self.__WIDTH
+        percent_bar_y = h_pix / self.__HEIGHT
 
-        self.__scroll_ratios = self.GetScrollPos(wx.HORIZONTAL) / (x_bound * 1.0) + percent_bar_x / 4.0, \
-                              self.GetScrollPos(wx.VERTICAL) / (y_bound * 1.0) + percent_bar_y / 4.0
+        self.__scroll_ratios = (self.GetScrollPos(wx.HORIZONTAL) / x_bound + percent_bar_x / 4.0,
+                                self.GetScrollPos(wx.VERTICAL) / y_bound + percent_bar_y / 4.0)
 
         # If we're in edit mode, update the cursor location in the toolbar
         if self.__user_handler.GetEditMode():
@@ -383,9 +382,6 @@ class Layout_Canvas(wx.ScrolledWindow):
     def GetScale(self):
         return self.__canvas_scale
 
-    def GetScheduleScale(self):
-        return self.__schedule_scale
-
     # # Updates the highlighting state of all cached transactions
     def UpdateTransactionHighlighting(self):
         for key, val in self.__colored_transactions.items():
@@ -446,11 +442,6 @@ class Layout_Canvas(wx.ScrolledWindow):
 
         super(self.__class__, self).Refresh()
 
-    def SetScheduleScale(self, scale):
-        self.__schedule_scale = scale
-        self.__context.FullUpdate()
-        self.Refresh()
-
     # # Returns a list of all Elements beneath the given point
     def DetectCollision(self, pt):
         return self.__context.DetectCollision(pt)
@@ -493,8 +484,8 @@ class Layout_Canvas(wx.ScrolledWindow):
         w_pix, h_pix = self.GetClientSize()
         x_bound, y_bound = self.__GetScrollBounds()
         x, y = self.__scroll_ratios
-        percent_bar_x = w_pix / (1.0 * self.__WIDTH)
-        percent_bar_y = h_pix / (1.0 * self.__HEIGHT)
+        percent_bar_x = w_pix / self.__WIDTH
+        percent_bar_y = h_pix / self.__HEIGHT
         if percent_bar_x > 1:
             percent_bar_x = 1
         if percent_bar_y > 1:

--- a/helios/pipeViewer/pipe_view/gui/layout_canvas.py
+++ b/helios/pipeViewer/pipe_view/gui/layout_canvas.py
@@ -2,6 +2,7 @@ import wx
 import wx.lib.dragscroller as drgscrlr
 import os
 import colorsys # For easy HSL to RGB conversion
+import math
 import sys
 import time
 import logging
@@ -32,6 +33,8 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     MIN_WIDTH = 500
     MIN_HEIGHT = 500
+    MIN_ZOOM = 0.1
+    MAX_ZOOM = 2
 
     # # Construct a Layout_Canvas
     #  @param parent Parent Layout_Frame
@@ -48,6 +51,8 @@ class Layout_Canvas(wx.ScrolledWindow):
                  style = wx.NO_FULL_REPAINT_ON_RESIZE):
 
         wx.ScrolledWindow.__init__(self, parent)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+        self.SetBackgroundColour(wx.WHITE)
         self.__renderer = core.Renderer()
         assert len(autocoloring.REASON_BRUSHES) > 0 and len(autocoloring.BACKGROUND_BRUSHES) > 0
         self.SetRendererBrushes()
@@ -74,12 +79,8 @@ class Layout_Canvas(wx.ScrolledWindow):
         #End TODO ###########################################
         self.__selection = Selection_Mgr(self, dialog)
         self.__user_handler = Input_Decoder(self, self.__selection)
-        self.__buffer = None
-        self.__backbuffer = None
-        # used to store original image segment when hover text drawn
-        self.__dirty_position = None
-        self.__clean_buffer = None
 
+        self.__set_renderer_font = False
         self.__schedule_line_draw_style = 4 # classic
         self.__schedule_scale = 1.0
 
@@ -89,13 +90,7 @@ class Layout_Canvas(wx.ScrolledWindow):
         self.__hover_preview = HoverPreview(self, context)
         # Load images
 
-        self.__fnt_layout = GetMonospaceFont(12)
-
-        # set up font
-        temp_dc = wx.MemoryDC()
-        temp_dc.SetFont(self.__fnt_layout)
-        self.__renderer.setFontFromDC(temp_dc)
-        del temp_dc
+        self.__fnt_layout = GetMonospaceFont(11)
 
         # Disable background erasing
         def disable_event(*pargs, **kwargs):
@@ -104,8 +99,7 @@ class Layout_Canvas(wx.ScrolledWindow):
         self.Bind(wx.EVT_ERASE_BACKGROUND, disable_event)
         self.Bind(wx.EVT_PAINT, self.OnPaint)
         self.Bind(wx.EVT_SIZE, self.OnSize)
-        # Ensure that the buffers are setup correctly
-        self.OnSize(None)
+
         # Bindings for mouse events
         self.Bind(wx.EVT_LEFT_DOWN,
                   partial(self.__user_handler.LeftDown, canvas = self,
@@ -139,9 +133,7 @@ class Layout_Canvas(wx.ScrolledWindow):
         # required to actually receive key events
         self.SetFocus()
 
-        self.Bind(wx.EVT_SCROLLWIN, self.Scrollin)
-
-        self.Bind(EVT_HOVER_REDRAW, self.OnHoverRedraw)
+        self.Bind(wx.EVT_SCROLLWIN, self.ScrollWin)
 
     # # Size of the canvas grid
     @property
@@ -193,56 +185,10 @@ class Layout_Canvas(wx.ScrolledWindow):
 
         return string_to_display, brush
 
-    # # Draw hover text onto specified DC.
-    # Function called by either OnPaint or OnHoverRedraw
-    def DoHoverTextDraw(self, dc):
-
-        string_to_display, brush = self.UpdateTransactionColor(self.__hover_preview.element, \
-                                                               self.__hover_preview.annotation)
-
-        # set brush and pen
-        dc.SetBrush(brush)
-        BORDER_LIGHTNESS = 0.7
-        dc.SetPen(wx.Pen((int(brush.Colour[0] * BORDER_LIGHTNESS),
-                          int(brush.Colour[1] * BORDER_LIGHTNESS),
-                          int(brush.Colour[2] * BORDER_LIGHTNESS)), 1)) # Darker border around brush
-        # draw text and box
-        text = self.__hover_preview.GetText()
-
-        if text == '':
-            return # Do not draw an empty rectangle here. It causes dirt to be
-                   # left behind when the 1px-wide buffer is restored
-
-        tr = self.__hover_preview.position
-
-        br = dc.GetMultiLineTextExtent(text)
-
-        rect_mop = [tr[0], tr[1], br[0] + 1, br[1] + 1]
-
-        visible_area = self.GetVisibleArea()
-        box_right = rect_mop[0] + rect_mop[2]
-        box_bottom = rect_mop[1] + rect_mop[3]
-        if box_right > visible_area[2]: # off the right edge
-            # shift left
-            rect_mop[0] -= (box_right - visible_area[2])
-        if box_bottom > visible_area[3]:
-            rect_mop[1] -= (box_bottom - visible_area[3])
-
-        if rect_mop[0] < 0 or rect_mop[1] < 0:
-            return # screen too small
-        # capture old swatch and position so we can patch it later.
-        self.__clean_buffer = self.__buffer.GetSubBitmap(rect_mop)
-        self.__dirty_position = rect_mop[0], rect_mop[1]
-
-        dc.DrawRectangle(*rect_mop)
-        dc.DrawLabel(text, rect = rect_mop)
-
     # # Here the canvas does all it's drawing
     def DoDraw(self, dc):
         logging.debug('xxx: Started C drawing')
 
-        # Reapply font
-        dc.SetFont(self.__fnt_layout)
         # Draw grid
         # This has effectively 0 cost
         if self.__draw_grid:
@@ -261,28 +207,19 @@ class Layout_Canvas(wx.ScrolledWindow):
 
         logging.debug('{0}s: C drawing'.format(time.monotonic() - t_start))
 
-    # # Flip the front and back buffers
-    def __flip(self):
-        self.__buffer, self.__backbuffer = self.__backbuffer, self.__buffer
-        self.Update()
-        self.Refresh()
-
-    def Scrollin(self, evt):
-        wx.ScrolledWindow.Refresh(self)
+    def ScrollWin(self, evt):
+        super(self.__class__, self).Refresh()
 
         bounds = self.__GetScrollBounds()
         x_bound = bounds[0] - self.scrollrate
         y_bound = bounds[1] - self.scrollrate
 
         w_pix, h_pix = self.GetClientSize()
-        percent_bar_x = w_pix / (1.0 * self.__WIDTH * self.__canvas_scale)
-        percent_bar_y = h_pix / (1.0 * self.__HEIGHT * self.__canvas_scale)
+        percent_bar_x = w_pix / (1.0 * self.__WIDTH)
+        percent_bar_y = h_pix / (1.0 * self.__HEIGHT)
 
         self.__scroll_ratios = self.GetScrollPos(wx.HORIZONTAL) / (x_bound * 1.0) + percent_bar_x / 4.0, \
                               self.GetScrollPos(wx.VERTICAL) / (y_bound * 1.0) + percent_bar_y / 4.0
-
-        # don't let old clean buffer be written in wrong spot
-        self.__clean_buffer = None
 
         # If we're in edit mode, update the cursor location in the toolbar
         if self.__user_handler.GetEditMode():
@@ -297,13 +234,15 @@ class Layout_Canvas(wx.ScrolledWindow):
 
             self.__parent.UpdateMouseLocation(x, y)
 
+        mousePos = wx.GetMousePosition()
+        self.__hover_preview.HandleMouseMove(mousePos, self)
         evt.Skip()
 
     # # Returns the position of the mouse within the canvas
     def GetMousePosition(self):
         return self.CalcUnscrolledPosition(self.ScreenToClient(wx.GetMousePosition()))
 
-    # # Execute all drawing logic, flip buffers
+    # # Execute all drawing logic
     def FullUpdate(self):
 
         # update quad tree (if needed)
@@ -312,38 +251,18 @@ class Layout_Canvas(wx.ScrolledWindow):
         # Tell the Element Prop's Dlg window to update itself
         self.__dlg.Refresh()
 
-    # # Execute all drawing logic, flip the buffers, blit the front buffer to
-    #  the screen
+    # # Execute all drawing logic
     def OnPaint(self, event):
-        dc = wx.MemoryDC()
-        dc.SelectObject(self.__backbuffer)
-        dc.Clear()
-        dc.SetUserScale(self.__canvas_scale, self.__canvas_scale)
+        paint_dc = wx.AutoBufferedPaintDC(self)
+        context = wx.GraphicsContext.Create(paint_dc)
+        dc = wx.GCDC(context)
+        dc.SetLogicalScale(self.__canvas_scale, self.__canvas_scale)
+        dc.SetFont(self.__fnt_layout)
+        if not self.__set_renderer_font:
+            self.__renderer.setFontFromDC(dc)
+            self.__set_renderer_font = True
         self.DoDraw(dc)
         self.__selection.Draw(dc)
-
-        self.__buffer, self.__backbuffer = self.__backbuffer, self.__buffer
-        dc = wx.BufferedPaintDC(self, self.__buffer)
-
-        # update the hover
-        if self.__hover_preview.IsEnabled():
-            mousePos = wx.GetMousePosition()
-            screenPos = self.GetScreenPosition()
-            localMousePos = (mousePos[0] - screenPos[0], mousePos[1] - screenPos[1])
-            self.__hover_preview.HandleMouseMove(localMousePos, self)
-
-    # # Perform limited redraw.
-    # Only updates the hover text that appears when object is moused over.
-    def OnHoverRedraw(self, event):
-        dc = wx.MemoryDC()
-        dc.SelectObject(self.__buffer)
-        if self.__clean_buffer:
-            dc.DrawBitmap(self.__clean_buffer, self.__dirty_position[0], self.__dirty_position[1])
-        if self.__hover_preview.show:
-            dc.SetFont(self.__fnt_layout)
-            self.DoHoverTextDraw(dc)
-        client_dc = wx.ClientDC(self)
-        wx.BufferedDC(client_dc, self.__buffer)
 
     # # Returns Hover Preview
     def GetHoverPreview(self):
@@ -365,16 +284,7 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     # # Gets called when the window is resized, and when the canvas is initialized
     def OnSize(self, event):
-        # Here we need to create a new off-screen buffer to hold
-        # the in-progress drawings on.
-        width, height = self.GetClientSize()
-        if width == 0:
-            width = 1
-        if height == 0:
-            height = 1
-        self.__buffer = wx.Bitmap(width, height)
-        self.__backbuffer = wx.Bitmap(width, height)
-        # Now update the screen
+        # update the screen
         self.FullUpdate()
 
     # # Gets the selection manager for this canvas
@@ -404,9 +314,37 @@ class Layout_Canvas(wx.ScrolledWindow):
                   mins[1] + height / self.__canvas_scale)
         return bounds
 
+    # Gets the update region relative to the current visible area
+    # Coordinates are scaled to account for current zoom factor
+    # Used by schedule elements to determine where to blit
+    def GetScaledUpdateRegion(self):
+        box = self.GetUpdateRegion().GetBox()
+        box = wx.Rect(math.floor(box[0] / self.__canvas_scale),
+                      math.floor(box[1] / self.__canvas_scale),
+                      math.ceil(box[2] / self.__canvas_scale),
+                      math.ceil(box[3] / self.__canvas_scale))
+
+        box.Inflate(10, 10) # Fudge factor to ensure no dirt is left behind
+        return box
+
+    # Gets the update region relative to the origin of the scrolled area
+    # Region is scaled to account for current zoom factor
+    # Used to determine which elements need to be updated
+    def GetScrolledUpdateRegion(self):
+        box = self.GetUpdateRegion().GetBox()
+        box.SetPosition(self.CalcUnscrolledPosition(box.GetTopLeft()))
+        box.SetHeight(math.ceil(box.GetHeight() / self.__canvas_scale))
+        box.SetWidth(math.ceil(box.GetWidth() / self.__canvas_scale))
+
+        box.Inflate(10, 10) # Fudge factor to ensure no dirt is left behind
+        return box
+
     # # Returns element pairs suitable for drawing
     def GetDrawPairs(self):
-        bounds = self.GetBounds()
+        box = self.GetScrolledUpdateRegion()
+        top_left = box.GetTopLeft()
+        bottom_right = box.GetBottomRight()
+        bounds = (top_left[0], top_left[1], bottom_right[0], bottom_right[1])
         return self.__context.GetDrawPairs(bounds)
 
     def GetVisibilityTick(self):
@@ -499,12 +437,8 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     def SetScale(self, scale):
         # cap at 2x zoom in
-        if scale > 2:
-            self.__canvas_scale = 2
-        else:
-            self.__canvas_scale = scale
-        # purge outdated buffer
-        self.__clean_buffer = None
+        self.__canvas_scale = min(max(self.MIN_ZOOM, scale), self.MAX_ZOOM)
+
         self.__CalcCanvasSize()
         self.__UpdateScrollbars()
         self.__UpdateGrid(self.__gridsize)
@@ -513,8 +447,6 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     def SetScheduleScale(self, scale):
         self.__schedule_scale = scale
-        # purge outdated buffer
-        self.__clean_buffer = None
         self.__context.FullUpdate()
         self.Refresh()
 
@@ -524,8 +456,9 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     # # override to handle full-canvas scale
     def CalcUnscrolledPosition(self, position):
-        x0, y0 = self.GetViewStart()[0] / self.__canvas_scale * self.scrollrate, \
-                        self.GetViewStart()[1] / self.__canvas_scale * self.scrollrate
+        view_start = self.GetViewStart()
+        x0 = view_start[0] * self.scrollrate / self.__canvas_scale
+        y0 = view_start[1] * self.scrollrate / self.__canvas_scale
         return x0 + position[0] / self.__canvas_scale, y0 + position[1] / self.__canvas_scale
 
     # # Calculate the canvas size based on all elements
@@ -533,6 +466,8 @@ class Layout_Canvas(wx.ScrolledWindow):
     def __CalcCanvasSize(self):
 
         l, t, r, b = self.__context.GetElementExtents()
+        r *= self.__canvas_scale
+        b *= self.__canvas_scale
 
         width = max(self.MIN_WIDTH, r + self.__AUTO_CANVAS_SIZE_MARGIN)
         height = max(self.MIN_HEIGHT, b + self.__AUTO_CANVAS_SIZE_MARGIN)
@@ -546,7 +481,7 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     def __GetScrollBounds(self):
         sr = float(self.scrollrate)
-        return self.__WIDTH * self.__canvas_scale / sr, self.__HEIGHT * self.__canvas_scale / sr
+        return self.__WIDTH / sr, self.__HEIGHT / sr
 
     # # Update the scrollbars based on a new canvas size
     #  Restores prior scroll offsets
@@ -557,8 +492,8 @@ class Layout_Canvas(wx.ScrolledWindow):
         w_pix, h_pix = self.GetClientSize()
         x_bound, y_bound = self.__GetScrollBounds()
         x, y = self.__scroll_ratios
-        percent_bar_x = w_pix / (1.0 * self.__WIDTH * self.__canvas_scale)
-        percent_bar_y = h_pix / (1.0 * self.__HEIGHT * self.__canvas_scale)
+        percent_bar_x = w_pix / (1.0 * self.__WIDTH)
+        percent_bar_y = h_pix / (1.0 * self.__HEIGHT)
         if percent_bar_x > 1:
             percent_bar_x = 1
         if percent_bar_y > 1:

--- a/helios/pipeViewer/pipe_view/gui/layout_canvas.py
+++ b/helios/pipeViewer/pipe_view/gui/layout_canvas.py
@@ -88,8 +88,6 @@ class Layout_Canvas(wx.ScrolledWindow):
 
         self.__hover_preview = HoverPreview(self, context)
         # Load images
-        # # \todo Use a image map
-        self.__mongoose_image = self.GetMongooseLogo()
 
         self.__fnt_layout = GetMonospaceFont(12)
 
@@ -162,17 +160,6 @@ class Layout_Canvas(wx.ScrolledWindow):
     @property
     def context(self):
         return self.__context
-
-    # # Returns bitmap of Mongoose logo
-    # Currently hardcoded
-    def GetMongooseLogo(self):
-        this_script_filename = os.path.join(os.getcwd(), __file__)
-        mongoose_logo_filename = os.path.dirname(os.path.dirname(this_script_filename)) + "/resources/mongoose_small.png"
-
-        if os.path.exists(mongoose_logo_filename):
-            return wx.Bitmap(mongoose_logo_filename, wx.BITMAP_TYPE_PNG)
-        else:
-            return wx.EmptyBitmapRGBA(10, 10)
 
     # # Returns the parent frame which owns this Canvas
     def GetFrame(self):
@@ -273,39 +260,6 @@ class Layout_Canvas(wx.ScrolledWindow):
         self.__renderer.drawElements(dc, self, self.__context.GetHC())
 
         logging.debug('{0}s: C drawing'.format(time.monotonic() - t_start))
-
-        # #t_start = time.monotonic()
-        # #
-        # ## Draw elements in draw-order
-        # #for pair in self.__context.GetElements():
-        # #    e = pair.GetElement()
-        # #    string_to_display = pair.GetVal()
-        # #    (x,y),(w,h) = e.GetProperty('position'),e.GetProperty('dimensions')
-        # #    (x,y) = (x-xoff, y-yoff)
-        # #
-        # #    pen  = wx.Pen(e.GetProperty('color'), 1)
-        # #    dc.SetPen(pen)
-        # #
-        # #    uop_id = string_to_display[:1]
-        # #    if uop_id in self.__background_brushes \
-        # #       and e.GetProperty('Content') == 'auto_color_annotation':
-        # #        dc.SetBrush(self.__background_brushes[uop_id])
-        # #    else:
-        # #        dc.SetBrush(dc.GetBackground())
-        # #
-        # #    dc.DrawRectangle(x,y,w,h)
-        # #
-        # #    # Draw text clipped to this element
-        # #    dc.SetClippingRegion(x,y,w,h)
-        # #
-        # #    if e.GetProperty('Content') == 'image':
-        # #        dc.DrawBitmap(self.__mongoose_image, x, y)
-        # #    else:
-        # #        dc.DrawText(string_to_display,x+2,y+2)
-        # #
-        # #    dc.DestroyClippingRegion()
-        # #
-        # #logging.debug('Py drawing took {0}s'.format(time.monotonic() - t_start))
 
     # # Flip the front and back buffers
     def __flip(self):
@@ -457,10 +411,6 @@ class Layout_Canvas(wx.ScrolledWindow):
 
     def GetVisibilityTick(self):
         return self.__context.GetVisibilityTick()
-
-    # # Return stored image
-    def GetMongooseImage(self):
-        return self.__mongoose_image
 
     # # Set the brushes in the renderer to the current brush set
     def SetRendererBrushes(self):

--- a/helios/pipeViewer/pipe_view/gui/layout_canvas.py
+++ b/helios/pipeViewer/pipe_view/gui/layout_canvas.py
@@ -254,6 +254,7 @@ class Layout_Canvas(wx.ScrolledWindow):
     # # Execute all drawing logic
     def OnPaint(self, event):
         paint_dc = wx.AutoBufferedPaintDC(self)
+        paint_dc.Clear();
         context = wx.GraphicsContext.Create(paint_dc)
         dc = wx.GCDC(context)
         dc.SetLogicalScale(self.__canvas_scale, self.__canvas_scale)

--- a/helios/pipeViewer/pipe_view/gui/selection_manager.py
+++ b/helios/pipeViewer/pipe_view/gui/selection_manager.py
@@ -251,7 +251,7 @@ class Selection_Mgr():
         '''
         bx, by, bw, bh = self.__queue[base]
         delta = self.__prev_y - pt[1]
-        current = self.__bottom * 1.0 - self.__prev_y
+        current = self.__bottom - self.__prev_y
         # Check that the mouse is moving in a direction at a location worth
         # resizing, since due to snapping, the element may already be where
         # the mouse is headed
@@ -274,7 +274,7 @@ class Selection_Mgr():
     def __LeftResizeScaling(self, pt, base):
         bx, by, bw, bh = self.__queue[base]
         delta = self.__prev_x - pt[0]
-        current = self.__right * 1.0 - self.__prev_x
+        current = self.__right - self.__prev_x
         if (((-delta < 0 and bx > pt[0]) or (-delta > 0 and bx < pt[0])) and
             current > 0):
             factor = -(delta / current + 1.0)
@@ -294,7 +294,7 @@ class Selection_Mgr():
     def __RightResizeScaling(self, pt, base):
         bx, by, bw, bh = self.__queue[base]
         delta = pt[0] - self.__prev_x
-        current = self.__prev_x - self.__left * 1.0
+        current = self.__prev_x - self.__left
         if (((delta < 0 and (bx + bw) > pt[0]) or (delta > 0 and (bx + bw) < pt[0]))
             and current > 0):
             factor = 1.0 + delta / current
@@ -314,7 +314,7 @@ class Selection_Mgr():
     def __BottomResizeScaling(self, pt, base):
         bx, by, bw, bh = self.__queue[base]
         delta = pt[1] - self.__prev_y
-        current = self.__prev_y - self.__top * 1.0
+        current = self.__prev_y - self.__top
         if (((delta < 0 and (by + bh) > pt[1]) or (delta > 0 and (by + bh) < pt[1]))
             and not (current == 0)):
             if current > 0:

--- a/helios/pipeViewer/pipe_view/model/content_options.py
+++ b/helios/pipeViewer/pipe_view/model/content_options.py
@@ -70,7 +70,7 @@ def GetCaption(trans, e, *args):
 
 
 def GetImage(*args):
-    return 'Mongoose logo'
+    return ''
 
 
 def GetClock(trans, e, dbhandle, tick, loc_vars, *args):
@@ -127,7 +127,7 @@ __CONTENT_PROC = {'type':                  (GetType, "Whether the transaction is
                 'auto_color_anno_notext':(GetAnnotation, "Color element based on seq ID, but do not display annotation"),
                 'auto_color_anno_nomunge':(GetAnnotation, "Color element based on seq ID, but do not munge text"),
                 'caption':               (GetCaption, "Caption (static text) from Element \'caption\' property"),
-                'image':                 (GetImage, "Image (currently hardcoded to the Mongoose logo)"),
+                'image':                 (GetImage, "Image (currently hardcoded to nothing)"),
                 'clock':                 (GetClock, "Name of clock associated with this location"),
                 'cycle':                 (GetCycle, "Current Cycle of clock associated with this location"),
                 'tick_duration':         (GetTickDuration, "Duration of this transaction in ticks"),

--- a/helios/pipeViewer/pipe_view/model/schedule_element.py
+++ b/helios/pipeViewer/pipe_view/model/schedule_element.py
@@ -686,11 +686,18 @@ class ScheduleElement(MultiElement):
                 clip_region = (0, 0, i_d_p, box_size[1])
 
             time_range = (start_range, end_range)
-            # crude copy
-            temp = self.__buffer.GetSubBitmap((0, 0, self.__buffer.GetWidth(), self.__buffer.GetHeight()))
-            # shift
-            self.__dc.DrawBitmap(temp, canvas.MAX_ZOOM * i_d_p, 0)
-            del temp
+            if i_d_p < 0:
+                sub_x = -canvas.MAX_ZOOM * i_d_p
+                sub_width = self.__buffer.GetWidth() - sub_x
+                dest_x = 0
+            else:
+                sub_x = 0
+                dest_x = canvas.MAX_ZOOM * i_d_p
+                sub_width = self.__buffer.GetWidth() - dest_x
+
+            self.__graphics_dc.SetLogicalScale(1, 1)
+            self.__dc.Blit(dest_x, 0, sub_width, self.__buffer.GetHeight(), self.__dc, sub_x, 0)
+            self.__graphics_dc.SetLogicalScale(canvas.MAX_ZOOM, canvas.MAX_ZOOM)
 
         # --Render Loop--
         for child_idx, child in enumerate(children):

--- a/helios/pipeViewer/pipe_view/model/schedule_element.py
+++ b/helios/pipeViewer/pipe_view/model/schedule_element.py
@@ -79,8 +79,6 @@ class ScheduleLineElement(LocationallyKeyedElement):
         self.__buffer = None
         self.__hc = 0
         self.__line_style = self.DRAW_LOOKUP[self.GetProperty('line_style')]
-        # used for horizontal zoom
-        self._scale_factor = 1.0
         InitWhiteBrush()
 
     @staticmethod
@@ -121,14 +119,13 @@ class ScheduleLineElement(LocationallyKeyedElement):
                 return x_ppos, y_pos
         elif key == 'time_scale':
             if parent:
-                return parent.GetProperty(key) * self._scale_factor
+                return parent.GetProperty(key)
             else:
-                return self._properties[key] * self._scale_factor
+                return self._properties[key]
         elif key == 't_offset':
             if parent:
                 # assume parent is schedule (for now)
-                return -parent.GetProperty('pixel_offset') * self._scale_factor * \
-                            parent.GetProperty('time_scale') / (1.0 * period)
+                return -parent.GetProperty('pixel_offset') * parent.GetProperty('time_scale') / period
         return self._properties[key]
 
     def SetProperty(self, key, val):
@@ -163,7 +160,6 @@ class ScheduleLineElement(LocationallyKeyedElement):
                     render_box = None,
                     fixed_offset = None):
 
-        self._scale_factor = canvas.GetScheduleScale()
         # -Set up draw style-
         line_style = self.__line_style
         dc.SetPen(self._pen)
@@ -241,7 +237,7 @@ class ScheduleLineElement(LocationallyKeyedElement):
             dc.DrawLine(clip[0], c_y, end_x, c_y)
 
             current_pixel = (time_range[0] - time_range[0] % period - self.__hc - t_offset * period) / t_scale
-            width = period / t_scale * 1.0
+            width = period / t_scale
 
             while current_pixel <= end_x:
                 start = int(current_pixel)
@@ -318,7 +314,7 @@ class ScheduleLineElement(LocationallyKeyedElement):
         if parent:
             getParentProperty = parent.GetProperty
             # assume parent is schedule (for now)
-            time_scale = getParentProperty('time_scale') * self._scale_factor
+            time_scale = getParentProperty('time_scale')
             offs = -getParentProperty('pixel_offset') * time_scale
             return (int(offs - period), int((offs + period) + self.GetXDim() * time_scale))
         else:
@@ -338,7 +334,7 @@ class ScheduleLineElement(LocationallyKeyedElement):
         offs += t_scale * pt[0]
 
         location = self.GetProperty('LocationString')
-        t_offset = offs / (1.0 * period)
+        t_offset = offs / period
 
         fake_element = FakeElement()
         fake_element.SetProperty('LocationString', location)
@@ -400,7 +396,6 @@ class ScheduleLineRulerElement(ScheduleLineElement):
                     render_box = None,
                     fixed_offset = None):
 
-        self._scale_factor = canvas.GetScheduleScale()
         # render box is disregarded so shift is
         # over-written when acting as a child of a container
         hc = self.GetTime()
@@ -610,8 +605,6 @@ class ScheduleElement(MultiElement):
             if ycpos < highest_y:
                 highest_y = ycpos
 
-            # push current scale factor
-            child._scale_factor = canvas.GetScheduleScale()
             # collect pairs from elements
             pair = canvas.context.GetElementPair(child)
             pairs.append(pair)


### PR DESCRIPTION
This PR makes Argos's zoomed view prettier and simplifies some of the canvas rendering

* Text and graphics scale smoothly when zoomed instead of becoming pixelated
* Hover box is moved to a separate UI widget so that it doesn't get scaled when the canvas is zoomed
* Double buffering is now handled automatically
* Optimized redraws so that we don't re-render an entire schedule widget if only a portion needs to be redrawn