### PR TITLE
Added param. to suppress events of stalled stages

### DIFF
--- a/sparta/sparta/resources/Pipeline.hpp
+++ b/sparta/sparta/resources/Pipeline.hpp
@@ -608,8 +608,12 @@ namespace sparta
          * \param stall_stage_id The stage that causes the pipeline stall
          * \param stall_cycles The total number of stall cycles
          * \param crush_bubbles Allow stages before the stall point to move forward into empty slots
+         * \param suppress_event Suppress events of stages before the stall point
          */
-        void stall(const uint32_t & stall_stage_id, const uint32_t & stall_cycles, const bool crush_bubbles=false)
+        void stall(const uint32_t & stall_stage_id,
+                   const uint32_t & stall_cycles,
+                   const bool crush_bubbles=false,
+                   const bool suppress_events=true)
         {
             sparta_assert(pipe_.isValid(stall_stage_id), "Try to stall an empty pipeline stage!");
             sparta_assert(!isStalledOrStalling(), "Try to stall a pipeline that is stalling or already stalled!");
@@ -620,7 +624,7 @@ namespace sparta
 
             stall_cycles_ = stall_cycles;
             stall_stage_id_ = stall_stage_id;
-            deactivate_(stall_stage_id_, crush_bubbles);
+            deactivate_(stall_stage_id_, crush_bubbles, suppress_events);
         }
 
         /*!
@@ -920,7 +924,9 @@ namespace sparta
         }
 
         //! Deactivate the pipeline stage handling events up to the stall causing stage
-        void deactivate_(const uint32_t & stall_stage_id, bool crush_bubbles)
+        void deactivate_(const uint32_t & stall_stage_id,
+                         const bool crush_bubbles,
+                         const bool suppress_events)
         {
             sparta_assert(stall_stage_id < num_stages_,
                         "Try to deactivate events for invalid pipeline stage[" << stall_stage_id << "]");
@@ -931,7 +937,7 @@ namespace sparta
                     return; // bubble, crush it by allowing earlier stages to advance
                 }
 
-                if (event_list_at_stage_[stage_id].size() > 0) {
+                if (suppress_events && event_list_at_stage_[stage_id].size() > 0) {
                     events_valid_at_stage_[stage_id] = false;
                 }
                 advance_into_stage_[stage_id] = false;

--- a/sparta/test/Pipeline/Pipeline_test.cpp
+++ b/sparta/test/Pipeline/Pipeline_test.cpp
@@ -1233,6 +1233,71 @@ int main ()
     EXPECT_TRUE (examplePipeline5.isValid(3));
     EXPECT_TRUE (examplePipeline5.isValid(4));
 
+    // allow pipeline to drain
+    offset = cyc_cnt + 1;
+    while (cyc_cnt < examplePipeline5.capacity() + offset) {
+        std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+        runCycle(examplePipeline5, &sched);
+    }
+    EXPECT_EQUAL(examplePipeline5.numValid(), 0);
+
+    std::cout << "Pipeline Stall without suppressing events of stalled stages Test\n";
+
+    std::cout << "Append pipeline with data[=1000]\n";
+    EXPECT_NOTHROW(examplePipeline5.append(1000));
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(examplePipeline5.isValid(0));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 1);
+
+    std::cout << "Append pipeline with data[=2000]\n";
+    EXPECT_NOTHROW(examplePipeline5.append(2000));
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(examplePipeline5.isValid(0));
+    EXPECT_TRUE(examplePipeline5.isValid(1));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 2);
+
+    // bubble
+    std::cout << "Insert bubble\n";
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(!examplePipeline5.isValid(0));
+    EXPECT_TRUE(examplePipeline5.isValid(1));
+    EXPECT_TRUE(examplePipeline5.isValid(2));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 2);
+
+    std::cout << "Stall stage[2] for 3 cycles (don't suppress events)\n";
+    EXPECT_NOTHROW(examplePipeline5.stall(2, 3, true, false));
+
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(!examplePipeline5.isValid(0));
+    EXPECT_TRUE(examplePipeline5.isValid(1));
+    EXPECT_TRUE(examplePipeline5.isValid(2));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 2);
+
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(!examplePipeline5.isValid(0));
+    EXPECT_TRUE(examplePipeline5.isValid(1));
+    EXPECT_TRUE(examplePipeline5.isValid(2));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 2);
+
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(!examplePipeline5.isValid(0));
+    EXPECT_TRUE(examplePipeline5.isValid(1));
+    EXPECT_TRUE(examplePipeline5.isValid(2));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 2);
+
+    // Move forward
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline5, &sched);
+    EXPECT_TRUE(!examplePipeline5.isValid(1));
+    EXPECT_TRUE(examplePipeline5.isValid(2));
+    EXPECT_TRUE(examplePipeline5.isValid(3));
+    EXPECT_EQUAL(examplePipeline5.numValid(), 2);
 
 #ifndef TEST_MANUAL_UPDATE
     stwr_pipe.performOwnUpdates();


### PR DESCRIPTION
Literally, "stall" should just represent pipeline stage forwarding stops. Data are still kept in those stalled stages. In some scenarios, modelers may still want registered events to be triggered to handle data.