### PR TITLE
Knutel/issue 253 extension ignored

### DIFF
--- a/sparta/example/CoreModel/CMakeLists.txt
+++ b/sparta/example/CoreModel/CMakeLists.txt
@@ -120,7 +120,9 @@ sparta_named_test(sparta_core_example_context_counter_update_triggers5 sparta_co
 sparta_named_test(sparta_core_example_context_counter_update_triggers6 sparta_core_example -i 710 --report context_counter_update_triggers6.yaml --config-file context_weights.yaml -p top.cpu.core0.params.foo 680)
 sparta_named_test(sparta_core_example_node_config_using_inner_include_yaml sparta_core_example -i 10k --config-file config_with_inner_include.yaml)
 sparta_named_test(sparta_core_example_arch_with_extensions sparta_core_example -i 10k --arch arch_with_extensions.yaml --arch-search-dir . --write-final-config final.yaml)
-sparta_named_test(sparta_core_example_indiv_tree_node_extensions sparta_core_example -i 10k -p top.cpu.core0.lsu.extension.dog.language_ woof --extension-file tree_node_extensions.yaml -p top.cpu.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
+# The old behavior of Sparta allowed extensions to be optional by default.  Now they are an error
+#sparta_named_test(sparta_core_example_indiv_tree_node_extensions sparta_core_example -i 10k -p top.cpu.core0.lsu.extension.dog.language_ woof --extension-file tree_node_extensions.yaml -p top.cpu.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
+sparta_named_test(sparta_core_example_indiv_tree_node_extensions sparta_core_example -i 10k --extension-file tree_node_extensions.yaml -p top.cpu.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
 sparta_named_test(sparta_core_example_sqldb_timeseries sparta_core_example -i 100k --report all_update_triggers.yaml --feature simdb 1 simdb_si_min_blob_size.yaml)
 sparta_named_test(sparta_core_example_sqldb_timeseries_opts1 sparta_core_example -i 100k --report all_update_triggers.yaml --feature simdb 1 simdb_si_opts1.yaml)
 sparta_named_test(sparta_core_example_sqldb_timeseries_opts2 sparta_core_example -i 100k --report all_update_triggers.yaml --feature simdb 1 simdb_si_opts2.yaml)

--- a/sparta/example/CoreModel/extensions_in_arch_file.yaml
+++ b/sparta/example/CoreModel/extensions_in_arch_file.yaml
@@ -1,5 +1,5 @@
-top: {
-    cpu.core0.lsu.extension.triangle: {
-        edges_: 3
-    }
-}
+top:
+  cpu.core0.lsu.extension.triangle:
+    edges_: 3
+  cpu.core0.lsu.extension.triangle:
+    edges_: <OPTIONAL>

--- a/sparta/example/CoreModel/extensions_in_config_file.yaml
+++ b/sparta/example/CoreModel/extensions_in_config_file.yaml
@@ -1,5 +1,5 @@
-top: {
-    cpu.core0.lsu.extension.hexagon: {
+top:
+    cpu.core0.lsu.extension.hexagon:
         edges_: 6
-    }
-}
+    cpu.core0.lsu.extension.hexagon:
+        edges_: <OPTIONAL>

--- a/sparta/example/CoreModel/src/ExampleSimulation.cpp
+++ b/sparta/example/CoreModel/src/ExampleSimulation.cpp
@@ -354,6 +354,11 @@ namespace sparta {
           std::cout << "  Node '" << getLocation()
                     << "' has parameter 'baz' with a value set to "
                     << baz_->read() << std::endl;
+          auto ext = getExtension("baz_ext");
+          if(ext) {
+              std::cout << "That's the ticket: "
+                        << ext->getParameters()->getParameterValueAs<std::string>("ticket_") << std::endl;
+          }
       }
 
   private:

--- a/sparta/example/DynamicModelPipeline/CMakeLists.txt
+++ b/sparta/example/DynamicModelPipeline/CMakeLists.txt
@@ -108,7 +108,9 @@ sparta_named_test(dynamic_model_pipeline_context_counter_update_triggers5 dynami
 sparta_named_test(dynamic_model_pipeline_context_counter_update_triggers6 dynamic_model_pipeline -i 710 --report context_counter_update_triggers6.yaml --config-file context_weights.yaml -p top.core0.params.foo 680)
 sparta_named_test(dynamic_model_pipeline_node_config_using_inner_include_yaml dynamic_model_pipeline -i 10k --config-file config_with_inner_include.yaml)
 sparta_named_test(dynamic_model_pipeline_arch_with_extensions dynamic_model_pipeline -i 10k --arch arch_with_extensions.yaml --arch-search-dir . --write-final-config final.yaml)
-sparta_named_test(dynamic_model_pipeline_indiv_tree_node_extensions dynamic_model_pipeline -i 10k -p top.core0.lsu.extension.dog.language_ woof --extension-file tree_node_extensions.yaml -p top.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
+# Extensions supplied that are not bound are now errors
+#sparta_named_test(dynamic_model_pipeline_indiv_tree_node_extensions dynamic_model_pipeline -i 10k -p top.core0.lsu.extension.dog.language_ woof --extension-file tree_node_extensions.yaml -p top.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
+sparta_named_test(dynamic_model_pipeline_indiv_tree_node_extensions dynamic_model_pipeline -i 10k --extension-file tree_node_extensions.yaml -p top.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
 sparta_named_test(dynamic_model_pipeline_sqldb_timeseries dynamic_model_pipeline -i 100k --report all_update_triggers.yaml --feature simdb 1 simdb_si_min_blob_size.yaml)
 sparta_named_test(dynamic_model_pipeline_sqldb_timeseries_opts1 dynamic_model_pipeline -i 100k --report all_update_triggers.yaml --feature simdb 1 simdb_si_opts1.yaml)
 sparta_named_test(dynamic_model_pipeline_sqldb_timeseries_opts2 dynamic_model_pipeline -i 100k --report all_update_triggers.yaml --feature simdb 1 simdb_si_opts2.yaml)

--- a/sparta/example/DynamicModelPipeline/extensions_in_arch_file.yaml
+++ b/sparta/example/DynamicModelPipeline/extensions_in_arch_file.yaml
@@ -3,3 +3,8 @@ top: {
         edges_: 3
     }
 }
+top: {
+    core0.lsu.extension.triangle: {
+        edges_: <OPTIONAL>
+    }
+}

--- a/sparta/example/DynamicModelPipeline/extensions_in_config_file.yaml
+++ b/sparta/example/DynamicModelPipeline/extensions_in_config_file.yaml
@@ -3,3 +3,8 @@ top: {
         edges_: 6
     }
 }
+top: {
+    core0.lsu.extension.hexagon: {
+        edges_: <OPTIONAL>
+    }
+}

--- a/sparta/example/DynamicModelPipeline/tree_node_extensions.yaml
+++ b/sparta/example/DynamicModelPipeline/tree_node_extensions.yaml
@@ -12,3 +12,9 @@ top: {
         ticket_:   "663"
     }
 }
+
+top: {
+    core0.dispatch.baz_node.extension.baz_ext: {
+        ticket_:   <OPTIONAL>
+    }
+}

--- a/sparta/python/sparta_support/module_sparta.cpp
+++ b/sparta/python/sparta_support/module_sparta.cpp
@@ -1988,7 +1988,7 @@ BOOST_PYTHON_MODULE(sparta)
         // Show information from node.
         .def("showInfo",
              +[](sparta::ParameterTree::Node& node){
-                 return node.recursPrint(std::cout, 0);})
+                 return node.recursePrint(std::cout, 0);})
         // Set this node with a string value.
         .def("setValue",
              +[](sparta::ParameterTree::Node& node, const std::string& val,
@@ -2220,7 +2220,7 @@ BOOST_PYTHON_MODULE(sparta)
         // Pretty print this tree.
         .def("showTree",
              +[](sparta::ParameterTree& ptree){
-                 return ptree.recursPrint(std::cout);})
+                 return ptree.recursePrint(std::cout);})
         // Check if node from path has value.
         .def("hasValue",
              +[](sparta::ParameterTree& p_tree, const std::string& path,

--- a/sparta/sparta/app/ConfigApplicators.hpp
+++ b/sparta/sparta/app/ConfigApplicators.hpp
@@ -329,10 +329,10 @@ public:
                     // Parse the string as YAML and assign it to this node
                     ParameterTree ptree;
                     sparta::ConfigParser::YAML::EventHandler handler("<command line>",
-                                                                   {p},
-                                                                   ptree,
-                                                                   {},
-                                                                   verbose);
+                                                                     {p},
+                                                                     ptree,
+                                                                     {},
+                                                                     verbose);
 
                     // These parameters will be in the unbound list first
                     // and then applied later where it MUST match existing nodes
@@ -680,5 +680,3 @@ typedef std::vector<std::unique_ptr<ConfigApplicator>>   ConfigVec;
 
 } // namespace app
 } // namespace sparta
