### PR TITLE
Added support on Pipeline to trigger payload event

### DIFF
--- a/sparta/sparta/resources/Pipeline.hpp
+++ b/sparta/sparta/resources/Pipeline.hpp
@@ -251,8 +251,8 @@ namespace sparta
             // 1. PhasedUniqueEvent
             // 2. PhasedPayloadEvent<DataT>
             static_assert(std::is_same_v<EventT, PhasedUniqueEvent> || std::is_same_v<EventT, PhasedPayloadEvent<DataT>>,
-                          "Pipeline is templated a unsupported Event type. "
-                          "Supported Event types: {PhasedUniqueEvent, PhasedPayloaodEvent<DataT>}");
+                          "Error: Pipeline is templated on a unsupported Event type. Supported Event types: "
+                          "UniqueEvent, PayloaodEvent (where DataT == DataT of the Pipeline).");
             events_valid_at_stage_.resize(num_stages, false);
             advance_into_stage_.resize(num_stages, true);
 

--- a/sparta/sparta/resources/Pipeline.hpp
+++ b/sparta/sparta/resources/Pipeline.hpp
@@ -289,10 +289,10 @@ namespace sparta
         void registerHandlerAtStage(const uint32_t & id, const SpartaHandler & handler)
         {
             sparta_assert(static_cast<uint32_t>(default_precedence_) == static_cast<uint32_t>(Precedence::NONE),
-                        "You have specified a default precedence (" << static_cast<uint32_t>(default_precedence_)
+                          "You have specified a default precedence (" << static_cast<uint32_t>(default_precedence_)
                           << ") between stages. No new handlers can be registered any more!");
             sparta_assert(id < event_list_at_stage_.size(),
-                        "Attempt to register handler for invalid pipeline stage[" << id << "]!");
+                          "Attempt to register handler for invalid pipeline stage[" << id << "]!");
 
             // Create a new stage event handler, and add it to its event list
             auto & event_list = event_list_at_stage_[id];
