### PR TITLE
Fix for Argos display bug where a transaction would sometimes extend for an extra cycle

### DIFF
--- a/sparta/sparta/collection/PipelineCollector.hpp
+++ b/sparta/sparta/collection/PipelineCollector.hpp
@@ -18,6 +18,7 @@
 #include "sparta/collection/Collector.hpp"
 #include "sparta/events/EventSet.hpp"
 #include "sparta/events/UniqueEvent.hpp"
+#include "sparta/events/GlobalOrderingPoint.hpp"
 #include "sparta/kernel/Scheduler.hpp"
 
 #include "sparta/pipeViewer/Outputter.hpp"
@@ -211,6 +212,17 @@ namespace collection
 
             ev_heartbeat_.setScheduleableClock(root_clk);
             ev_heartbeat_.setScheduler(scheduler_);
+
+            // By default, every event in PostTick is automatically set to precede the CollectionHeartbeat GOP.
+            // We need to reverse that for ev_heartbeat_ so that every other event happens *before* ev_heartbeat_.
+            // Doing this ensures that we don't accidentally mark a 1-cycle transaction as continued.
+            DAG* dag = scheduler_->getDAG(); // Get a handle to the DAG
+            sparta_assert(dag);
+            Vertex* heartbeat_gop = dag->getGOPoint("CollectionHeartbeat"); // Get a handle to the CollectionHeartbeat GOP
+            sparta_assert(heartbeat_gop);
+
+            dag->unlink(ev_heartbeat_.getVertex(), heartbeat_gop); // Undo the ev_heartbeat_ >> heartbeat_gop link
+            heartbeat_gop->precedes(ev_heartbeat_); // Set heartbeat_gop >> ev_heartbeat_
 
             sparta_assert(root != nullptr, "Pipeline Collection will not be able to create location file because it was passed a nullptr root treenode.");
             sparta_assert(root->isFinalized(), "Pipeline collection cannot be constructed until the sparta tree has been finalized.");
@@ -629,7 +641,7 @@ namespace collection
 
         //! Event and EventSet for performing heartbeats
         EventSet collector_events_;
-        UniqueEvent<SchedulingPhase::Collection> ev_heartbeat_;
+        UniqueEvent<SchedulingPhase::PostTick> ev_heartbeat_;
 
         //! The time that the next heartbeat will occur
         uint64_t closing_time_ = 0;

--- a/sparta/sparta/collection/PipelineCollector.hpp
+++ b/sparta/sparta/collection/PipelineCollector.hpp
@@ -213,16 +213,16 @@ namespace collection
             ev_heartbeat_.setScheduleableClock(root_clk);
             ev_heartbeat_.setScheduler(scheduler_);
 
-            // By default, every event in PostTick is automatically set to precede the CollectionHeartbeat GOP.
-            // We need to reverse that for ev_heartbeat_ so that every other event happens *before* ev_heartbeat_.
+            // We need to reverse the dependency order for the PostTick GOP and ev_heartbeat_ so that every other
+            // event happens *before* ev_heartbeat_.
             // Doing this ensures that we don't accidentally mark a 1-cycle transaction as continued.
             DAG* dag = scheduler_->getDAG(); // Get a handle to the DAG
             sparta_assert(dag);
-            Vertex* heartbeat_gop = dag->getGOPoint("CollectionHeartbeat"); // Get a handle to the CollectionHeartbeat GOP
-            sparta_assert(heartbeat_gop);
+            Vertex* post_tick_gop = dag->getGOPoint("PostTick"); // Get a handle to the PostTick GOP
+            sparta_assert(post_tick_gop);
 
-            dag->unlink(ev_heartbeat_.getVertex(), heartbeat_gop); // Undo the ev_heartbeat_ >> heartbeat_gop link
-            heartbeat_gop->precedes(ev_heartbeat_); // Set heartbeat_gop >> ev_heartbeat_
+            dag->unlink(ev_heartbeat_.getVertex(), post_tick_gop); // Undo the ev_heartbeat_ >> heartbeat_gop link
+            post_tick_gop->precedes(ev_heartbeat_); // Set post_tick_gop >> heartbeat_gop
 
             sparta_assert(root != nullptr, "Pipeline Collection will not be able to create location file because it was passed a nullptr root treenode.");
             sparta_assert(root->isFinalized(), "Pipeline collection cannot be constructed until the sparta tree has been finalized.");

--- a/sparta/src/Scheduleable.cpp
+++ b/sparta/src/Scheduleable.cpp
@@ -145,9 +145,6 @@ namespace sparta
         case SchedulingPhase::PostTick:
             dag->link(dag->getGOPoint("Tick"), this->vertex_);
             this->precedes(dag->getGOPoint("PostTick"));
-            // This is a special GOP used to ensure that the pipeline collector heartbeat
-            // happens *after* every other event
-            this->precedes(dag->getGOPoint("CollectionHeartbeat"));
             break;
         case SchedulingPhase::Invalid:
             sparta_assert(!"Should not have gotten here");

--- a/sparta/src/Scheduleable.cpp
+++ b/sparta/src/Scheduleable.cpp
@@ -145,6 +145,9 @@ namespace sparta
         case SchedulingPhase::PostTick:
             dag->link(dag->getGOPoint("Tick"), this->vertex_);
             this->precedes(dag->getGOPoint("PostTick"));
+            // This is a special GOP used to ensure that the pipeline collector heartbeat
+            // happens *after* every other event
+            this->precedes(dag->getGOPoint("CollectionHeartbeat"));
             break;
         case SchedulingPhase::Invalid:
             sparta_assert(!"Should not have gotten here");


### PR DESCRIPTION
This PR fixes an Argos display bug that caused transactions to occasionally extend for an extra cycle if they ended at a heartbeat interval.

### Background
Whenever a heartbeat event occurs, any open transactions are marked as "continuing," which tells Argos that they should be extended past the heartbeat boundary when they are rendered. Transactions are marked closed at collection time whenever the underlying data changes.

### Root Cause
The PipelineCollector heartbeat event is scheduled during the Collection phase without any precedence set, which means it can occur in any order with respect to other events in that phase. The Collection phase is also the default scheduler phase for all pipeline collection events. Any locations that have their collection events scheduled before the heartbeat event wouldn't be affected by this bug, while any locations after the event could be erroneously marked as "continuing" (see images below for an example of how this affects Argos' rendering).

#### Examples of Bug (left) and Fix (right)
![bug](https://user-images.githubusercontent.com/5447668/115632714-ef32a080-a2cd-11eb-9777-bb17435f027c.png) ![fix](https://user-images.githubusercontent.com/5447668/115632729-f8bc0880-a2cd-11eb-881c-4d6613fa6895.png)

### Fix
This fix ensures that *all* pipeline collection occurs before the heartbeat event by moving the heartbeat event to the PostTick phase and adding a Global Ordering Point (GOP) between all other events in PostTick and the heartbeat event. This was necessary because it's possible for collection to happen in any scheduler phase.

![event_diagram](https://user-images.githubusercontent.com/5447668/115635458-5c940080-a2d1-11eb-9213-f1350e74af73.png)