-
-

--- a/sparta/sparta/app/ConfigApplicators.hpp
+++ b/sparta/sparta/app/ConfigApplicators.hpp
@@ -606,7 +606,7 @@ public:
         sparta::ConfigParser::YAML param_file(filename_, include_paths_);
         param_file.allowMissingNodes(true);
         param_file.consumeParameters(&dummy, verbose);
-        //param_file.getParameterTree().recursPrint(std::cout);
+        //param_file.getParameterTree().recursePrint(std::cout);
         ptree.create(loc_pattern_, false)->appendTree(param_file.getParameterTree().getRoot()); // Apply to existing ptree
     }
 };
@@ -668,7 +668,7 @@ public:
         sparta::ConfigParser::YAML param_file(filename_, include_paths_);
         param_file.allowMissingNodes(true);
         param_file.consumeParameters(&dummy, verbose);
-        //param_file.getParameterTree().recursPrint(std::cout);
+        //param_file.getParameterTree().recursePrint(std::cout);
         ptree.create(loc_pattern_, false)->appendTree(param_file.getParameterTree().getRoot()); // Apply to existing ptree
     }
 };

--- a/sparta/sparta/app/SimulationConfiguration.hpp
+++ b/sparta/sparta/app/SimulationConfiguration.hpp
@@ -621,6 +621,11 @@ public:
     bool show_dag = false;
 
     /*!
+     * Suppress parameter unread _warnings_ not the errors
+     */
+    bool suppress_unread_parameter_warnings = false;
+
+    /*!
      * The default pipeline collection prefix for pipeline collection
      * (-z option).  Empty string means no prefix
      */

