### PR TITLE
fix build fail if map is not a root project of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 3.14)
 
 project(MAP)
 
+set (MAP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
 set (SPARTA_BASE ${CMAKE_CURRENT_SOURCE_DIR}/sparta)
 
 add_subdirectory (sparta)

--- a/helios/pipeViewer/transactiondb/CMakeLists.txt
+++ b/helios/pipeViewer/transactiondb/CMakeLists.txt
@@ -23,7 +23,7 @@ add_custom_command(OUTPUT transactiondb.sh
   TARGETDIR="lib"
   BUILD_MODULES="transactiondb"
   REQUIRED_SPARTA_LIBS="sparta"
-  LIB_SPARTA_BUILT_PATH="${CMAKE_BINARY_DIR}/sparta"
+  LIB_SPARTA_BUILT_PATH="${MAP_BINARY_DIR}/sparta"
   CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
   python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py build_ext --inplace;' > transactiondb.sh && chmod +x transactiondb.sh
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)

--- a/sparta/CMakeLists.txt
+++ b/sparta/CMakeLists.txt
@@ -198,7 +198,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 # CppCheck Support
 set (CPPCHECK_XML_OUTPUT "${PROJECT_BINARY_DIR}/analysis/cppcheck/cppcheck_analysis.xml")
 set (CPPCHECK_EXCLUDES
-  ${CMAKE_BINARY_DIR}
+  ${MAP_BINARY_DIR}
   ${SPARTA_BASE}/test
 )
 find_package (Cppcheck)


### PR DESCRIPTION
CMAKE_BINARY_DIR is not map if it is not root project.
To replace CMAKE_BINARY_DIR with MAP_BINARY_DIR