### PR TITLE
Let events can be scheduled before/after pipeline updates

### DIFF
--- a/sparta/sparta/resources/Pipeline.hpp
+++ b/sparta/sparta/resources/Pipeline.hpp
@@ -400,6 +400,38 @@ namespace sparta
         }
 
         /*!
+         * \brief Specify producer event for the pipeline update event
+         * \param ev_handler The producer event handler
+         *
+         * \note Since pipeline update event happens on the Update phase,
+         * ev_handler is also expected to be on the same phase
+         */
+        template<typename EventType>
+        void setProducerForPipelineUpdate(EventType & ev_handler)
+        {
+            auto phase = ev_handler.getScheduleable().getSchedulingPhase();
+            sparta_assert(phase == SchedulingPhase::Update,
+                          "Cannot set producer event for pipeline update event, it's not on the Update phase!");
+            ev_handler.getScheduleable().precedes(ev_pipeline_update_.getScheduleable());
+        }
+
+        /*!
+         * \brief Specify consumer event for the pipeline update event
+         * \param ev_handler The consumer event handler
+         *
+         * \note Since pipeline update event happens on the Update phase,
+         * ev_handler is also expected to be on the same phase
+         */
+        template<typename EventType>
+        void setConsumerForPipelineUpdate(EventType & ev_handler)
+        {
+            auto phase = ev_handler.getScheduleable().getSchedulingPhase();
+            sparta_assert(phase == SchedulingPhase::Update,
+                          "Cannot set consumer event for pipeline update event, it's not on the Update phase!");
+            ev_pipeline_update_.getScheduleable().precedes(ev_handler.getScheduleable());
+        }
+
+        /*!
          * \brief Specify producer event for a designated pipeline stage
          *
          * \param id The stage number


### PR DESCRIPTION
To forward data through the pipe, Sparta Pipeline Class schedules a "pipeline update" event in the Update phase to do it.

However, the data at the stage N in Cycle T always comes from the stage N-1 in Cycle T-1. This makes us hard to insert a new data into the specific stage half through the pipeline.

The newly added method, setConsumerForPipelineUpdate, enables us to schedule an event just after pipeline updates. After the pipeline forwards the data, now we have flexibility to modify data at the specific stage before collection/tick phases. But be noted that the handler of stage might need to be scheduled by user because the modified stage can be originally invalid in this cycle. Pipeline class wouldn't schedule an event for an invalid stage.