@@ -350,13 +350,13 @@ namespace sparta
         void setPrecedenceBetweenStage(const uint32_t & pid, const uint32_t & cid)
         {
             sparta_assert(static_cast<uint32_t>(default_precedence_) == static_cast<uint32_t>(Precedence::NONE),
-                        "You have specified a default precedence (" << static_cast<uint32_t>(default_precedence_)
-                        << "). No more precedence between stages can be set!");
+                          "You have specified a default precedence (" << static_cast<uint32_t>(default_precedence_)
+                          << "). No more precedence between stages can be set!");
             sparta_assert(pid != cid, "Cannot specify precedence with yourself!");
             sparta_assert((pid < event_list_at_stage_.size()) && (event_list_at_stage_[pid].size() > 0),
-                        "Precedence setup fails: No handler for pipeline stage[" << pid << "]!");
+                          "Precedence setup fails: No handler for pipeline stage[" << pid << "]!");
             sparta_assert((cid < event_list_at_stage_.size()) && (event_list_at_stage_[cid].size() > 0),
-                        "Precedence setup fails: No handler for pipeline stage[" << cid << "]!");
+                          "Precedence setup fails: No handler for pipeline stage[" << cid << "]!");
 
             for (uint32_t phase_id = 0; phase_id < NUM_SCHEDULING_PHASES; phase_id++) {
                 auto & pstage_event_list = event_matrix_at_stage_[pid][phase_id];
@@ -388,11 +388,11 @@ namespace sparta
         void setPrecedenceBetweenPipeline(const uint32_t & pid, Pipeline<DataT2> & c_pipeline, const uint32_t & cid)
         {
             sparta_assert(static_cast<void*>(&c_pipeline) != static_cast<void*>(this),
-                        "Cannot use this function to set precedence between stages within the same pipeline instance!");
+                          "Cannot use this function to set precedence between stages within the same pipeline instance!");
             sparta_assert((pid < event_list_at_stage_.size()) && (event_list_at_stage_[pid].size() > 0),
-                        "Precedence setup fails: No handler for pipeline stage[" << pid << "]!");
+                          "Precedence setup fails: No handler for pipeline stage[" << pid << "]!");
             sparta_assert((cid < c_pipeline.event_list_at_stage_.size()) && (c_pipeline.event_list_at_stage_[cid].size() > 0),
-                        "Precedence setup fails: No handler for pipeline stage[" << cid << "]!");
+                          "Precedence setup fails: No handler for pipeline stage[" << cid << "]!");
 
             for (uint32_t phase_id = 0; phase_id < NUM_SCHEDULING_PHASES; phase_id++) {
                 auto & pstage_event_list = event_matrix_at_stage_[pid][phase_id];
@@ -421,7 +421,7 @@ namespace sparta
         void setDefaultStagePrecedence(const Precedence & default_precedence)
         {
             sparta_assert(static_cast<uint32_t>(default_precedence) < static_cast<uint32_t>(Precedence::NUM_OF_PRECEDENCE),
-                        "Unknown default precedence is specified for sparta::Pipeline!");
+                          "Unknown default precedence is specified for sparta::Pipeline!");
 
             if (static_cast<uint32_t>(default_precedence) == static_cast<uint32_t>(Precedence::NONE)) {
                 return;
@@ -498,13 +498,13 @@ namespace sparta
         void setProducerForStage(const uint32_t & id, EventType & ev_handler)
         {
             sparta_assert((id < event_list_at_stage_.size()) && (event_list_at_stage_[id].size() > 0),
-                        "Precedence setup fails: No handler for pipeline stage[" << id << "]!");
+                          "Precedence setup fails: No handler for pipeline stage[" << id << "]!");
 
             auto phase_id = static_cast<uint32_t>(ev_handler.getScheduleable().getSchedulingPhase());
             auto & event_list = event_matrix_at_stage_[id][phase_id];
 
             sparta_assert(!event_list.empty(),
-                        "Cannot set producer event for pipeline stage[" << id << "]. No registered stage event on the SAME phase!");
+                          "Cannot set producer event for pipeline stage[" << id << "]. No registered stage event on the SAME phase!");
             if constexpr (std::is_same_v<EventT, PhasedPayloadEvent<DataT>>) {
                 ev_handler.getScheduleable().precedes((event_list.front())->getScheduleable());
             } else {
@@ -522,14 +522,14 @@ namespace sparta
         void setConsumerForStage(const uint32_t & id, EventType & ev_handler)
         {
             sparta_assert((id < event_list_at_stage_.size()) && (event_list_at_stage_[id].size() > 0),
-                        "Precedence setup fails: No handler for pipeline stage[" << id << "]!");
+                          "Precedence setup fails: No handler for pipeline stage[" << id << "]!");
 
             auto phase_id = static_cast<uint32_t>(ev_handler.getScheduleable().getSchedulingPhase());
             auto & event_list = event_matrix_at_stage_[id][phase_id];
 
             sparta_assert(!event_list.empty(),
-                        "Cannot set consumer event for pipeline stage[" << id
-                        << "]. No registered stage event on the SAME phase!");
+                          "Cannot set consumer event for pipeline stage[" << id
+                          << "]. No registered stage event on the SAME phase!");
             if constexpr (std::is_same_v<EventT, PhasedPayloadEvent<DataT>>) {
                 (event_list.back())->getScheduleable().precedes(ev_handler.getScheduleable());
             } else {
@@ -547,12 +547,12 @@ namespace sparta
                                      const SchedulingPhase phase = SchedulingPhase::Tick)
         {
             sparta_assert(id < event_matrix_at_stage_.size(),
-                        "Attempt to get events at an invalid pipeline stage["
-                        << id << "]!");
+                          "Attempt to get events at an invalid pipeline stage["
+                          << id << "]!");
             using SchedUType = std::underlying_type<SchedulingPhase>::type;
             auto & event_list = event_matrix_at_stage_[id][static_cast<SchedUType>(phase)];
             sparta_assert(!event_list.empty(),
-                        "No registered events at stage[" << id << "]!");
+                          "No registered events at stage[" << id << "]!");
             return event_list;
         }
 
@@ -568,7 +568,7 @@ namespace sparta
          */
         bool isEventRegisteredAtStage(const uint32_t & id) const {
             sparta_assert(id < event_list_at_stage_.size(),
-                        "Attempt to check event handler for invalid pipeline stage[" << id << "]!");
+                          "Attempt to check event handler for invalid pipeline stage[" << id << "]!");
 
             return (event_list_at_stage_[id].size() > 0);
         }
@@ -585,9 +585,9 @@ namespace sparta
         void activateEventAtStage(const uint32_t & id)
         {
             sparta_assert(id < event_list_at_stage_.size(),
-                        "Attempt to activate event handler for invalid pipeline stage[" << id << "]!");
+                          "Attempt to activate event handler for invalid pipeline stage[" << id << "]!");
             sparta_assert((event_list_at_stage_[id].size() > 0),
-                        "Activation fails: No registered event handler for stage[" << id << "]!");
+                          "Activation fails: No registered event handler for stage[" << id << "]!");
 
             events_valid_at_stage_[id] = true;
         }