--- a/sparta/sparta/report/format/PythonDict.hpp
+++ b/sparta/sparta/report/format/PythonDict.hpp
@@ -86,8 +86,8 @@ protected:
      */
     virtual void writeContentToStream_(std::ostream& out) const override
     {
-        out << "{" ;
-        writeDictContents_(out, report_, 1);
+        out << "report = {" ;
+        writeDictContents_(out, report_);
         out << "}" ;
         out << std::endl;
     }
@@ -98,9 +98,14 @@ protected:
     /*!
      * \brief Write Python Dictionary
      */
-    int writeDictContents_(std::ostream& out, const Report* r, int idx) const
+    void writeDictContents_(std::ostream& out, const Report* r) const
     {
-        out << "\"" << r->getName() << "\"" << ": {" ;
+        std::string leaf_name = r->getName();
+        const auto pos = leaf_name.find_last_of(".");
+        if(pos != std::string::npos) {
+            leaf_name = r->getName().substr(pos+1);
+        }
+        out << "\"" << leaf_name << "\"" << ": {" ;
 
         int elements_=0;
         for (const Report::stat_pair_t& si : r->getStatistics()) {
@@ -109,15 +114,15 @@ protected:
                     out << ", ";
                 }
                 out << "\"" << si.first << "\": " ;
-                    double val = si.second->getValue();
-                    if(isnan(val)){
-                        out << "float('nan')";
-                    }else if(isinf(val)){
-                        out << "float('inf')";
-                    }else{
-                        out << Report::formatNumber(val);
-                    }
-                elements_++;
+                double val = si.second->getValue();
+                if(isnan(val)){
+                    out << "float('nan')";
+                }else if(isinf(val)){
+                    out << "float('inf')";
+                }else{
+                    out << Report::formatNumber(val);
+                }
+                ++elements_;
             }
         }
 
