### PR TITLE
Don't destruct data objects in Buffer::erase() or Buffer::clear(),

### DIFF
--- a/sparta/sparta/events/PhasedPayloadEvent.hpp
+++ b/sparta/sparta/events/PhasedPayloadEvent.hpp
@@ -16,6 +16,7 @@
 #include "sparta/events/Scheduleable.hpp"
 #include "sparta/events/SchedulingPhases.hpp"
 #include "sparta/utils/ValidValue.hpp"
+#include "sparta/utils/MetaStructs.hpp"
 #include "sparta/events/StartupEvent.hpp"
 
 namespace sparta
@@ -175,6 +176,9 @@ namespace sparta
         //! reusable.
         void reclaimProxy_(typename ProxyInflightList::iterator & pl_location) {
             sparta_assert(pl_location != inflight_pl_.end());
+            if constexpr(MetaStruct::is_any_pointer<DataT>::value) {
+                (*pl_location)->setPayload_(nullptr);
+            }
             free_pl_[free_idx_++] = *pl_location;
             inflight_pl_.erase(pl_location);
             pl_location = inflight_pl_.end();

--- a/sparta/sparta/resources/Buffer.hpp
+++ b/sparta/sparta/resources/Buffer.hpp
@@ -611,9 +611,6 @@ namespace sparta
             if constexpr(MetaStruct::is_any_pointer<value_type>::value) {
                 free_position_->data = nullptr; // Nullify the pointer
             }
-            else {
-                free_position_->data.~DataT(); // Destruct the data object
-            }
             free_position_->next_free = oldFree;
 
             // Mark DataPointer as invalid
@@ -675,12 +672,14 @@ namespace sparta
         void clear()
         {
             num_valid_ = 0;
-            std::for_each(buffer_map_.begin(), buffer_map_.end(), [] (auto map_entry)
-                                                                  {
-                                                                      if(map_entry) {
-                                                                          map_entry->data.~DataT();
-                                                                      }
-                                                                  });
+            if constexpr(MetaStruct::is_any_pointer<value_type>::value) {
+                std::for_each(buffer_map_.begin(), buffer_map_.end(), [] (auto map_entry)
+                                                                      {
+                                                                          if(map_entry) {
+                                                                              map_entry->data = nullptr;
+                                                                          }
+                                                                      });
+            }
             std::fill(buffer_map_.begin(), buffer_map_.end(), nullptr);
             for(uint32_t i = 0; i < data_pool_size_ - 1; ++i) {
                 data_pool_[i].next_free = &data_pool_[i + 1];


### PR DESCRIPTION
since the data objects are currently never re-constructed; also,
ensure refcount is decremented when a PayloadDeliveringProxy with a
smart pointer payload is reclaimed for a PhasedPayloadEvent