### PR TITLE
FIX: run git describe in source directory, not build

### DIFF
--- a/sparta/CMakeLists.txt
+++ b/sparta/CMakeLists.txt
@@ -104,7 +104,11 @@ if (COMPILE_WITH_PYTHON)
     python/sparta_support/Completer.cpp)
 endif ()
 
-execute_process (COMMAND bash "-c" "git describe --tags --always" OUTPUT_VARIABLE GIT_REPO_VERSION RESULT_VARIABLE rc)
+execute_process (COMMAND bash "-c" "git describe --tags --always"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_REPO_VERSION RESULT_VARIABLE rc
+)
+
 if (NOT rc EQUAL "0")
   message (FATAL_ERROR "could not run git command 'git describe --tags --always', rc=${rc}")
 endif ()


### PR DESCRIPTION
This fixes the error 
```
fatal: not a git repository (or any of the parent directories): .git
CMake Error at sparta/CMakeLists.txt:109 (message):
  could not run git command 'git describe --tags --always', rc=128
```
when not running `cmake` in the source directory.