### PR TITLE
[fix]:change the cmake version in sparta/REAME.md

### DIFF
--- a/sparta/README.md
+++ b/sparta/README.md
@@ -22,7 +22,7 @@ design.
 #    cmake boost hdf5 yaml-cpp rapidJSON xz sqlite doxygen
 #
 # Versions tested and known to work:
-#    cmake     3.14
+#    cmake     3.15
 #    boost     1.71  (can go older, can go newer)
 #    yaml-cpp  0.6
 #    RapidJSON 1.1


### PR DESCRIPTION
[Sparta-README](https://github.com/sparcians/map/blob/master/sparta/README.md) said the cmake version is 3.14 
But when I build the project myself , the error output says
```bash
CMake Error at helios/pipeViewer/CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.15 or higher is required.  You are running version 3.14.0
```
and it's true in the first line of CMakeLists.txt in pipViewer is 
```
cmake_minimum_required(VERSION 3.15)
```
and also `3.15` is the latest version in **all** CMakeLists.txt which is located in this project, so I think this need to be fixed 