### PR TITLE
Close Collectable record when collected object pointer becomes null

### DIFF
--- a/sparta/example/CoreModel/src/Execute.hpp
+++ b/sparta/example/CoreModel/src/Execute.hpp
@@ -84,7 +84,7 @@ namespace core_example
         const bool in_order_issue_;
         sparta::collection::IterableCollector<std::list<ExampleInstPtr>>
         ready_queue_collector_ {getContainer(), "scheduler_queue",
-                ready_queue_, scheduler_size_};
+                &ready_queue_, scheduler_size_};
 
         // Events used to issue and complete the instruction
         sparta::UniqueEvent<> issue_inst_{&unit_event_set_, getName() + "_issue_inst",

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -197,6 +197,11 @@ namespace sparta{
             //! CollectableTreeNode/PipelineCollector when a user of the
             //! TreeNode requests this object to be collected.
             void collect() override final {
+                // If pointer has become nullified, close the record
+                if(nullptr == collected_object_) {
+                    closeRecord();
+                    return;
+                }
                 collect(*collected_object_);
             }
 
@@ -206,6 +211,11 @@ namespace sparta{
              * \pre Must have constructed wit ha non-null collected object
              */
             void collectWithDuration(sparta::Clock::Cycle duration) {
+                // If pointer has become nullified, close the record
+                if(nullptr == collected_object_) {
+                    closeRecord();
+                    return;
+                }
                 collectWithDuration(*collected_object_, duration);
             }
 
@@ -586,26 +596,12 @@ namespace sparta{
             template <typename T>
             MetaStruct::enable_if_t<MetaStruct::is_any_pointer<T>::value, void>
             collect(const T & val){
-                collect_(*val);
-
-                // if the value pairs are not the same as the
-                // previous value pairs and the previous record is still open
-                if(!isSameRecord() && !record_closed_)
-                {
-
-                    //Close the old record (if there is one)
+                // If pointer has become nullified, close the record
+                if(nullptr == collected_object_) {
                     closeRecord();
+                    return;
                 }
-
-                // Remember the new value pairs for a new record and start
-                // a new record if not empty.
-                updateLastRecord_();
-
-                // If the new Value pairs are not empty and current record is closed, we start a new record.
-                if(!last_record_values_.empty() && record_closed_){
-                    startNewRecord_();
-                    record_closed_ = false;
-                }
+                collect(*val);
             }
 
             /*!
@@ -643,19 +639,23 @@ namespace sparta{
             template<typename T>
             MetaStruct::enable_if_t<MetaStruct::is_any_pointer<T>::value, void>
             collectWithDuration(const T & val, sparta::Clock::Cycle duration){
-                if(SPARTA_EXPECT_FALSE(isCollected()))
-                {
-                    if(duration != 0) {
-                        ev_close_record_.preparePayload(false)->schedule(duration);
-                    }
-                    collect(*val);
+                // If pointer has become nullified, close the record
+                if(nullptr == collected_object_) {
+                    closeRecord();
+                    return;
                 }
+                collectWithDuration(*val, duration);
             }
 
             //! Virtual method called by
             //! CollectableTreeNode/PipelineCollector when a user of the
             //! TreeNode requests this object to be collected.
             void collect() override final {
+                // If pointer has become nullified, close the record
+                if(nullptr == collected_object_) {
+                    closeRecord();
+                    return;
+                }
                 collect(*collected_object_);
             }
 
@@ -665,6 +665,11 @@ namespace sparta{
              * \pre Must have constructed wit ha non-null collected object
              */
             void collectWithDuration(sparta::Clock::Cycle duration) {
+                // If pointer has become nullified, close the record
+                if(nullptr == collected_object_) {
+                    closeRecord();
+                    return;
+                }
                 collectWithDuration(*collected_object_, duration);
             }
 

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -133,7 +133,10 @@ namespace sparta{
                         uint64_t parentid = 0,
                         const std::string & desc = "Collectable <manual, no desc>") :
                 Collectable(parent, name, nullptr, parentid, desc)
-            {}
+            {
+                // Can't auto collect without setting collected_object_
+                setManualCollection();
+            }
 
             //! Virtual destructor -- does nothing
             virtual ~Collectable() {}
@@ -532,7 +535,10 @@ namespace sparta{
                         uint64_t parentid = 0,
                         const std::string & desc = "Collectable <manual, no desc>") :
                 Collectable(parent, name, nullptr, parentid, desc)
-            {}
+            {
+                // Can't auto collect without setting collected_object_
+                setManualCollection();
+            }
 
             //! Virtual destructor -- does nothing
             virtual ~Collectable() {}

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -602,7 +602,7 @@ namespace sparta{
             MetaStruct::enable_if_t<MetaStruct::is_any_pointer<T>::value, void>
             collect(const T & val){
                 // If pointer has become nullified, close the record
-                if(nullptr == collected_object_) {
+                if(nullptr == val) {
                     closeRecord();
                     return;
                 }
@@ -645,7 +645,7 @@ namespace sparta{
             MetaStruct::enable_if_t<MetaStruct::is_any_pointer<T>::value, void>
             collectWithDuration(const T & val, sparta::Clock::Cycle duration){
                 // If pointer has become nullified, close the record
-                if(nullptr == collected_object_) {
+                if(nullptr == val) {
                     closeRecord();
                     return;
                 }

--- a/sparta/sparta/collection/Collectable.hpp
+++ b/sparta/sparta/collection/Collectable.hpp
@@ -580,7 +580,6 @@ namespace sparta{
                 // previous value pairs and the previous record is still open
                 if(!isSameRecord() && !record_closed_)
                 {
-
                     //Close the old record (if there is one)
                     closeRecord();
                 }

--- a/sparta/sparta/collection/DelayedCollectable.hpp
+++ b/sparta/sparta/collection/DelayedCollectable.hpp
@@ -102,7 +102,10 @@ namespace collection
                            uint64_t parentid = 0,
                            const std::string & desc = "DelayedCollectable <manual, no desc>") :
             DelayedCollectable(parent, name, nullptr, parentid, desc)
-        {}
+        {
+            // Can't auto collect without setting iterable_object_
+            Collectable<DataT>::setManualCollection();
+        }
 
         /*!
          * \brief Explicitly collect a value in the future

--- a/sparta/sparta/collection/IterableCollector.hpp
+++ b/sparta/sparta/collection/IterableCollector.hpp
@@ -197,6 +197,13 @@ public:
         }
     }
 
+    //! Schedule event to close all records for this iterable type.
+    void scheduleCloseRecord(sparta::Clock::Cycle cycle) {
+        if(SPARTA_EXPECT_FALSE(isCollected())) {
+            ev_close_record_.preparePayload(false)->schedule(cycle);
+        }
+    }
+
     //! \brief Do not perform any automatic collection
     //! The SchedulingPhase is ignored
     void setManualCollection() {

--- a/sparta/sparta/collection/IterableCollector.hpp
+++ b/sparta/sparta/collection/IterableCollector.hpp
@@ -78,7 +78,7 @@ public:
      * \param group Group this collector is part of
      * \param index the index within the group
      * \param desc Description of this node
-     * \param iterable the iterable object to collect
+     * \param iterable Pointer to the iterable object to collect
      * \param expected_capacity The maximum size this item should grow to
      */
     IterableCollector (TreeNode * parent,
@@ -108,8 +108,28 @@ public:
      * \brief constructor
      * \param parent the parent treenode for the collector
      * \param name the name of the collector
+     * \param group Group this collector is part of
+     * \param index the index within the group
      * \param desc Description of this node
      * \param iterable the iterable object to collect
+     * \param expected_capacity The maximum size this item should grow to
+     */
+    IterableCollector (TreeNode * parent,
+                       const std::string & name,
+                       const std::string & group,
+                       const uint32_t index,
+                       const std::string & desc,
+                       const IterableType & iterable,
+                       const size_type expected_capacity) :
+        IterableCollector(parent, name, group, index, desc, &iterable, expected_capacity)
+    {}
+
+    /**
+     * \brief constructor
+     * \param parent the parent treenode for the collector
+     * \param name the name of the collector
+     * \param desc Description of this node
+     * \param iterable Pointer to the iterable object to collect
      * \param expected_capacity The maximum size this item should grow to
      */
     IterableCollector (TreeNode * parent,
@@ -121,10 +141,26 @@ public:
     {}
 
     /**
+     * \brief constructor
+     * \param parent the parent treenode for the collector
+     * \param name the name of the collector
+     * \param desc Description of this node
+     * \param iterable the iterable object to collect
+     * \param expected_capacity The maximum size this item should grow to
+     */
+    IterableCollector (TreeNode * parent,
+                       const std::string & name,
+                       const std::string & desc,
+                       const IterableType & iterable,
+                       const size_type expected_capacity) :
+        IterableCollector(parent, name, name, 0, desc, &iterable, expected_capacity)
+    {}
+
+    /**
      * \brief constructor with no description
      * \param parent the parent treenode for the collector
      * \param name the name of the collector
-     * \param iterable the iterable object to collect
+     * \param iterable Pointer to the iterable object to collect
      * \param expected_capacity The maximum size this item should grow to
      */
     IterableCollector (TreeNode * parent,
@@ -133,6 +169,23 @@ public:
                        const size_type expected_capacity) :
         IterableCollector (parent, name, name + " Iterable Collector",
                            iterable, expected_capacity)
+    {
+        // Delegated constructor
+    }
+
+    /**
+     * \brief constructor with no description
+     * \param parent the parent treenode for the collector
+     * \param name the name of the collector
+     * \param iterable the iterable object to collect
+     * \param expected_capacity The maximum size this item should grow to
+     */
+    IterableCollector (TreeNode * parent,
+                       const std::string & name,
+                       const IterableType & iterable,
+                       const size_type expected_capacity) :
+        IterableCollector (parent, name, name + " Iterable Collector",
+                           &iterable, expected_capacity)
     {
         // Delegated constructor
     }

--- a/sparta/sparta/resources/Array.hpp
+++ b/sparta/sparta/resources/Array.hpp
@@ -806,12 +806,12 @@ namespace sparta
             collector_.
                 reset(new collection::IterableCollector<FullArrayType,
                                                         SchedulingPhase::Collection, true>
-                      (parent, name_, *this, capacity()));
+                      (parent, name_, this, capacity()));
 
             if(ArrayT == ArrayType::AGED) {
                 age_collector_.reset(new collection::IterableCollector<AgedArrayCollectorProxy>
                                      (parent, name_ + "_age_ordered",
-                                      aged_array_col_, capacity()));
+                                      &aged_array_col_, capacity()));
             }
         }
 

--- a/sparta/sparta/resources/Buffer.hpp
+++ b/sparta/sparta/resources/Buffer.hpp
@@ -721,7 +721,7 @@ namespace sparta
         void enableCollection(TreeNode * parent) {
             collector_.
                 reset(new collection::IterableCollector<Buffer<DataT> >(parent, getName(),
-                                                                        *this, capacity()));
+                                                                        this, capacity()));
         }
 
         /**

--- a/sparta/sparta/resources/CircularBuffer.hpp
+++ b/sparta/sparta/resources/CircularBuffer.hpp
@@ -431,7 +431,7 @@ namespace sparta
         void enableCollection(TreeNode * parent) {
             collector_.
                 reset(new collection::IterableCollector<CircularBuffer<DataT> >(parent, getName(),
-                                                                                *this, capacity()));
+                                                                                this, capacity()));
         }
 
         //! Get this CircularBuffer's name

--- a/sparta/sparta/resources/Pipe.hpp
+++ b/sparta/sparta/resources/Pipe.hpp
@@ -488,7 +488,7 @@ public:
     template<sparta::SchedulingPhase phase = SchedulingPhase::Collection>
     void enableCollection(TreeNode * parent) {
         collector_.reset (new collection::IterableCollector<Pipe<DataT>, phase, true>
-                          (parent, name_, *this, capacity()));
+                          (parent, name_, this, capacity()));
     }
 
 private:

--- a/sparta/sparta/resources/Queue.hpp
+++ b/sparta/sparta/resources/Queue.hpp
@@ -594,7 +594,7 @@ namespace sparta
          */
         void enableCollection(TreeNode * parent) {
             collector_.reset(new collection::IterableCollector<Queue<value_type> >
-                             (parent, name_, *this, capacity()));
+                             (parent, name_, this, capacity()));
         }
 
         /**


### PR DESCRIPTION
Closes #166 

Fixed bug where a collector would throw an exception if it tried to collect a nullptr. Collector will now close the current record if there is one open and not throw.

Also added an additional constructor to `IterableCollector` class so it can be created without an associated collected object and added a method to schedule a "close record" event.