### PR TITLE
Fix for allow_slide setting for SyncPorts, in case of a collision

### DIFF
--- a/sparta/sparta/ports/SyncPort.hpp
+++ b/sparta/sparta/ports/SyncPort.hpp
@@ -331,7 +331,7 @@ namespace sparta
             // Convert the absolute tick of the send event into a current
             // cycle relative cycle and return that value
             Clock::Cycle next_send_cycle = clk_->getCycle(send_tick) + send_delay_cycles;
-            sparta_assert(next_send_cycle > current_cycle);
+            sparta_assert(next_send_cycle >= current_cycle);
             return next_send_cycle;
         }
 
@@ -855,7 +855,7 @@ namespace sparta
                                                    send_clk->getTick(send_delay_cycles),
                                                    send_clk, receive_delay_ticks_, receiver_clock_);
 
-            sparta_assert( data_arrival_tick > num_delay_ticks );
+            sparta_assert( data_arrival_tick >= num_delay_ticks );
             return num_delay_ticks;
         }
 

--- a/sparta/sparta/ports/SyncPort.hpp
+++ b/sparta/sparta/ports/SyncPort.hpp
@@ -229,7 +229,10 @@ namespace sparta
         }
 
         /**
-         *  \brief Send data on the output port and allow slide
+         *  \brief Send data on the output port. In case of a conflict (multiple packets scheduled
+         *  to be received within the same clock cycle), the new packet is rescheduled for transmission
+         *  in the next clock cycle automatically. There is no limit on how many packets can be
+         *  rescheduled, the FIFO is without an upper bound.
          *  \param dat The data to send
          *  \param send_delay_cycles Cycles to delay before sending
          *
@@ -244,8 +247,12 @@ namespace sparta
          *  \brief Send data on the output port
          *  \param dat The data to send
          *  \param send_delay_cycles Cycles to delay before sending
-         *  \param allow_slide Allows the receive to slide relative to
-         *                     previous requests
+         *  \param allow_slide If set to true and, in case of packets already in flight and scheduled to be
+         *                     delivered in the same clock cycle, automatically reschedule this new packet to be
+         *                     transmitted in the next following clock cycle. If set to false, no rescheduling is
+         *                     performed. In case of of a collision, the port will throw an assertion.
+         *                     There is no limit on the number of packets that can be rescheduled as the FIFO
+         *                     does not have an upper bound.
          *
          *  \return The delay in ticks from sending
          */

--- a/sparta/sparta/ports/SyncPort.hpp
+++ b/sparta/sparta/ports/SyncPort.hpp
@@ -93,7 +93,7 @@ namespace sparta
      *  a bus.  The destination SyncInPort will handle any latch
      *  delays.  Note that since this potentially send occurs across a
      *  clock boundary, the number of cycles actually delayed won't
-     *  necessarily be in the sending clock comain.
+     *  necessarily be in the sending clock domain.
      *
      *  The rules for sending across clock boundaries are:
      *
@@ -261,11 +261,7 @@ namespace sparta
             sparta_assert(sync_in_port_ != 0, "Attempting to send data on unbound port:" << getLocation());
             sparta_assert(clk_->isPosedge(), "Posedge check failed in port:" << getLocation());
 
-            Clock::Cycle send_cycle = clk_->currentCycle() + send_delay_cycles;
-            
-            if(allow_slide) {
-                send_cycle += sync_in_port_->getNumInFlight();
-            }
+            Clock::Cycle send_cycle = computeNextAvailableCycleForSend(send_delay_cycles, 0);
             
             if (SPARTA_EXPECT_FALSE(info_logger_)) {
                 info_logger_ << "SEND @" << send_cycle
@@ -334,11 +330,9 @@ namespace sparta
 
             // Convert the absolute tick of the send event into a current
             // cycle relative cycle and return that value
-            Clock::Cycle next_send_cycle = clk_->getCycle(send_tick);
+            Clock::Cycle next_send_cycle = clk_->getCycle(send_tick) + send_delay_cycles;
             sparta_assert(next_send_cycle > current_cycle);
-            Clock::Cycle delay_cycle = next_send_cycle - current_cycle;
-
-            return delay_cycle;
+            return next_send_cycle;
         }
 
 

--- a/sparta/sparta/ports/SyncPort.hpp
+++ b/sparta/sparta/ports/SyncPort.hpp
@@ -733,7 +733,6 @@ namespace sparta
         friend void SyncOutPort<DataT>::bind(Port * in);
 
         //! Allow SyncOutPort::send() to call SyncInPort::send_()
-        //! and SyncInPort::getNumInFlight()
         friend uint64_t SyncOutPort<DataT>::send(const DataT &, uint64_t, const bool);
 
         //! Allow DataOutPort::isReady() to call DataInPort::couldAccept_()
@@ -931,16 +930,6 @@ namespace sparta
             return num_delay_ticks;
         }
         
