### PR TITLE
Added new stats/counters to the scheduler/output for sys/wall time

### DIFF
--- a/sparta/sparta/kernel/Scheduler.hpp
+++ b/sparta/sparta/kernel/Scheduler.hpp
@@ -1045,14 +1045,26 @@ private:
     StatisticDef nanoseconds_stat_;
 
     //! user runtime of the process, in seconds
-    Counter user_runtime_stat_;
+    StatisticDef user_runtime_stat_;
 
     //! system runtime f the process, in seconds
-    Counter system_runtime_stat_;
+    StatisticDef system_runtime_stat_;
+
+    //! wall clock runtime f the process, in seconds
+    StatisticDef wall_runtime_stat_;
 
     //! Timer used to calculate runtime
     boost::timer::cpu_timer timer_;
 
+    //! User, System, and Wall clock counts
+    uint64_t        user_time_ = 0;
+    ReadOnlyCounter user_time_cnt_;
+
+    uint64_t        system_time_ = 0;
+    ReadOnlyCounter system_time_cnt_;
+
+    uint64_t        wall_time_ = 0;
+    ReadOnlyCounter wall_time_cnt_;
 
 public:
     /**

--- a/sparta/src/Scheduler.cpp
+++ b/sparta/src/Scheduler.cpp
@@ -94,13 +94,23 @@ Scheduler::Scheduler(const std::string& name, GlobalTreeNode* search_scope) :
                       &sset_,
                       "picoseconds/1000.0"),
     user_runtime_stat_(&sset_,
-                       "user_runtime_seconds",
+                       "host_machine_user_runtime_seconds",
                        "Simulation user runtime in seconds as measured on the host machine",
-                       Counter::COUNT_LATEST),
+                       &sset_,
+                       "host_user_time_count_ms/1000.0"),
     system_runtime_stat_(&sset_,
-                         "system_runtime_seconds",
+                         "host_machine_system_runtime_seconds",
                          "Simulation system runtime in seconds as measured on the host machine",
-                         Counter::COUNT_LATEST),
+                         &sset_,
+                         "host_system_time_count_ms/1000.0"),
+    wall_runtime_stat_(&sset_,
+                       "host_machine_wall_runtime_seconds",
+                       "Simulation wall clock runtime in seconds as measured on the host machine",
+                       &sset_,
+                       "host_wall_time_count_ms/1000.0"),
+    user_time_cnt_  (&sset_, "host_user_time_count_ms",   "User scheduler performance (not simulated time)",   Counter::COUNT_NORMAL, &user_time_),
+    system_time_cnt_(&sset_, "host_system_time_count_ms", "System scheduler performance (not simulated time)", Counter::COUNT_NORMAL, &system_time_),
+    wall_time_cnt_  (&sset_, "host_wall_time_count_ms",   "Wall scheduler performance (not simulated time)",   Counter::COUNT_NORMAL, &wall_time_),
     es_uptr_(new EventSet(this))
 #ifdef SYSTEMC_SUPPORT
     , item_scheduled_(this, "item_scheduled", "Broadcasted when something is scheduled", "item_scheduled")
@@ -595,8 +605,11 @@ void Scheduler::run(Tick num_ticks,
     running_ = false;
     if(SPARTA_EXPECT_TRUE(measure_run_time)) {
         timer_.stop();
-        user_runtime_stat_ = (timer_.elapsed().user / 1E9);  // Convert from ns to seconds
-        system_runtime_stat_ = (timer_.elapsed().system / 1E9);  // Convert from ns to seconds
+        const auto elapsed = timer_.elapsed();
+        const double MILLISECOND_CONVERT = 1000000.0;
+        user_time_   = (elapsed.user)   / MILLISECOND_CONVERT;
+        system_time_ = (elapsed.system) / MILLISECOND_CONVERT;
+        wall_time_   = (elapsed.wall)   / MILLISECOND_CONVERT;
     }
 }
 

--- a/sparta/test/Report/test_autopopulate.html.EXPECTED
+++ b/sparta/test/Report/test_autopopulate.html.EXPECTED
@@ -255,17 +255,45 @@ scheduler.stats.picoseconds' style='' >60</td>
 <tr>
 
 <td class='name' title='Simulation user runtime in seconds as measured on the host machine
-scheduler.stats.user_runtime_seconds'>user_runtime_seconds</td>
+(scheduler.stats.host_user_time_count_ms/1000)'>host_machine_user_runtime_seconds</td>
 <td class='value' title='Simulation user runtime in seconds as measured on the host machine
-scheduler.stats.user_runtime_seconds' style='' >&nbsp;0</td>
+(scheduler.stats.host_user_time_count_ms/1000)' style='' >&nbsp;0</td>
 <td class='expression'>Simulation user runtime in seconds as measured on the host machine</td>
 <tr>
 
 <td class='name' title='Simulation system runtime in seconds as measured on the host machine
-scheduler.stats.system_runtime_seconds'>system_runtime_seconds</td>
+(scheduler.stats.host_system_time_count_ms/1000)'>host_machine_system_runtime_seconds</td>
 <td class='value' title='Simulation system runtime in seconds as measured on the host machine
-scheduler.stats.system_runtime_seconds' style='' >&nbsp;0</td>
+(scheduler.stats.host_system_time_count_ms/1000)' style='' >&nbsp;0</td>
 <td class='expression'>Simulation system runtime in seconds as measured on the host machine</td>
+<tr>
+
+<td class='name' title='Simulation wall clock runtime in seconds as measured on the host machine
+(scheduler.stats.host_wall_time_count_ms/1000)'>host_machine_wall_runtime_seconds</td>
+<td class='value' title='Simulation wall clock runtime in seconds as measured on the host machine
+(scheduler.stats.host_wall_time_count_ms/1000)' style='' >&nbsp;0</td>
+<td class='expression'>Simulation wall clock runtime in seconds as measured on the host machine</td>
+<tr>
+
+<td class='name' title='User scheduler performance (not simulated time)
+scheduler.stats.host_user_time_count_ms'>host_user_time_count_ms</td>
+<td class='value' title='User scheduler performance (not simulated time)
+scheduler.stats.host_user_time_count_ms' style='' >&nbsp;0</td>
+<td class='expression'>User scheduler performance (not simulated time)</td>
+<tr>
+
+<td class='name' title='System scheduler performance (not simulated time)
+scheduler.stats.host_system_time_count_ms'>host_system_time_count_ms</td>
+<td class='value' title='System scheduler performance (not simulated time)
+scheduler.stats.host_system_time_count_ms' style='' >&nbsp;0</td>
+<td class='expression'>System scheduler performance (not simulated time)</td>
+<tr>
+
+<td class='name' title='Wall scheduler performance (not simulated time)
+scheduler.stats.host_wall_time_count_ms'>host_wall_time_count_ms</td>
+<td class='value' title='Wall scheduler performance (not simulated time)
+scheduler.stats.host_wall_time_count_ms' style='' >&nbsp;0</td>
+<td class='expression'>Wall scheduler performance (not simulated time)</td>
 </tr>
 </tbody>
 </table><br/></td></tr>

--- a/sparta/test/Report/test_autopopulate.txt.EXPECTED
+++ b/sparta/test/Report/test_autopopulate.txt.EXPECTED
@@ -31,7 +31,11 @@ Report "Report Autopopulation Test" [0,61]
       milliseconds = 6e-08
       microseconds = 6e-05
       nanoseconds = 0.06
-      user_runtime_seconds = 0
-      system_runtime_seconds = 0
+      host_machine_user_runtime_seconds = 0
+      host_machine_system_runtime_seconds = 0
+      host_machine_wall_runtime_seconds = 0
+      host_user_time_count_ms = 0
+      host_system_time_count_ms = 0
+      host_wall_time_count_ms = 0
 
 

--- a/sparta/test/Report/test_autopopulate_from_string.html.EXPECTED
+++ b/sparta/test/Report/test_autopopulate_from_string.html.EXPECTED
@@ -255,17 +255,45 @@ scheduler.stats.picoseconds' style='' >60</td>
 <tr>
 
 <td class='name' title='Simulation user runtime in seconds as measured on the host machine
-scheduler.stats.user_runtime_seconds'>user_runtime_seconds</td>
+(scheduler.stats.host_user_time_count_ms/1000)'>host_machine_user_runtime_seconds</td>
 <td class='value' title='Simulation user runtime in seconds as measured on the host machine
-scheduler.stats.user_runtime_seconds' style='' >&nbsp;0</td>
+(scheduler.stats.host_user_time_count_ms/1000)' style='' >&nbsp;0</td>
 <td class='expression'>Simulation user runtime in seconds as measured on the host machine</td>
 <tr>
 
 <td class='name' title='Simulation system runtime in seconds as measured on the host machine
-scheduler.stats.system_runtime_seconds'>system_runtime_seconds</td>
+(scheduler.stats.host_system_time_count_ms/1000)'>host_machine_system_runtime_seconds</td>
 <td class='value' title='Simulation system runtime in seconds as measured on the host machine
-scheduler.stats.system_runtime_seconds' style='' >&nbsp;0</td>
+(scheduler.stats.host_system_time_count_ms/1000)' style='' >&nbsp;0</td>
 <td class='expression'>Simulation system runtime in seconds as measured on the host machine</td>
+<tr>
+
+<td class='name' title='Simulation wall clock runtime in seconds as measured on the host machine
+(scheduler.stats.host_wall_time_count_ms/1000)'>host_machine_wall_runtime_seconds</td>
+<td class='value' title='Simulation wall clock runtime in seconds as measured on the host machine
+(scheduler.stats.host_wall_time_count_ms/1000)' style='' >&nbsp;0</td>
+<td class='expression'>Simulation wall clock runtime in seconds as measured on the host machine</td>
+<tr>
+
+<td class='name' title='User scheduler performance (not simulated time)
+scheduler.stats.host_user_time_count_ms'>host_user_time_count_ms</td>
+<td class='value' title='User scheduler performance (not simulated time)
+scheduler.stats.host_user_time_count_ms' style='' >&nbsp;0</td>
+<td class='expression'>User scheduler performance (not simulated time)</td>
+<tr>
+
+<td class='name' title='System scheduler performance (not simulated time)
+scheduler.stats.host_system_time_count_ms'>host_system_time_count_ms</td>
+<td class='value' title='System scheduler performance (not simulated time)
+scheduler.stats.host_system_time_count_ms' style='' >&nbsp;0</td>
+<td class='expression'>System scheduler performance (not simulated time)</td>
+<tr>
+
+<td class='name' title='Wall scheduler performance (not simulated time)
+scheduler.stats.host_wall_time_count_ms'>host_wall_time_count_ms</td>
+<td class='value' title='Wall scheduler performance (not simulated time)
+scheduler.stats.host_wall_time_count_ms' style='' >&nbsp;0</td>
+<td class='expression'>Wall scheduler performance (not simulated time)</td>
 </tr>
 </tbody>
 </table><br/></td></tr>


### PR DESCRIPTION
closes #251 

Renamed scheduler.stats:
user_runtime_seconds -> host_machine_user_runtime_seconds
system_runtime_seconds -> host_machine_system_runtime_seconds

Added scheduler.stats:
host_machine_wall_runtime_seconds

Changed simulation output strings:
Simulation Performance: -> Scheduler Tick Rate  (KTPS):
Scheduler Event Rate:   -> Scheduler Event Rate (KEPS):
Simulation Performance: is now a string dump of a typical timer