### PR TITLE
Fix for MacOS (Tested on Big Sur v11.2.1) and Linux

### DIFF
--- a/scripts/render_recipe_for_platform.sh
+++ b/scripts/render_recipe_for_platform.sh
@@ -47,10 +47,10 @@ fi
 
 case "$(uname)" in
     Darwin)
-	conda_platform='osx'
+	conda_platform='osx_64'
 	;;
     Linux)
-        conda_platform='linux'
+        conda_platform='linux_64'
 	;;
     *)
 	echo "::ERROR:: Unknown uname '$(uname)'"

--- a/sparta/README.md
+++ b/sparta/README.md
@@ -31,7 +31,7 @@ design.
 #    Doxygen   1.8
 
 # Clone Sparta via the MAP GitHub repo and 'cd' into it
-git clone https://github.com/sparcians/map
+git clone ssh://github.com/sparcians/map
 cd map/sparta
 
 # Build a release version
@@ -81,7 +81,7 @@ Open a MacOS Terminal
 1. `sudo easy_install Pygments==2.5.2` # Do not use HomeBrew! Needed for cppcheck-htmlreport
 1. Install XCode and check for clang: `clang --version`
 
-Clone sparta through https: `git clone https://github.com/sparcians/map.git`
+Clone sparta through ssh: `git clone ssh://github.com/sparcians/map.git`
 
 Attempt a build:
 


### PR DESCRIPTION
closes #227

Also, updated the readme to use SSH instead of HTTPS as the cloning method