@@ -603,9 +603,9 @@ namespace sparta
         void deactivateEventAtStage(const uint32_t & id)
         {
             sparta_assert(id < event_list_at_stage_.size(),
-                        "Attempt to deactivate event handler for invalid pipeline stage[" << id << "]!");
+                          "Attempt to deactivate event handler for invalid pipeline stage[" << id << "]!");
             sparta_assert((event_list_at_stage_[id].size() > 0),
-                        "Deactivation fails: No registered event handler for stage[" << id << "]!");
+                          "Deactivation fails: No registered event handler for stage[" << id << "]!");
 
             events_valid_at_stage_[id] = false;
         }
@@ -964,7 +964,7 @@ namespace sparta
         void cancelEventsAtStage_(const uint32_t & stage_id)
         {
             sparta_assert(stage_id < num_stages_,
-                        "Try to cancel events for invalid pipeline stage[" << stage_id << "]");
+                          "Try to cancel events for invalid pipeline stage[" << stage_id << "]");
             if (pipe_.isValid(stage_id) && events_valid_at_stage_[stage_id]) {
                 sparta_assert(event_list_at_stage_[stage_id].size());
                 for (const auto & ev_ptr :  event_list_at_stage_[stage_id]) {
@@ -998,7 +998,7 @@ namespace sparta
                          const bool suppress_events)
         {
             sparta_assert(stall_stage_id < num_stages_,
-                        "Try to deactivate events for invalid pipeline stage[" << stall_stage_id << "]");
+                          "Try to deactivate events for invalid pipeline stage[" << stall_stage_id << "]");
 
             for (int32_t stage_id = stall_stage_id; stage_id >= 0; stage_id--) {
 
@@ -1018,7 +1018,7 @@ namespace sparta
         {
             for (uint32_t stage_id = 0; stage_id <= stall_stage_id; stage_id++) {
                 sparta_assert(stage_id < num_stages_,
-                            "Try to restart invalid pipeline stage[" << stage_id << "]");
+                              "Try to restart invalid pipeline stage[" << stage_id << "]");
                 if (event_list_at_stage_[stage_id].size() > 0) {
                     events_valid_at_stage_[stage_id] = true;
                 }

--- a/sparta/test/Pipeline/Pipeline_test.cpp
+++ b/sparta/test/Pipeline/Pipeline_test.cpp
@@ -1609,6 +1609,8 @@ int main ()
     EXPECT_TRUE(examplePipeline8.isValid(1));
     EXPECT_TRUE(examplePipeline8.isValid(2));
 
+    std::cout << "[FINISH] Pipeline Data Event Handling Test\n";
+
     rtn.enterTeardown();
 
 #ifdef PIPEOUT_GEN

--- a/sparta/test/Pipeline/Pipeline_test.cpp
+++ b/sparta/test/Pipeline/Pipeline_test.cpp
@@ -61,6 +61,10 @@ public:
     void stage4_F_Handle0(void) { std::cout << "  Stage[4]: handler(Flush)\n"; }
     void stage4_T_Handle0(void) { std::cout << "  Stage[4]: handler0(Tick)\n"; }
 
+    void stage0_T_DataHandle(const uint64_t & dat) { std::cout << "  Stage[0]: handle data: " << dat << std::endl; }
+    void stage1_T_DataHandle(const uint64_t & dat) { std::cout << "  Stage[1]: handle data: " << dat << std::endl; }
+    void stage2_T_DataHandle(const uint64_t & dat) { std::cout << "  Stage[2]: handle data: " << dat << std::endl; }
+
     void task0(void) { std::cout << "  Stage[3]: producer(Tick)\n"; }
     void task1(void) { std::cout << "  Stage[0]: producer(PortUpdate)\n"; }
     template<typename DataT>
@@ -288,6 +292,8 @@ int main ()
 
     sparta::Pipeline<uint64_t> examplePipeline7("mySeventhSpartaPipeline", 2, root_clk.get());
 
+    sparta::Pipeline<uint64_t, sparta::PhasedPayloadEvent<uint64_t>> examplePipeline8(&es, "myEighthSpartaPipeline", 3, root_clk.get());
+
     sparta::Pipeline<bool> stwr_pipe("STWR_Pipe", 5, root_clk.get());
 
     DummyClass2<uint64_t> dummyObj2(&examplePipeline6);
@@ -311,6 +317,7 @@ int main ()
     examplePipeline5.enableCollection<sparta::SchedulingPhase::Collection>(&rtn);
     examplePipeline6.enableCollection<sparta::SchedulingPhase::Collection>(&rtn);
     examplePipeline7.enableCollection<sparta::SchedulingPhase::Collection>(&rtn);
+    examplePipeline8.enableCollection<sparta::SchedulingPhase::Collection>(&rtn);
     stwr_pipe.enableCollection<sparta::SchedulingPhase::Collection>(&rtn);
 #endif
 
@@ -499,6 +506,28 @@ int main ()
         examplePipeline6.registerHandlerAtStage<sparta::SchedulingPhase::Tick>
             (4, CREATE_SPARTA_HANDLER_WITH_OBJ(DummyClass, &dummyObj1, stage4_T_Handle0)));
 
+    /*
+     * examplePipeline8: Precedence Chain Setup per Stage
+     * stage[0]: handler (Tick)
+     * stage[1]: handler (Tick)
+     * stage[2]: handler (Tick)
+     */
+
+
+    // examplePipeline8 Stage[0] handler: Tick phase
+    EXPECT_NOTHROW(
+        examplePipeline8.registerHandlerAtStage<sparta::SchedulingPhase::Tick>
+            (0, CREATE_SPARTA_HANDLER_WITH_DATA_WITH_OBJ(DummyClass, &dummyObj1, stage0_T_DataHandle, uint64_t)));
+
+    // examplePipeline8 Stage[1] handler: Tick phase
+    EXPECT_NOTHROW(
+        examplePipeline8.registerHandlerAtStage<sparta::SchedulingPhase::Tick>
+            (1, CREATE_SPARTA_HANDLER_WITH_DATA_WITH_OBJ(DummyClass, &dummyObj1, stage1_T_DataHandle, uint64_t)));
+
+    // examplePipeline8 Stage[2] handler: Tick phase
+    EXPECT_NOTHROW(
+        examplePipeline8.registerHandlerAtStage<sparta::SchedulingPhase::Tick>
+            (2, CREATE_SPARTA_HANDLER_WITH_DATA_WITH_OBJ(DummyClass, &dummyObj1, stage2_T_DataHandle, uint64_t)));
 
     rtn.enterConfiguring();
     rtn.enterFinalized();
@@ -1528,8 +1557,57 @@ int main ()
     ev_task5_update.schedule();
     sched.run(1, true);
 
+    // allow pipeline to drain
+    offset = cyc_cnt + 1;
+    while (cyc_cnt < examplePipeline1.capacity() + offset) {
+        std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+        sched.run(1, true);
+    }
+    EXPECT_EQUAL(examplePipeline1.numValid(), 0);
+
     std::cout << "[FINISH] Pipeline UpdateEvent Test" << std::endl;
 
+    ////////////////////////////////////////////////////////////////////////////////
+    // Pipeline Data Event Handling Test
+    ////////////////////////////////////////////////////////////////////////////////
+
+    std::cout << "\n[START] Pipeline Data Event Handling Test\n";
+
+#ifndef TEST_MANUAL_UPDATE
+    examplePipeline8.performOwnUpdates();
+#endif
+
+    cyc_cnt = 0;
+
+
+    std::cout << "Append pipeline with data[=1000]\n";
+    EXPECT_NOTHROW(examplePipeline8.append(1000));
+
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline8, &sched);
+    EXPECT_EQUAL(examplePipeline8.numValid(), 1);
+    EXPECT_TRUE(examplePipeline8.isValid(0));
+
+
+    std::cout << "Append pipeline with data[=2000]\n";
+    EXPECT_NOTHROW(examplePipeline8.append(2000));
+
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline8, &sched);
+    EXPECT_EQUAL(examplePipeline8.numValid(), 2);
+    EXPECT_TRUE(examplePipeline8.isValid(0));
+    EXPECT_TRUE(examplePipeline8.isValid(1));
+
+
+    std::cout << "Append pipeline with data[=3000]\n";
+    EXPECT_NOTHROW(examplePipeline8.append(3000));
+
+    std::cout << "Cycle[" << cyc_cnt++ << "]:\n";
+    runCycle(examplePipeline8, &sched);
+    EXPECT_EQUAL(examplePipeline8.numValid(), 3);
+    EXPECT_TRUE(examplePipeline8.isValid(0));
+    EXPECT_TRUE(examplePipeline8.isValid(1));
+    EXPECT_TRUE(examplePipeline8.isValid(2));
 
     rtn.enterTeardown();
 


### PR DESCRIPTION
Added a new template parameter of Pipeline, EventT, to enhance Pipeline event system.

Copying the description from codes:
> Template parameter DataT specifies the type of data flowing through pipeline stages, and
EventT can be specified by 2 Event types: PhasedUniqueEvent (default) and PhasedPayloadEvent<DataT>.
The difference between both types is related to what kind of SpartaHandler modelers are going
to register at stages. With default PhasedUniqueEvent, you can regsiter a SpartaHandler
with no data; or, with PhasedPayloadEvent<DataT>, you can register a SpartaHandler with
data of type DataT. Pipeline will prepare payload and pass data of the stage to every handler.

I was surprised that the Pipeline implementation had been using EventSet pointed to NULL.

However, PayloadEvent needs an available EventSet. So I added a new parameter in constructor to set it up.

Also a dummy EventSet variable is added to keep the backward compatibility, making codes a little tricky ...