### PR TITLE
Initialize and Process Meta-Data Architecture Parameter

### DIFF
--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -1993,8 +1993,20 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
                                                        filter_parameters);
         }
 
-        // If we are reading a final config. Assert that we actually loaded a final config.
+        // Store the arch param
         std::vector<sparta::TreeNode*> children;
+        sim->getMetaParamRoot()->findChildren("params.architecture", children);
+        sparta_assert (children.size() > 0, "Sparta should have made a default meta.params.architecture.");
+        sparta::Parameter<std::string>* arch_p = dynamic_cast<sparta::Parameter<std::string>*>(children.at(0));
+        sparta_assert(arch_p);
+        const auto run_metadata = getSimulationConfiguration().getRunMetadata();
+        const auto run_metadata_it = std::find_if(run_metadata.begin(), run_metadata.end(),
+            [] (const auto md_param) { return md_param.first == "arch"; });
+        sparta_assert(run_metadata_it != run_metadata.end());
+        arch_p->setValueFromString(run_metadata_it->second);
+
+        // If we are reading a final config. Assert that we actually loaded a final config.
+        children.clear();
         sim->getMetaParamRoot()->findChildren("params.is_final_config", children);
         sparta_assert (children.size() > 0, "Sparta should have made a default meta.params.is_final_config.");
         sparta::Parameter<bool>* is_final_p = dynamic_cast<sparta::Parameter<bool>*>(children.at(0));

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -724,6 +724,9 @@ bool CommandLineSimulator::parse(int argc,
     // --parameter / -p (pattern, value as a string)
     std::vector<std::tuple<std::string, std::string, bool>> individual_parameter_values;
 
+    // metadata arch value read from config files
+    utils::ValidValue<std::pair<std::string, std::string>> config_metadata_arch;
+
     // Parse options from command line
     try{
         std::vector<std::string> pos_opts;
@@ -1597,9 +1600,44 @@ bool CommandLineSimulator::parse(int argc,
         sim_config_.omitStatsWithValueZeroForReportFormat("json_reduced");
     }
 
+    // Get metadata architecture param from config files
+    bool config_metadata_arch_final = false;
+    for (const auto & cfg : config_pattern_names) {
+        const std::string & filename = std::get<1>(cfg);
+        const bool is_final = std::get<2>(cfg);
+        if(config_metadata_arch_final && !is_final) { continue; }
+        TreeNode dummy("dummy", "dummy");
+        sparta::ConfigParser::YAML param_file(filename, sim_config_.getConfigSearchPath());
+        param_file.allowMissingNodes(true);
+        constexpr bool VERBOSE = false;
+        param_file.consumeParameters(&dummy, VERBOSE);
+
+        const auto ptree = param_file.getParameterTree();
+        if(ptree.hasValue("meta.params.architecture")) {
+            const std::string& arch = ptree.get("meta.params.architecture").getValue();
+            if(arch != "NONE") {
+                const std::string & pattern = std::get<0>(cfg);
+                config_metadata_arch = std::make_pair(pattern, arch);
+            }
+            if(is_final) {
+                config_metadata_arch_final = true;
+            }
+        }
+
+    }
+
     // Check for valid arch config if required by defaults
+    //
+    // Priority:
+    // 1. --arch
+    // 2. --read-final-config
+    // 3. --config-file / --node-config-file
+    // 4. Default (if required)
     if(arch_pattern_name.isValid()) {
         sim_config_.processArch(arch_pattern_name.getValue().first, arch_pattern_name.getValue().second);
+    }
+    else if(config_metadata_arch.isValid()) {
+        sim_config_.processArch(config_metadata_arch.getValue().first, config_metadata_arch.getValue().second);
     }
     else {
         if(!sim_config_.archFileProvided()) {
@@ -2002,8 +2040,9 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
         const auto run_metadata = getSimulationConfiguration().getRunMetadata();
         const auto run_metadata_it = std::find_if(run_metadata.begin(), run_metadata.end(),
             [] (const auto md_param) { return md_param.first == "arch"; });
-        sparta_assert(run_metadata_it != run_metadata.end());
-        arch_p->setValueFromString(run_metadata_it->second);
+        if(run_metadata_it != run_metadata.end()) {
+            arch_p->setValueFromString(run_metadata_it->second);
+        }
 
         // If we are reading a final config. Assert that we actually loaded a final config.
         children.clear();

--- a/sparta/src/SimulationConfiguration.cpp
+++ b/sparta/src/SimulationConfiguration.cpp
@@ -59,6 +59,7 @@ namespace app {
         sparta_assert(arch_applicator_ == nullptr, "Cannot specify more than one arch option");
         sparta_assert(!is_consumed_, "You cannot process arch files after simulation has been populated");
         std::string found_filename = utils::findArchitectureConfigFile(arch_search_paths_, filename);
+        addRunMetadata("arch", filename);
         arch_applicator_.reset(new ArchNodeConfigFileApplicator(pattern, found_filename, arch_search_paths_));
         arch_applicator_->applyUnbound(arch_ptree_, verbose_cfg);
         std::cout << "  [in] Arch Config: " << arch_applicator_->stringize() << std::endl;


### PR DESCRIPTION
When generating config files, write the arch value to the meta param "architecture". When reading in config yamls, also read in and process the meta arch value.

Priority of different "arch" value sources:
1.  --arch
2. --read-final-config
3. --config-file / --node-config-file
4. Default (if required)


Closes #353 