### PR TITLE
Added a method to access data in the specific pipe

### DIFF
--- a/sparta/sparta/resources/Pipeline.hpp
+++ b/sparta/sparta/resources/Pipeline.hpp
@@ -686,6 +686,20 @@ namespace sparta
         DataT & operator[](const uint32_t & stage_id) { return pipe_.access(stage_id); }
 
         /*!
+         * \brief Access (read-only) a specific stage of the pipeline
+         *
+         * \param stage_id The stage number
+         */
+        const DataT & at(const uint32_t & stage_id) const { return pipe_.read(stage_id); }
+
+        /*!
+         * \brief Access a specific stage of the pipeline
+         *
+         * \param stage_id The stage number
+         */
+        DataT & at(const uint32_t & stage_id) { return pipe_.access(stage_id); }
+
+        /*!
          * \brief Indicate the validity of a specific pipeline stage
          *
          * \param stage_id The stage number

--- a/sparta/test/Pipeline/Pipeline_test.cpp
+++ b/sparta/test/Pipeline/Pipeline_test.cpp
@@ -665,8 +665,10 @@ int main ()
     EXPECT_EQUAL(examplePipeline1.numValid(), 2);
     EXPECT_TRUE(examplePipeline1.isValid(0));
     EXPECT_EQUAL(examplePipeline1[0], 20);
+    EXPECT_EQUAL(examplePipeline1[0], examplePipeline1.at(0));
     EXPECT_TRUE(examplePipeline1.isValid(1));
     EXPECT_EQUAL(examplePipeline1[1], 14);
+    EXPECT_EQUAL(examplePipeline1[1], examplePipeline1.at(1));
     EXPECT_NOTHROW(examplePipeline1.writeStage(0, 25));
 
 


### PR DESCRIPTION
It would nice if having this method in the scenario using the pointer to sparta::Pipeline ...

I like PipelinePtr->at(idx) rather than (*PipelinePtr)[idx]