### PR TITLE
Knutel/issue 273 tn missing alias

### DIFF
--- a/sparta/sparta/simulation/TreeNode.hpp
+++ b/sparta/sparta/simulation/TreeNode.hpp
@@ -253,7 +253,7 @@ namespace sparta
          * an ordered container (e.g. std::map) is required. A sorted contained
          * is probably desirable, but not required
          */
-        typedef std::map<std::string, TreeNode*> ChildNameMapping;
+        typedef std::multimap<std::string, TreeNode*> ChildNameMapping;
 
         /*!
          * \brief Index within a group
@@ -1505,7 +1505,7 @@ namespace sparta
         /*!
          * \brief Retrieves a child with this dotted path name
          * \note this is not a full recursive search. The child, if found, will
-         * be N levels below this node whrere N Is dependent on the number of
+         * be N levels below this node where N Is dependent on the number of
          * '.' tokens in the search string.
          * \param name path to child. This may be a single name or a dotted path
          * refering to a node several levels below this node.
@@ -1516,6 +1516,8 @@ namespace sparta
          * be found and must_exist==true, throws SpartaException. Otherwise
          * returns nullptr.
          * \note no pattern matching supported in this method
+         * \note if a name matches on both an alias and a TreeNode name,
+         * the TreeNode name will take precedence
          * \throw SpartaException if child is not found and must_exist==true
          *
          * Example:

--- a/sparta/sparta/statistics/CycleHistogram.hpp
+++ b/sparta/sparta/statistics/CycleHistogram.hpp
@@ -365,7 +365,8 @@ namespace sparta
             std::string weighted_total_str = "( " + std::to_string(lower_val_) + " * " + underflow_bin_->getName() + " )";
             std::string weighted_total_nonzero_str;
             std::string count0_statistic_str;
-            for (uint64_t i = 0; i < num_bins_; ++i) {
+            for (uint64_t i = 0; i < num_bins_; ++i)
+            {
                 if (end_val > upper_val_) {
                     end_val = upper_val_;
                 }
@@ -423,11 +424,11 @@ namespace sparta
                 }
 
                 bin_.emplace_back(sparta::CycleCounter(sset,
-                                                     str.str(),
-                                                     name.empty() ? std::string("cycle_count") : name, i,
-                                                     description + " histogram bin",
-                                                     sparta::Counter::COUNT_NORMAL,
-                                                     clk, visibility));
+                                                       str.str(),
+                                                       name.empty() ? std::string("cycle_count") : name, i,
+                                                       description + " histogram bin",
+                                                       sparta::Counter::COUNT_NORMAL,
+                                                       clk, visibility));
                 probabilities_.emplace_back(new StatisticDef(sset,
                                                              str.str() + "_probability",
                                                              str.str() + " bin probability",

--- a/sparta/src/TreeNode.cpp
+++ b/sparta/src/TreeNode.cpp
@@ -965,8 +965,8 @@ uint32_t TreeNode::findImmediateChildren_(std::regex& expr,
                                           std::vector<std::vector<std::string>>& replacements,
                                           bool allow_private) {
     uint32_t num_found = 0;
-    for(ChildNameMapping::reference chp : names_){
-
+    for(ChildNameMapping::reference chp : names_)
+    {
         std::vector<std::string> replaced; // Replacements per name
         if(identityMatchesPattern_(chp.first, expr, replaced)){
             TreeNode* child = chp.second;
@@ -976,8 +976,11 @@ uint32_t TreeNode::findImmediateChildren_(std::regex& expr,
                 if (consider_child)
                 {
                     ++num_found;
-                    found.push_back(child);
-                    replacements.push_back(replaced);
+                    // Can already be added/found if an alias matched
+                    if(std::find(found.begin(), found.end(), child) == found.end()) {
+                        found.push_back(child);
+                        replacements.push_back(replaced);
+                    }
                 }
 
             }
@@ -1008,8 +1011,10 @@ uint32_t TreeNode::findImmediateChildren_(std::regex& expr,
             {
                 if(child){ // Ensure child is not null (e.g. grouping)
                     ++num_found;
-                    found.push_back(child);
-                    replacements.push_back(replaced);
+                    if(std::find(found.begin(), found.end(), child) == found.end()) {
+                        found.push_back(child);
+                        replacements.push_back(replaced);
+                    }
                 }
             }
         }
@@ -1098,7 +1103,8 @@ bool TreeNode::locationMatchesPattern(const std::string& pattern,
 
 TreeNode* TreeNode::getChild_(const std::string& name,
                               bool must_exist,
-                              bool private_also) {
+                              bool private_also)
+{
     incrementGetChildCount_(name);
 
     size_t name_pos = 0;
@@ -1106,8 +1112,8 @@ TreeNode* TreeNode::getChild_(const std::string& name,
     if(name.size() == 0){
         return this;
     }
-    while(node != nullptr && name_pos != std::string::npos){
-
+    while(node != nullptr && name_pos != std::string::npos)
+    {
         std::string immediate_child_name;
         immediate_child_name = getNextName(name, name_pos);
 
@@ -1794,8 +1800,7 @@ void TreeNode::addChild_(TreeNode* child, bool inherit_phase) {
         }
 
         if(child->getGroup().size() > 0){ // Group may be empty string
-            // Ignore group mappings for now
-            //addChildNameMapping_(child->getGroup(), 0);
+            addChildNameMapping_(child->getGroup() + std::to_string(child->getGroupIdx()), child);
         }
 
         // Connect child to parent.
@@ -1979,7 +1984,8 @@ TreeNode::getImmediateChildByIdentity_(const std::string& name,
                                        bool must_exist)
 {
     ChildNameMapping::iterator it = names_.find(name);
-    if(it == names_.end()){
+    if(it == names_.end())
+    {
         if(false == must_exist){
             return nullptr;
         }

--- a/sparta/test/TreeNode/TreeNode_test.cpp
+++ b/sparta/test/TreeNode/TreeNode_test.cpp
@@ -717,7 +717,7 @@ int main()
         EXPECT_THROW(b.getChildren().at(1)); // No dynamically created child YET
         std::vector<std::string> idents;
         a.getChildrenIdentifiers(idents);
-        EXPECT_EQUAL(idents.size(), (size_t)4);
+        EXPECT_EQUAL(idents.size(), (size_t)7);
         std::cout << "A idents: " << idents << std::endl;
         EXPECT_NOTHROW(a.getAs<sparta::TreeNode*>());
         EXPECT_NOTHROW(a.getAs<sparta::TreeNode>());
@@ -844,8 +844,8 @@ int main()
 
         // Find all children
         found.clear();
-        EXPECT_EQUAL((a.findChildren("*", found)), (uint32_t)4);
-        EXPECT_EQUAL(found.size(), (size_t)4);
+        EXPECT_EQUAL((a.findChildren("*", found)), (uint32_t)3);
+        EXPECT_EQUAL(found.size(), (size_t)3);
         EXPECT_TRUE(std::find(found.begin(), found.end(), &b) != found.end());
         EXPECT_TRUE(std::find(found.begin(), found.end(), &b1) != found.end()); // Should be found twice
         EXPECT_TRUE(std::find(found.begin(), found.end(), (sparta::TreeNode*)a.getParameterSet()) != found.end());


### PR DESCRIPTION
This is a fix that adds TreeNode alias names to the list of valid names to search for.  

closes #273 