@@ -125,12 +130,11 @@ protected:
             if(elements_ > 0){
                 out << ", ";
             }
-            writeDictContents_(out, &sr, idx);
-            elements_++;
+            writeDictContents_(out, &sr);
+            ++elements_;
         }
 
         out << "}" ;
-        return idx;
     }
 
 };
@@ -144,4 +148,3 @@ inline std::ostream& operator<< (std::ostream& out, PythonDict & f) {
         } // namespace format
     } // namespace report
 } // namespace sparta
-

--- a/sparta/sparta/simulation/ParameterTree.hpp
+++ b/sparta/sparta/simulation/ParameterTree.hpp
@@ -64,7 +64,7 @@ namespace sparta
 
         private:
 
-            Node* parent_;         //!< Parent node
+            Node* parent_ = nullptr; //!< Parent node
             ParameterTree * tree_ = nullptr;  //!< Tree owning this node. Applies to root only
             std::string name_;     //!< Name of this node relative to it's parent
             std::string value_;    //!< Value of this node (if set. See has_value_)
@@ -257,7 +257,7 @@ namespace sparta
              * \brief Increment the read count of this node
              */
             void incrementReadCount() const {
-                read_count_++;
+                ++read_count_;
             }
 
             /*!
@@ -276,6 +276,16 @@ namespace sparta
             const std::string& getValue() const {
                 sparta_assert(hasValue(), "Node \"" << name_ << "\" does not have a value associated with it");
                 incrementReadCount();
+                return value_;
+            }
+
+            /*!
+             * \brief Gets the value of this object as a string
+             * \pre Value must be set for this node. See hasValue
+             * \post Does not increments read count
+             */
+            const std::string& peekValue() const {
+                sparta_assert(hasValue(), "Node \"" << name_ << "\" does not have a value associated with it");
                 return value_;
             }
 
@@ -568,6 +578,15 @@ namespace sparta
                 }
             }
 
+            /**
+             * \brief Release this node and its children from the tree
+             * \return The ChildVector including this node
+             *
+             */
+            std::unique_ptr<Node> release() {
+                return parent_->release_(this);
+            }
+
             /*!
              * \brief Set the string value of a child of this node. Note that this may not affect
              * this node directly because of the way pattern nodes work
@@ -769,7 +788,7 @@ namespace sparta
             void recursAppendTree_(const Node* ot) {
                 // Inherit value. Never invalidate
                 if(ot->hasValue()){
-                    setValue(ot->getValue(), ot->getRequiredCount() > 0, ot->getOrigin());
+                    setValue(ot->peekValue(), ot->getRequiredCount() > 0, ot->getOrigin());
                 }
 
                 for(auto & child : ot->getChildren()){
@@ -777,6 +796,19 @@ namespace sparta
                     Node* c = create(child->getName(), child->getRequiredCount() > 0); // Create if needed
                     c->recursAppendTree_(child);
                 }
+            }
+
+            std::unique_ptr<Node> release_(Node *node) {
+                std::unique_ptr<Node> rtn;
+                auto it = std::find_if(children_.begin(), children_.end(),
+                                       [node] (const auto & child) -> bool {
+                                           return (child.get() == node);
+                                       });
+                if (it != children_.end()) {
+                    rtn = std::move(*it);
+                    children_.erase(it);
+                }
+                return rtn;
             }
         };
 
@@ -1043,7 +1075,7 @@ namespace sparta
         /*!
          * \brief Recursively print
          */
