### PR TITLE
Added missing brew package `binutils` for MacOS

### DIFF
--- a/sparta/README.md
+++ b/sparta/README.md
@@ -77,6 +77,7 @@ Open a MacOS Terminal
 1. `brew install xz`
 1. `brew install zstd`
 1. `brew install cppcheck`
+1. `brew install binutils`  # This is for addr2line support for error debug log generation on crash
 1. `sudo easy_install Pygments==2.5.2` # Do not use HomeBrew! Needed for cppcheck-htmlreport
 1. Install XCode and check for clang: `clang --version`
 


### PR DESCRIPTION
Updated the README.md to reflect the optional package.

closes #174 