### PR TITLE
Fix spurious transaction value changes in Argos

### DIFF
--- a/helios/pipeViewer/argos_dumper/DatabaseDump/Database_dumper.cpp
+++ b/helios/pipeViewer/argos_dumper/DatabaseDump/Database_dumper.cpp
@@ -144,6 +144,7 @@ namespace pipeViewer
                 for (uint32_t i = 0; i < p->nameVector.size(); ++i) {
                     os << p->nameVector[i] << "(" << p->stringVector[i] << ") ";
                 }
+                os << "start: " << p->time_Start << " end: " << p->time_End;
                 os << std::endl;
             }
 

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -574,7 +574,7 @@ namespace sparta{
                 updateLastRecord_();
 
                 // If the new Value pairs are not empty and current record is closed, we start a new record.
-                if(!last_record_values_.empty() && record_closed_){
+                if(!(last_record_values_.empty() && last_string_values_.empty()) && record_closed_){
                     startNewRecord_();
                     record_closed_ = false;
                 }
@@ -602,7 +602,7 @@ namespace sparta{
                 updateLastRecord_();
 
                 // If the new Value pairs are not empty and current record is closed, we start a new record.
-                if(!last_record_values_.empty() && record_closed_){
+                if(!(last_record_values_.empty() && last_string_values_.empty()) && record_closed_){
                     startNewRecord_();
                     record_closed_ = false;
                 }
@@ -691,6 +691,7 @@ namespace sparta{
 
                         // Clear the previous vector containing the Name Value pairs.
                         last_record_values_.clear();
+                        last_string_values_.clear();
                     }
                     record_closed_ = true;
                 }
@@ -705,7 +706,7 @@ namespace sparta{
             //! \brief Before writing a record to file, we need to check
             //  if any of the old Values have changed or not.
             bool isSameRecord() const {
-                return last_record_values_ == getDataVector();
+                return (last_record_values_ == getDataVector()) && (last_string_values_ == getStringVector());
             }
 
             //! \brief Strictly a Debug/Testing API.
@@ -759,6 +760,7 @@ namespace sparta{
             //  this cycle of Collection.
             void updateLastRecord_(){
                 last_record_values_ = getDataVector();
+                last_string_values_ = getStringVector();
             }
 
             //! \brief Send the Pair Structure Record to Outputter
@@ -782,7 +784,7 @@ namespace sparta{
                 argos_record_.nameVector = getNameStrings();
                 argos_record_.sizeOfVector = getSizeOfVector();
                 argos_record_.valueVector = last_record_values_;
-                argos_record_.stringVector = getStringVector();
+                argos_record_.stringVector = last_string_values_;
                 argos_record_.length = argos_record_.nameVector.size();
                 argos_record_.delimVector.emplace_back(getArgosFormatGuide());
 
@@ -818,7 +820,7 @@ namespace sparta{
                 sparta_assert(pipeline_col_ != nullptr,
                             "Collectables can only added to PipelineCollectors... for now");
 
-                if(collect && !last_record_values_.empty()){
+                if(collect && !(last_record_values_.empty() && last_string_values_.empty())){
 
                     // Set the start time for this transaction to be
                     // moment collection is enabled.
@@ -853,6 +855,7 @@ namespace sparta{
             // a Name String and its corresponding Value.
             typedef std::pair<uint64_t, bool> ValidPair;
             std::vector<ValidPair> last_record_values_;
+            std::vector<std::string> last_string_values_;
 
             // Ze Collec-tor
             PipelineCollector * pipeline_col_ = nullptr;

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -763,7 +763,7 @@ namespace sparta{
                 if(SPARTA_EXPECT_FALSE(argos_record_.nameVector.empty())) {
                     argos_record_.nameVector = getNameStrings();
                     argos_record_.length = argos_record_.nameVector.size();
-                    has_display_id_field_ = argos_record_.nameVector[0] == "DID";
+                    has_display_id_field_ = (argos_record_.nameVector[0] == "DID");
                 }
 
                 if(SPARTA_EXPECT_FALSE(argos_record_.sizeOfVector.empty())) {

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -758,26 +758,10 @@ namespace sparta{
             //! \brief Fill it with the new Name Value pairs from
             //  this cycle of Collection.
             void updateLastRecord_(){
-                // These fields only need to be set once - they define the format of the collectable
-                // and remain constant for the duration of the simulation
-                if(SPARTA_EXPECT_FALSE(argos_record_.nameVector.empty())) {
-                    argos_record_.nameVector = getNameStrings();
-                    argos_record_.length = argos_record_.nameVector.size();
-                    has_display_id_field_ = (argos_record_.nameVector[0] == "DID");
-                }
-
-                if(SPARTA_EXPECT_FALSE(argos_record_.sizeOfVector.empty())) {
-                    argos_record_.sizeOfVector = getSizeOfVector();
-                }
-
-                if(SPARTA_EXPECT_FALSE(argos_record_.delimVector.empty())) {
-                    argos_record_.delimVector.emplace_back(getArgosFormatGuide());
-                }
-                // End of collectable format fields
-
                 // These values will change every time the transaction changes
                 argos_record_.valueVector = getDataVector();
                 argos_record_.stringVector = getStringVector();
+                argos_record_.sizeOfVector = getSizeOfVector();
 
                 if (has_display_id_field_) {
                     argos_record_.display_ID = argos_record_.valueVector[0].first & 0x0fff;
@@ -834,6 +818,13 @@ namespace sparta{
                 pipeline_col_ = dynamic_cast<PipelineCollector *>(collector);
                 sparta_assert(pipeline_col_ != nullptr,
                             "Collectables can only added to PipelineCollectors... for now");
+
+                // These fields only need to be set once - they define the format of the collectable
+                // and remain constant for the duration of the simulation
+                argos_record_.nameVector = getNameStrings();
+                argos_record_.length = argos_record_.nameVector.size();
+                has_display_id_field_ = (argos_record_.nameVector[0] == "DID");
+                argos_record_.delimVector.emplace_back(getArgosFormatGuide());
 
                 if(collect && hasData_()){
 


### PR DESCRIPTION
This PR fixes a bug in Argos collection that caused collectors to grab the latest string data for a location every time that location was written to a database. Unfortunately, this often resulted in it getting the string data for the _next_ transaction instead of the current one.

A common example of this bug is an instruction in a sparta::Queue that appears to suddenly change its disassembly string several cycles before the next instruction actually enters that entry.