### PR TITLE
OS X Big Sur Argos Build Fix

### DIFF
--- a/helios/pipeViewer/CMakeLists.txt
+++ b/helios/pipeViewer/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SETUP_PY "${CMAKE_CURRENT_SOURCE_DIR}/pipe_view/core/setup.py")
 set(PY_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/build/core.so.built")
 
 add_custom_command(OUTPUT "${PY_OUTPUT}"
-		   COMMAND TARGETDIR=${CMAKE_CURRENT_SOURCE_DIR}/pipe_view/core ${PYTHON} ${SETUP_PY} build_ext --inplace
+		   COMMAND ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} LD=${CMAKE_LINKER} TARGETDIR=${CMAKE_CURRENT_SOURCE_DIR}/pipe_view/core ${PYTHON} ${SETUP_PY} build_ext --inplace
                    COMMAND ${CMAKE_COMMAND} -E touch ${PY_OUTPUT}
                    DEPENDS ${SETUP_PY} "${CMAKE_CURRENT_SOURCE_DIR}/pipe_view/core/src/core.pyx"
                    )

--- a/helios/pipeViewer/README.md
+++ b/helios/pipeViewer/README.md
@@ -19,6 +19,7 @@
    * `conda activate sparta`
    * `cd $(git rev-parse --show-toplevel); mkdir release; cd release`
    * `cmake -DCMAKE_BUILD_TYPE=Release ..`
+     * If you're running newer versions of OS X and get compile errors, try using `CC=/usr/bin/clang CXX=/usr/bin/clang++ LD=/usr/bin/ld cmake -DCMAKE_BUILD_TYPE=Release ..` instead
    * `make`
 
 ## Example of Usage

--- a/helios/pipeViewer/pipe_view/core/setup.py
+++ b/helios/pipeViewer/pipe_view/core/setup.py
@@ -36,9 +36,6 @@ destination_dir = os.environ["TARGETDIR"]
 extension = os.environ.get("BUILD", '') # Required from caller for choosing an extension to build
 
 system_include_dirs = []
-# cython likes to do things like #include "string", so this fixes that
-if "clang" in os.environ.get("CC",""):
-    system_include_dirs.append(os.path.join(os.path.dirname(os.path.dirname(distutils.spawn.find_executable(os.environ["CC"]))), "include", "c++", "v1"))
 
 py_src_dir = Path(__file__).parent.resolve() / 'src'
 

--- a/helios/pipeViewer/transactiondb/CMakeLists.txt
+++ b/helios/pipeViewer/transactiondb/CMakeLists.txt
@@ -25,6 +25,9 @@ add_custom_command(OUTPUT transactiondb.sh
   REQUIRED_SPARTA_LIBS="sparta"
   LIB_SPARTA_BUILT_PATH="${MAP_BINARY_DIR}/sparta"
   CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+  CC="${CMAKE_C_COMPILER}"
+  CXX="${CMAKE_CXX_COMPILER}"
+  LD="${CMAKE_LINKER}"
   python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py build_ext --inplace;' > transactiondb.sh && chmod +x transactiondb.sh
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
 

--- a/helios/pipeViewer/transactiondb/setup.py
+++ b/helios/pipeViewer/transactiondb/setup.py
@@ -35,10 +35,6 @@ if 'TARGETDIR' not in os.environ:
 destination_dir = os.environ["TARGETDIR"]
 system_include_dirs = [a.strip('\\') for a in os.environ.get("SYSINCDIRS", None).split()]
 
-# cython likes to do things like #include "string", so this fixes that
-if "clang" in os.environ.get("CC",""):
-    system_include_dirs.append(join(dirname(dirname(spawn.find_executable(os.environ["CC"]))), "include", "c++", "v1"))
-
 sparta_base_dir = os.environ["SPARTA_BASE"]
 required_sparta_libs = os.environ['REQUIRED_SPARTA_LIBS'].split()
 required_sparta_libs = [x.lstrip('-l') for x in required_sparta_libs]


### PR DESCRIPTION
The latest version of XCode available in OS X Big Sur has some incompatibilities when building the Argos extensions against the Conda libcxx library.