### PR TITLE
Fix use of bitwise operator or with boolean operands

### DIFF
--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -1814,7 +1814,7 @@ bool CommandLineSimulator::parse(int argc,
     sim_config_.reports                 = reports;
 
     //pevents
-    run_pevents_ = (vm_.count("pevents-at") > 0) | (vm_.count("pevents") > 0) | (vm_.count("verbose-pevents") > 0);
+    run_pevents_ = (vm_.count("pevents-at") > 0) || (vm_.count("pevents") > 0) || (vm_.count("verbose-pevents") > 0);
 
     bool show_options = vm_.count("show-options") > 0;
     if(show_options){


### PR DESCRIPTION
Fixes a conda-forge clang14.04 warning that I found on osx-arm64:
`error: use of bitwise '|' with boolean operands [-Werror,-Wbitwise-instead-of-logical]`