### PR TITLE
Fixed YAML include property issue

### DIFF
--- a/sparta/cmake/sparta-config.cmake
+++ b/sparta/cmake/sparta-config.cmake
@@ -60,7 +60,6 @@ message (STATUS "Using BOOST ${Boost_VERSION_STRING}")
 # Find YAML CPP
 find_package (yaml-cpp 0.6 REQUIRED)
 message (STATUS "Using YAML CPP ${yaml-cpp_VERSION}")
-#get_target_property(YAML_CPP_INCLUDE_DIR yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
 get_property(YAML_CPP_INCLUDE_DIR TARGET yaml-cpp PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 
 # Find RapidJSON

--- a/sparta/cmake/sparta-config.cmake
+++ b/sparta/cmake/sparta-config.cmake
@@ -60,7 +60,8 @@ message (STATUS "Using BOOST ${Boost_VERSION_STRING}")
 # Find YAML CPP
 find_package (yaml-cpp 0.6 REQUIRED)
 message (STATUS "Using YAML CPP ${yaml-cpp_VERSION}")
-get_target_property(YAML_CPP_INCLUDE_DIR yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
+#get_target_property(YAML_CPP_INCLUDE_DIR yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
+get_property(YAML_CPP_INCLUDE_DIR TARGET yaml-cpp PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 
 # Find RapidJSON
 find_package (RapidJSON 1.1 REQUIRED)


### PR DESCRIPTION
Suggestion by @quasiquote1 

Used the wrong `get` method to set the YAML CPP include.  Works for some, not for others.  This patch appears to work for all.

closes #328 