-        void recursPrint(std::ostream& o) const {
+        void recursePrint(std::ostream& o) const {
             root_->recursPrint(o, 0); // Begin with 0 indent
         }
 

--- a/sparta/sparta/simulation/ParameterTree.hpp
+++ b/sparta/sparta/simulation/ParameterTree.hpp
@@ -633,18 +633,8 @@ namespace sparta
             bool isRequired() const {
                 // Start at beginning. Another, later-written node may override
                 // this node if it has the same patch or a matching pattern.
-                if (getOwner()->isRequired(getPath())) {
-                    // The "extension" keyword is reserved. Tree nodes will never
-                    // have that as their name. If our "grandparent" node has the
-                    // name "extension", then this is a tree node extension parameter,
-                    // which are never required to be consumed / queried.
-                    const ParameterTree::Node * n = getParent();
-                    if (n) {
-                        n = n->getParent();
-                        if (n && n->getName() == "extension") {
-                            return false;
-                        }
-                    }
+                if (getOwner()->isRequired(getPath()))
+                {
                     return true;
                 }
                 return false;
@@ -683,17 +673,18 @@ namespace sparta
             /*!
              * \brief Recursively print
              */
-            void recursPrint(std::ostream& o, uint32_t indent=0) const {
+            void recursePrint(std::ostream& o, uint32_t indent=0) const {
                 for(uint32_t i=0; i<indent; ++i){
                     o << " ";
                 }
                 o << name_;
                 if(has_value_){
-                    o << " = \"" << value_ << "\" (read " << read_count_ << ", written " << write_count_ << " origin " << getOrigin() << ")";
+                    o << " = \"" << value_ << "\" (read " << read_count_ << ", written " << write_count_
+                      << ", required " << required_ << ", origin '" << getOrigin() << "')";
                 }
                 o << "\n";
                 for(auto & n : children_){
-                    n->recursPrint(o, indent+2);
+                    n->recursePrint(o, indent+2);
                 }
             }
 
@@ -1076,7 +1067,7 @@ namespace sparta
          * \brief Recursively print
          */
         void recursePrint(std::ostream& o) const {
-            root_->recursPrint(o, 0); // Begin with 0 indent
+            root_->recursePrint(o, 0); // Begin with 0 indent
         }
 
     private:

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -1630,14 +1630,7 @@ bool CommandLineSimulator::parse(int argc,
         const std::string & pattern = std::get<0>(pvalue);
         const std::string & value = std::get<1>(pvalue);
         const bool is_optional = std::get<2>(pvalue);
-        //Individual extensions name/value pairs must be forwarded
-        //to the dedicated ParameterTree for extensions.
-        if (pattern.find(".extension") != std::string::npos) {
-            auto & extensions_ptree = sim_config_.getExtensionsUnboundParameterTree();
-            extensions_ptree.set(pattern, value, !is_optional);
-        } else {
-            sim_config_.processParameter(pattern, value, is_optional);
-        }
+        sim_config_.processParameter(pattern, value, is_optional);
     }
 
     // Interpret debug-dump post-run value
@@ -1966,7 +1959,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
     try{
         if(show_tree_){
             std::cout << "\nPre-processed UnboundParameterTree:" << std::endl;
-            sim_config_.getUnboundParameterTree().recursPrint(std::cout);
+            sim_config_.getUnboundParameterTree().recursePrint(std::cout);
         }
 
         // Construction phases. Typically, these are invoked by a startup script

--- a/sparta/src/ConfigParserYAML.cpp
+++ b/sparta/src/ConfigParserYAML.cpp
@@ -78,7 +78,7 @@ namespace sparta
 
                 seq_params_.addValue(value);
                 //std::cerr << "seq scalar assigned @\"" << pt_node_->getPath() << "\" \"" << sequence_pos_ << "\" <- " << value << std::endl;
-                //ptree_.recursPrint(std::cerr);
+                //ptree_.recursePrint(std::cerr);
 
                 sequence_pos_.back() += 1;
 
@@ -139,7 +139,7 @@ namespace sparta
                             }
                         }
                         //std::cerr << "set " << pt_node_->getPath() << " \"" << last_val_ << "\" <- " << value << std::endl;
-                        //ptree_.recursPrint(std::cerr);
+                        //ptree_.recursePrint(std::cerr);
                     }
                 }
 
@@ -189,7 +189,7 @@ namespace sparta
                         const bool required = true; // Temporary value. Parameters created this way are always required
                         pt_node_->setValue(value, required, markToString_(mark, false));
                         //std::cerr << "setValue " << pt_node_->getPath() << " \"" << last_val_ << "\" <- " << value << std::endl;
-                        //ptree_.recursPrint(std::cerr);
+                        //ptree_.recursePrint(std::cerr);
                     }
                 }
 
