### PR TITLE
Argos: Fix uop highlighting for multiline annotation strings

### DIFF
--- a/helios/pipeViewer/pipe_view/model/highlighting_utils.py
+++ b/helios/pipeViewer/pipe_view/model/highlighting_utils.py
@@ -7,7 +7,7 @@ def GetUopUid(anno_string):
     if not isinstance(anno_string, str):
         return None
 
-    uid_match = __UOP_UID_REGEX.match(anno_string)
+    uid_match = __UOP_UID_REGEX.search(anno_string)
 
     if uid_match is not None:
         return int(uid_match.group(1))


### PR DESCRIPTION
This PR fixes a bug in Argos that broke uop highlighting if the annotation string has multiple lines.