### PR TITLE
Put in a fix to not dump reports when the sim crashes

### DIFF
--- a/sparta/sparta/app/Simulation.hpp
+++ b/sparta/sparta/app/Simulation.hpp
@@ -371,6 +371,12 @@ public:
     // Status
 
     /*!
+     * \brief Was simulation successful?
+     * \return true if no exceptions were thrown; false otherwise
+     */
+    bool simulationSuccessful() const { return simulation_successful_; }
+
+    /*!
      * \brief return the number of events fired on the scheduler
      * during simulation.
      */
@@ -923,6 +929,11 @@ protected:
      * collection
      */
     std::unique_ptr<trigger::Trigger> debug_trigger_;
+
+    /*!
+     * \brief Was simulation successful?  I.e. no exceptions were thrown
+     */
+    bool simulation_successful_ = true;
 
 private:
 

--- a/sparta/sparta/ports/Port.hpp
+++ b/sparta/sparta/ports/Port.hpp
@@ -583,7 +583,7 @@ namespace sparta
 
             InPort * inp = nullptr;
             if((inp = dynamic_cast<InPort *>(in)) == 0) {
-                throw SpartaException("ERROR: Could not case '" +
+                throw SpartaException("ERROR: Could not cast '" +
                                     in->getName() + "' to an InPort for some reason...");
             }
 

--- a/sparta/src/DAG.cpp
+++ b/sparta/src/DAG.cpp
@@ -188,7 +188,7 @@ namespace sparta
     }
 
 
-bool DAG::sort()
+    bool DAG::sort()
     {
         uint32_t vcount = alloc_vertices_.size();
         num_groups_ = 1;

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -984,10 +984,18 @@ public:
 
     ~Impl()
     {
-        try {
-            this->saveReports();
-        } catch (...) {
-            std::cerr << "WARNING: Error saving reports to file" << std::endl;
+        // If we're not in the middle of an exception, we can save
+        // reports, unless report_on_error is defined
+        const bool save_reports =
+            (sim_ && sim_->getSimulationConfiguration()->report_on_error) ||
+            (sim_ && sim_->simulationSuccessful());
+        if(save_reports)
+        {
+            try {
+                this->saveReports();
+            } catch (...) {
+                std::cerr << "WARNING: Error saving reports to file" << std::endl;
+            }
         }
     }
 

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -933,6 +933,7 @@ void Simulation::run(uint64_t run_time)
 
         // Rethrow exception if necessary
         if(eptr != std::exception_ptr()){
+            simulation_successful_ = false;
             std::rethrow_exception(eptr);
         }
 


### PR DESCRIPTION
Also, this honors the `--report-on-error` flag