@@ -280,7 +280,7 @@ namespace sparta
                     const bool required = true; // Temporary value. Parameters created this way are always required
                     auto npt_node = pt_node_->create(last_val_, required); // Fails if it contains a parent reference
                     //std::cerr << "OnSequenceStart Create \"" << pt_node_->getPath() << "\" \"" << last_val_ << "\"" << std::endl;
-                    //ptree_.recursPrint(std::cerr);
+                    //ptree_.recursePrint(std::cerr);
                     if(!npt_node){
                         std::cerr << "WARNING: Encountered parameter path with parent reference: \"" << pt_node_->getPath()
                                   << "\" + \"" << last_val_ << "\". This node will not be available in the unbound parameter tree."
@@ -348,7 +348,7 @@ namespace sparta
                     const bool required = true; // Temporary value. Parameters created this way are always required
                     pt_node_->setValue(seq_params_.getValue(), required);
                     //std::cerr << "OnSequenceEnd setValue @\"" << pt_node_->getPath() << " \"" << seq_params_.getValue() << "\"" << std::endl;
-                    //ptree_.recursPrint(std::cerr);
+                    //ptree_.recursePrint(std::cerr);
                 }
 
                 // Reached end of nested sequence, pop pt_stack_ tos to get node before sequences started
@@ -542,7 +542,7 @@ namespace sparta
                 ss << values;
                 ptn->setValue(ss.str(), required, markToString_(node.Mark()));
                 //std::cerr << "setValue " << pt_node_->getPath() << " \"" << ss.str() << "\"" << std::endl;
-                //ptree_.recursPrint(std::cerr);
+                //ptree_.recursePrint(std::cerr);
             }else if(pt_node_){
                 std::cerr << "WARNING: Encountered parameter path with parent reference: \"" << pt_node_->getPath()
                           << "\" + \"" << param_path << "\". This node will not be available in the unbound parameter tree."

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -2227,7 +2227,7 @@ void Simulation::checkAllVirtualParamsRead_(const ParameterTree& pt)
                     err_list << "    ERROR: unread unbound parameter: \"" << path << "\" from: \""
                               << node->getOrigin() << "\". value: \"" << node->getValue() << "\". Path exists in tree up to: \""
                               << root_.getSearchScope()->getDeepestMatchingPath(path) << "\"" << std::endl;
-                }else{
+                }else if(!sim_config_->suppress_unread_parameter_warnings) {
                     std::cerr << "    NOTE: unread optional unbound parameter: \"" << path << "\" from: \""
                               << node->getOrigin() << "\". value: \"" << node->getValue() << "\". Path exists in tree up to: \""
                               << root_.getSearchScope()->getDeepestMatchingPath(path) << "\"" << std::endl;

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -761,6 +761,9 @@ void Simulation::finalizeTree()
 
         // Ensure that all unbound parameters have been consumed by ParameterSets or explicitly
         checkAllVirtualParamsRead_(sim_config_->getUnboundParameterTree());
+
+        // Ensure that all unbound extension parameters were consumed
+        checkAllVirtualParamsRead_(sim_config_->getExtensionsUnboundParameterTree());
     }
 
     // Check ports and such

