### PR TITLE
Avoided double reclaiming proxy in PayloadEvent

### DIFF
--- a/sparta/sparta/events/PhasedPayloadEvent.hpp
+++ b/sparta/sparta/events/PhasedPayloadEvent.hpp
@@ -175,7 +175,9 @@ namespace sparta
         //! The payload was delivered, this proxy object is now
         //! reusable.
         void reclaimProxy_(typename ProxyInflightList::iterator & pl_location) {
-            sparta_assert(pl_location != inflight_pl_.end());
+            if (SPARTA_EXPECT_FALSE(pl_location == inflight_pl_.end())) {
+                return;
+            }
             if constexpr(MetaStruct::is_any_pointer<DataT>::value) {
                 (*pl_location)->setPayload_(nullptr);
             }


### PR DESCRIPTION
I ran into the assertion in `reclaimProxy_`.

In my use case, I was canceling DataOutPort calls in the same registered handler.
```
out_port.registerHandler(handlePortCall);

void handlePortCall(T Data)
{
  out_port.cancelIf(criteria);
}
```

I noticed proxy was reclaimed when Scheduler was delivering payload. So it is possible that the proxy can be repeatedly reclaimed if criteria matches. I added an if-condition to skip reclaiming if it was already reclaimed.