### PR TITLE
Removing parameter from isReady

### DIFF
--- a/sparta/test/SyncPort/SyncPort_test.cpp
+++ b/sparta/test/SyncPort/SyncPort_test.cpp
@@ -323,10 +323,7 @@ void Unit::schedule_commands(double other_clk_mhz)
         std::cout << getName() << ": sending data '" << data << "' at tick '"
                   << src_delay * src_clk_period << "' expecting arrival at '" << src_data_arrival_tick << "'\n";
 #endif
-        if (!EXPECT_TRUE(out_cmd.isReady(src_delay + src_delay_factor))) {
-            std::cout << "ERROR: " << getName() << ": should always be ready next cycle (idx=" << idx << ", delay="<< src_delay + src_delay_factor << ")\n";
-        }
-        if (!EXPECT_FALSE(out_cmd.isReady(src_delay))) {
+        if (!EXPECT_FALSE(out_cmd.isReady())) {
             std::cout << "ERROR: " << getName() << ": should never be ready this cycle (idx=" << idx << ")\n";
         }
 


### PR DESCRIPTION
The parameter for isReady to check the readiness of a connected SyncInPort can be omitted. In the documentation it is suggested, to check for  SyncOutPort::isReady(n), if this is followed by a SyncOutPort::send(message, n). However, between the current clock cycle `c` and `c+n`, the input port can become unready by calling SyncInPort::setReady(false). Therefore, there is a discrepancy of what the method `isReady` does and the comment. 
Further, `isReady` calls `couldAccept_` which then asserts that the parameter given to `isReady`, equals 0. 
This commit removes the parameter from the list of `isReady` and `couldAccept_`. Further, it improve comments regarding the purpose and functionality of `isReady`.

Related to issue #356 