--- a/sparta/src/SimulationConfiguration.cpp
+++ b/sparta/src/SimulationConfiguration.cpp
@@ -292,7 +292,8 @@ namespace app {
         //Now add these tree node extension leaf nodes to the final
         //"extensions_ptree_".
         for (const ParameterTree::Node * node : has_value_nodes) {
-            extensions_ptree_.set(node->getPath(), node->peekValue(), false);
+            extensions_ptree_.set(node->getPath(), node->peekValue(),
+                                  node->getRequiredCount() != 0, node->getOrigin());
         }
     }
 

--- a/sparta/src/TreeNode.cpp
+++ b/sparta/src/TreeNode.cpp
@@ -2706,7 +2706,7 @@ TreeNode::ExtensionsBase * TreeNode::getExtension(const std::string & extension_
             if (extension_node == nullptr) {
                 if (extension_name != "*") {
                     std::ostringstream oss;
-                    ptree.getRoot()->recursPrint(oss);
+                    ptree.getRoot()->recursePrint(oss);
                     const std::string tree_str = oss.str();
                     if (!tree_str.empty() && tree_str != "\n") {
                         std::cerr << "Invalid node path found in arch/config/extensions file YAML. The tree node\n"
@@ -2842,7 +2842,7 @@ TreeNode::ExtensionsBase * TreeNode::getExtension(const std::string & extension_
                     std::cerr << "WARNING: Found a malformed extension: '"
                               << extension_name << "' location: '"
                               << extension_node->getOrigin() << "'\n\t"
-                              << "Expected 'name: value' pairs for the named extension, but found none"
+                              << "Expected 'extension.name: value' pairs for the named extension, but found only name"
                               << std::endl;
                     return nullptr;
                 }

--- a/sparta/src/TreeNode.cpp
+++ b/sparta/src/TreeNode.cpp
@@ -2752,7 +2752,7 @@ TreeNode::ExtensionsBase * TreeNode::getExtension(const std::string & extension_
         {
             // Apply extensions from the virtual extensions tree
             app::SimulationConfiguration * cfg = sim->getSimulationConfiguration();
-            auto extensions_pt  = cfg->getExtensionsUnboundParameterTree();
+            auto & extensions_pt  = cfg->getExtensionsUnboundParameterTree();
             auto extension_node = resolve_extension_node(extensions_pt);
             if (extension_node != nullptr) {
                 extension_node = resolve_named_extension_node(extension_node);

--- a/sparta/test/VirtualParameterTree/VPT_test.cpp
+++ b/sparta/test/VirtualParameterTree/VPT_test.cpp
@@ -47,7 +47,7 @@ int main ()
     //pt"top.foo.biz"] = "0x2";
     //pt["top"]["foo"]["baz"] = "03";
 
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
 
     // Read some values
     EXPECT_EQUAL(pt.get("top.foo.bar"), "1");
@@ -67,14 +67,14 @@ int main ()
     // Test wildcard access
     pt.set("top.foo.*", "2", true, "origin #2");
     std::cout << "A:" << std::endl;
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
     EXPECT_EQUAL(pt.get("top.foo.bar"), "2");
     EXPECT_EQUAL(pt.get("top.foo.bar").getOrigin(), "origin #2");
     EXPECT_EQUAL(pt.get("top.foo.something_else"), "2");
 
     pt.set("top.foo.biz", "3", true);
     std::cout << "B:" << std::endl;
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
     EXPECT_EQUAL(pt.get("top.foo.bar"), "2");
     EXPECT_EQUAL(pt.get("top.foo.biz"), "3");
     EXPECT_EQUAL(pt.get("top.foo.something_else"), "2");
@@ -82,7 +82,7 @@ int main ()
 
     pt.set("top.*.biz", "4", true);
     std::cout << "C:" << std::endl;
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
     EXPECT_EQUAL(pt.get("top.foo.bar"), "2");
     EXPECT_EQUAL(pt.get("top.foo.biz"), "4");
     EXPECT_EQUAL(pt.get("top.foo.something_else"), "2");
@@ -90,7 +90,7 @@ int main ()
 
     pt.set("top.foo+.biz", "5", true);
     std::cout << "D:" << std::endl;
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
     EXPECT_EQUAL(pt.get("top.foo.bar"), "2");
     EXPECT_EQUAL(pt.get("top.foo.biz"), "4");
     EXPECT_EQUAL(pt.get("top.foo.something_else"), "2");
@@ -101,7 +101,7 @@ int main ()
     // For now parent (..) access when setting a parameter, changes NOTHING
     EXPECT_EQUAL(pt.set("top.foo+..", "6", true), false);
     std::cout << "E:" << std::endl;
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
     EXPECT_EQUAL(pt.get("top.foo.bar"), "2");
     EXPECT_EQUAL(pt.get("top.foo.biz"), "4");
     EXPECT_EQUAL(pt.get("top.foo.something_else"), "2");
@@ -128,7 +128,7 @@ int main ()
     std::cout << "Unreads: " << unreads << std::endl;
 
     std::cout << "After all nodes" << std::endl;
-    pt.recursPrint(std::cout);
+    pt.recursePrint(std::cout);
 
     // Test unrequire at the path level
     pt.set("top.foo.bar.fiz.bin1", "blah", true);
@@ -147,7 +147,7 @@ int main ()
     param_file.consumeParameters(&tmp, false); // verbose?
     //ParameterTree ypt = param_file.getParameterTree(); // Copy
     std::cout << "ParameterTree from config file" << std::endl;
-    param_file.getParameterTree().recursPrint(std::cout);
+    param_file.getParameterTree().recursePrint(std::cout);
     EXPECT_EQUAL(param_file.getParameterTree().get("top.foo.bar"), "0x001");
     EXPECT_EQUAL(param_file.getParameterTree().get("top.foo.biz"), "0x2");
     EXPECT_EQUAL(param_file.getParameterTree().get("top.foo.baz"), "03");
@@ -181,7 +181,7 @@ int main ()
     pt4.set("top.biz.buz", "pt4", true);
     pt4 = param_file.getParameterTree();
     std::cout << "After cloning yaml file output tree to pt4" << std::endl;
-    pt4.recursPrint(std::cout);
+    pt4.recursePrint(std::cout);
     EXPECT_THROW(pt4.get("top.biz.buz")); // Cleared as part of pt3 = ...
     EXPECT_EQUAL(pt4.get("top.foo.a.b.c"), "abc_value");
     EXPECT_EQUAL(pt4.get("top.fiz.bin"), "top.fiz.bin");
@@ -195,7 +195,7 @@ int main ()
 
     pt2.clear();
     std::cout << "After clearing pt2" << std::endl;
-    pt2.recursPrint(std::cout);
+    pt2.recursePrint(std::cout);
 
     // Walk to apply to a device tree
 


### PR DESCRIPTION
Changed the behavior of Sparta's extension support -- it's now an error if the extension does not exist in the tree OR is not referenced by the simulator.  Added support for `<OPTIONAL>` on the extensions.  

Fixed an issue where `-c <config>` and `--arch` yaml files would pick up extension changes, but not `-p` in the same order as regular parameters.