-        /*!
-         * \brief Called by SyncOutPort, only if allow_slide is true.
-         * To calculate, at what clock cycle a packet can be sent to this SyncInPort, the
-         * SyncOutPort needs to know, how many packets are already in flight to "slide" the new
-         * packet into the earliest cycle possible.
-         * \return The number of packets that are currently in flight.
-         */
-        uint32_t getNumInFlight() {
-            return num_in_flight_;
-        }
 
     private:
 


### PR DESCRIPTION
This commit resolves 2 issues with the `allow_slide` parameter in `SyncOutPort::send` and derivatives (`SyncOutPort::sendAndAllowSlide()`):

1. The documentation does not clearly explain the impact and function of `allow_slide`
2. Setting `allow_slide` to true has either no effect or in case of a collision causes a `sparta_assert`, which should not happen.

### Documentation
The improvement in documentation explains what the parameter `allow_slide` does. This is related to issue #356 in which it has been briefly mentioned.

### `allow_slide`
The SyncPort allows the transmission of 1 packet per clock cycle only. Hence, calling `send` for the same SyncOutPort twice within a clock cycle, will cause an assertion to be thrown. The `allow_slide` = true allows to reschedule packets which are sent in the same clock cycle. The newly added packets will recirculate and rescheduled for transmission in the next possible clock cycle after all the packets in flight have been transmitted. Consider the following example code:
```
if(outPorts->isReady()) {
    outPorts->send(message0, 1, false);
    outPorts->send(message1, 1, false);
    outPorts->send(message2, 1, false);
}
```
will result in
```
21: top.arch.memory_cpu0.crossbar.ports.out_arbiter0: SEND @22 allow_slide=0 # 0x564c98ed2070
21: top.arch.memory_cpu0.ports.in_crossbar_to_llc: RECEIVE SCHEDULED @22(0)  # 0x564c98ed2070
21: top.arch.memory_cpu0.crossbar.ports.out_arbiter0: SEND @22 allow_slide=0 # 0x564c98ed2071
21: top.arch.memory_cpu0.ports.in_crossbar_to_llc: RECEIVE SCHEDULED @22(1)  # 0x564c98ed2071
terminate called after throwing an instance of 'sparta::SpartaException'
  what():  prev_data_arrival_tick_ < abs_scheduled_tick || prev_data_arrival_tick_ == PREV_DATA_ARRIVAL_TICK_INIT: top.arch.memory_cpu0.ports.in_crossbar_to_llc: attempt to schedule send for tick 34, which is not later than the previous data at tick 34; SyncInPorts should only get data once per cycle; data was: 0x564c98ed2070: in file: '../map/sparta/sparta/ports/SyncPort.hpp', on line: 944
```
The first 2 lines schedule the first `send` call correctly. The second `send` call (for data with the address `0x564c98ed2071`) cause the assertion.

The problem arises, that in the code snipped above, setting the last parameter in `send` to `true` to activate the `allow_slide` mechanism, the output is the same, which is incorrect. Instead, the `message1` and `message2` in the second and third call to `send` should be scheduled for delivery in clock cycle 23 and 24, respectively, following `message0` in clock cycle 22. With this commit, the behavior is correct:

```
21: top.arch.memory_cpu0.crossbar.ports.out_arbiter0: SEND @22 allow_slide=1 # 0x556d6b022070
21: top.arch.memory_cpu0.ports.in_crossbar_to_llc: RECEIVE SCHEDULED @22(0)  # 0x556d6b022070
21: top.arch.memory_cpu0.crossbar.ports.out_arbiter0: SEND @23 allow_slide=1 # 0x556d6b022071
21: top.arch.memory_cpu0.ports.in_crossbar_to_llc: RECEIVE SCHEDULED @23(1)  # 0x556d6b022071
21: top.arch.memory_cpu0.crossbar.ports.out_arbiter0: SEND @24 allow_slide=1 # 0x556d6b022072
21: top.arch.memory_cpu0.ports.in_crossbar_to_llc: RECEIVE SCHEDULED @24(2)  # 0x556d6b022072
22: DELIVERING @22(2)  # 0x556d6b022070
23: DELIVERING @23(1)  # 0x556d6b022071
24: DELIVERING @24(0)  # 0x556d6b022072
```

The commit fixes the rescheduling by checking, how many packets are already in flight and adding this number to the desired delay given in `send`

Points worth noticing/discussing and Terms and Conditions:
1. Currently, there is no limit on packets that are in flight. Hence, the implementation cannot be used to simulate FIFO buffers having upper bounds, which would be more realistic in hardware. To have FIFOs for the packets in flight, a bit of infrastructure surrounding the SyncPort pair needs to be implemented.
2. I have not tested cross clock domain behavior of the slide, as my current project has only 1 common clock.
3. It is unclear to me (maybe I am overthinking it), how the SyncPort should react in case the `send` call is interleaved with various differentiating delay parameters. For instance, imagine that the second `send` in the snippet above is replaced by `outPorts->send(message1, 1000, true);` I believe that the sending of packets needs to be always in ascending order. Hence, `message2` can only be sent at a delay of > 1000.