### PR TITLE
Support for Arbitrary Report File Header Metadata

### DIFF
--- a/sparta/example/DynamicModelPipeline/placeholders.yaml
+++ b/sparta/example/DynamicModelPipeline/placeholders.yaml
@@ -1,3 +1,5 @@
+header_metadata:
+  warmup: %CORE0_WARMUP%
 content:
   report:
     pattern:   _global

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -80,6 +80,7 @@ namespace sparta {
 
         typedef std::unordered_map<std::string, boost::any> NamedExtensions;
         typedef std::unordered_map<std::string, std::string> TriggerKeyValues;
+        typedef std::unordered_map<std::string, std::string> MetaDataKeyValues;
 
         /*!
          * \brief Describes one or more report to instantiate
@@ -270,6 +271,11 @@ namespace sparta {
              * configurations to descriptors.
              */
             NamedExtensions extensions_;
+
+            /*!
+             * \brief Metadata to include in report headers
+             */
+            MetaDataKeyValues header_metadata_;
 
             /*!
              * \brief Calling this method causes the simulation to skip this

--- a/sparta/sparta/trigger/ContextCounterTrigger.hpp
+++ b/sparta/sparta/trigger/ContextCounterTrigger.hpp
@@ -181,7 +181,9 @@ public:
 
 private:
     virtual bool isTriggerReached_() const override;
+    virtual bool supportsMultipleCounters() const override;
     virtual const CounterBase * getCounter() const override;
+    virtual const Counters& getCounters() const override;
 
     class Impl;
 

--- a/sparta/sparta/trigger/ExpressionTrigger.hpp
+++ b/sparta/sparta/trigger/ExpressionTrigger.hpp
@@ -370,7 +370,7 @@ public:
      * \brief Get counter of source counter trigger
      */
     const CounterBase * getCounter() const {
-        return source_counter_triggers_.empty() ? nullptr :
+        return !supports_single_ct_trig_cb_ ? nullptr :
             source_counter_triggers_[0]->getCounter();
     }
 

--- a/sparta/sparta/trigger/ExpressionTrigger.hpp
+++ b/sparta/sparta/trigger/ExpressionTrigger.hpp
@@ -370,8 +370,14 @@ public:
      * \brief Get counter of source counter trigger
      */
     const CounterBase * getCounter() const {
-        return !supports_single_ct_trig_cb_ ? nullptr :
-            source_counter_triggers_[0]->getCounter();
+        if (!supports_single_ct_trig_cb_) {
+            return nullptr;
+        }
+        else {
+            const auto& first_trigger = source_counter_triggers_[0];
+            return first_trigger->supportsMultipleCounters() ? first_trigger->getCounters()[0]
+                                                             : first_trigger->getCounter();
+        }
     }
 
     /*

--- a/sparta/sparta/trigger/ExpressionTrigger.hpp
+++ b/sparta/sparta/trigger/ExpressionTrigger.hpp
@@ -366,6 +366,14 @@ public:
     };
     const ExpressionTriggerInternals & getInternals();
 
+    /*!
+     * \brief Get counter of source counter trigger
+     */
+    const CounterBase * getCounter() const {
+        return source_counter_triggers_.empty() ? nullptr :
+            source_counter_triggers_[0]->getCounter();
+    }
+
     /*
      * \brief Helper which splits expressions like these:
      *           "entityA >= 90"

--- a/sparta/sparta/trigger/SingleTrigger.hpp
+++ b/sparta/sparta/trigger/SingleTrigger.hpp
@@ -18,6 +18,8 @@
 namespace sparta{
     namespace trigger{
 
+    using Counters = std::vector<const CounterBase*>;
+
 /**
  * \class TriggerEvent
  */
@@ -341,6 +343,14 @@ public:
     }
 
     /*!
+     * \brief Return if this trigger supports multiple counters
+     */
+    virtual bool supportsMultipleCounters() const
+    {
+        return false;
+    }
+
+    /*!
      * \brief Return the counter associated with this trigger. Will not be nullptr
      */
     virtual const CounterBase* getCounter() const
@@ -349,6 +359,15 @@ public:
                     "Cannot getCounter on a CounterTrigger because the referenced counter "
                     "has expired");
         return counter_;
+    }
+
+    /*!
+     * \brief Return the counters associated with this trigger
+     */
+    virtual const Counters& getCounters() const
+    {
+        throw SpartaException("SingleTrigger does not support multiple counters. "
+                              "Use \"getCounter()\" instead");
     }
 
     /*!

--- a/sparta/src/ContextCounterTrigger.cpp
+++ b/sparta/src/ContextCounterTrigger.cpp
@@ -223,17 +223,8 @@ public:
 
     const CounterBase * getCounter() const
     {
-        if (internal_counters_.empty()) {
-            return nullptr;
-        }
-        if (internal_counters_.size() == 1) {
-            return internal_counters_[0];
-        }
-        throw SpartaException("You may not call the getCounter() method on this "
-                            "ContextCounterTrigger since it has ")
-            << internal_counters_.size()
-            << " internal counters, not just one.";
-        return nullptr;
+        return internal_counters_.empty() ? nullptr :
+            internal_counters_[0];
     }
 
     ~Impl() = default;

--- a/sparta/src/ContextCounterTrigger.cpp
+++ b/sparta/src/ContextCounterTrigger.cpp
@@ -223,8 +223,22 @@ public:
 
     const CounterBase * getCounter() const
     {
-        return internal_counters_.empty() ? nullptr :
-            internal_counters_[0];
+        // There is an assert in the constructor to ensure that internal_counters_ is never empty
+        if(internal_counters_.size() == 1) {
+            sparta_assert(false == internal_counters_[0]->isExpired(),
+                "Cannot getCounter on a ContextCounterTrigger because the referenced counter "
+                "has expired");
+            return internal_counters_[0];
+        }
+        else {
+            throw SpartaException("ContextCounterTrigger supports multiple counters. "
+                                  "Use \"getCounters()\" instead");
+        }
+    }
+
+    const Counters& getCounters() const
+    {
+        return internal_counters_;
     }
 
     ~Impl() = default;
@@ -321,9 +335,19 @@ bool ContextCounterTrigger::isTriggerReached_() const
     return impl_->isTriggerReached();
 }
 
+bool ContextCounterTrigger::supportsMultipleCounters() const
+{
+    return true;
+}
+
 const CounterBase * ContextCounterTrigger::getCounter() const
 {
     return impl_->getCounter();
+}
+
+const Counters& ContextCounterTrigger::getCounters() const
+{
+    return impl_->getCounters();
 }
 
 void ContextCounterTrigger::registerContextCounterCalcFunction(

--- a/sparta/src/Report.cpp
+++ b/sparta/src/Report.cpp
@@ -912,7 +912,7 @@ class ReportFileParserYAML
             if(itr == next_uid_map_.end()){
                 // Inherit form parent, no entry in the map
                 verbose() << indent_() << "(getNextNodeID_) parent entry: " << *parent
-                          << " not found. in map. Inheriting parent uid " << parent->uid << std::endl;
+                          << " not found in map. Inheriting parent uid " << parent->uid << std::endl;
                 verbose() << indent_() << "(getNextNodeID_) next uid map (" << next_uid_map_.size()
                           << " entries):" << std::endl;
                 for(auto& e : next_uid_map_){

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -886,7 +886,9 @@ class ReportDescriptorFileParserYAML
         static constexpr char KEY_SKIP[]            = "skip";
         static constexpr char KEY_AUTO_EXPAND_CC[]  = "expand-cc";
         static constexpr char KEY_METADATA[]        = "header_metadata";
-        static constexpr char KEY_COUNTER[]         = "counter";
+        static constexpr char KEY_START_COUNTER[]   = "start_counter";
+        static constexpr char KEY_STOP_COUNTER[]    = "stop_counter";
+        static constexpr char KEY_UPDATE_COUNTER[]  = "update_counter";
 
         virtual bool handleEnterMap_(
             const std::string & key,
@@ -976,8 +978,8 @@ class ReportDescriptorFileParserYAML
             const NavNode& scope) override final
         {
             if (in_header_metadata_) {
-                sparta_assert(assoc_key != KEY_COUNTER,
-                    "Metadata key \"counter\" is reserved");
+                sparta_assert(isMetadataReservedKey_(assoc_key) == false,
+                    "Metadata key \""+assoc_key+"\" is reserved");
                 header_metadata_kv_pairs_[assoc_key] = value;
                 return true;
             }
@@ -1062,6 +1064,14 @@ class ReportDescriptorFileParserYAML
                     key == KEY_SKIP             ||
                     key == KEY_AUTO_EXPAND_CC   ||
                     key == KEY_METADATA);
+        }
+
+        bool isMetadataReservedKey_(
+            const std::string & key) const
+        {
+            return (key == KEY_START_COUNTER  ||
+                    key == KEY_STOP_COUNTER   ||
+                    key == KEY_UPDATE_COUNTER);
         }
 
         void prepareForNextDescriptor_()
@@ -1182,7 +1192,13 @@ constexpr char ReportDescriptorFileParserYAML::
     ReportDescriptorFileEventHandlerYAML::KEY_METADATA[];
 
 constexpr char ReportDescriptorFileParserYAML::
-    ReportDescriptorFileEventHandlerYAML::KEY_COUNTER[];
+    ReportDescriptorFileEventHandlerYAML::KEY_START_COUNTER[];
+
+constexpr char ReportDescriptorFileParserYAML::
+    ReportDescriptorFileEventHandlerYAML::KEY_STOP_COUNTER[];
+
+constexpr char ReportDescriptorFileParserYAML::
+    ReportDescriptorFileEventHandlerYAML::KEY_UPDATE_COUNTER[];
 
 /*!
  * \brief Parse a YAML file containing key-value pairs into a

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -886,6 +886,7 @@ class ReportDescriptorFileParserYAML
         static constexpr char KEY_SKIP[]            = "skip";
         static constexpr char KEY_AUTO_EXPAND_CC[]  = "expand-cc";
         static constexpr char KEY_METADATA[]        = "header_metadata";
+        static constexpr char KEY_COUNTER[]         = "counter";
 
         virtual bool handleEnterMap_(
             const std::string & key,
@@ -975,6 +976,8 @@ class ReportDescriptorFileParserYAML
             const NavNode& scope) override final
         {
             if (in_header_metadata_) {
+                sparta_assert(assoc_key != KEY_COUNTER,
+                    "Metadata key \"counter\" is reserved");
                 header_metadata_kv_pairs_[assoc_key] = value;
                 return true;
             }
@@ -1177,6 +1180,9 @@ constexpr char ReportDescriptorFileParserYAML::
 
 constexpr char ReportDescriptorFileParserYAML::
     ReportDescriptorFileEventHandlerYAML::KEY_METADATA[];
+
+constexpr char ReportDescriptorFileParserYAML::
+    ReportDescriptorFileEventHandlerYAML::KEY_COUNTER[];
 
 /*!
  * \brief Parse a YAML file containing key-value pairs into a

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -851,6 +851,7 @@ class ReportDescriptorFileParserYAML
     private:
         std::stack<bool> in_report_stack_;
         bool in_trigger_definition_ = false;
+        bool in_header_metadata_ = false;
         ReportDescVec completed_descriptors_;
 
         std::string loc_pattern_;
@@ -862,6 +863,7 @@ class ReportDescriptorFileParserYAML
         bool auto_expand_context_counter_stats_ = false;
 
         app::TriggerKeyValues trigger_kv_pairs_;
+        app::MetaDataKeyValues header_metadata_kv_pairs_;
 
         /*!
          * \brief Reserved keywords for this parser's dictionary
@@ -883,6 +885,7 @@ class ReportDescriptorFileParserYAML
         static constexpr char KEY_TAG[]             = "tag";
         static constexpr char KEY_SKIP[]            = "skip";
         static constexpr char KEY_AUTO_EXPAND_CC[]  = "expand-cc";
+        static constexpr char KEY_METADATA[]        = "header_metadata";
 
         virtual bool handleEnterMap_(
             const std::string & key,
@@ -908,6 +911,9 @@ class ReportDescriptorFileParserYAML
                         "Nested trigger definitions are not supported");
                 }
                 in_trigger_definition_ = true;
+                return false;
+            } else if (key == KEY_METADATA) {
+                in_header_metadata_ = true;
                 return false;
             }
 
@@ -962,6 +968,19 @@ class ReportDescriptorFileParserYAML
             }
         }
 
+        virtual bool handleLeafScalarUnknownKey_(
+            TreeNode * n,
+            const std::string & value,
+            const std::string & assoc_key,
+            const NavNode& scope) override final
+        {
+            if (in_header_metadata_) {
+                header_metadata_kv_pairs_[assoc_key] = value;
+                return true;
+            }
+            return false;
+        }
+
         virtual bool handleExitMap_(
             const std::string & key,
             const NavVector & context) override final
@@ -1002,12 +1021,18 @@ class ReportDescriptorFileParserYAML
                     auto & descriptor = completed_descriptors_.back();
                     descriptor.extensions_.swap(trigger_extensions);
                 }
+                if (!header_metadata_kv_pairs_.empty()) {
+                    auto & descriptor = completed_descriptors_.back();
+                    descriptor.header_metadata_.swap(header_metadata_kv_pairs_);
+                }
                 if (auto_expand_context_counter_stats_) {
                     auto & descriptor = completed_descriptors_.back();
                     descriptor.extensions_["expand-cc"] = true;
                 }
             } else if (key == KEY_TRIGGER) {
                 in_trigger_definition_ = false;
+            } else if (key == KEY_METADATA) {
+                in_header_metadata_ = false;
             }
 
             return false;
@@ -1032,7 +1057,8 @@ class ReportDescriptorFileParserYAML
                     key == KEY_UPDATE_WHENEVER  ||
                     key == KEY_TAG              ||
                     key == KEY_SKIP             ||
-                    key == KEY_AUTO_EXPAND_CC);
+                    key == KEY_AUTO_EXPAND_CC   ||
+                    key == KEY_METADATA);
         }
 
         void prepareForNextDescriptor_()
@@ -1148,6 +1174,9 @@ constexpr char ReportDescriptorFileParserYAML::
 
 constexpr char ReportDescriptorFileParserYAML::
     ReportDescriptorFileEventHandlerYAML::KEY_AUTO_EXPAND_CC[];
+
+constexpr char ReportDescriptorFileParserYAML::
+    ReportDescriptorFileEventHandlerYAML::KEY_METADATA[];
 
 /*!
  * \brief Parse a YAML file containing key-value pairs into a

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -730,8 +730,14 @@ private:
         for (auto & r : reports_) {
             auto & header = r->getHeader();
 
-            if (start_trigger_counter_.isValid()) {
-                header.set("counter", start_trigger_counter_.getValue()->getLocation());
+            if (report_start_trigger_ && report_start_trigger_->getCounter()) {
+                header.set("start_counter", report_start_trigger_->getCounter()->getLocation());
+            }
+            if (report_stop_trigger_ && report_stop_trigger_->getCounter()) {
+                header.set("stop_counter", report_stop_trigger_->getCounter()->getLocation());
+            }
+            if (report_update_trigger_ && report_update_trigger_->getCounter()) {
+                header.set("update_counter", report_update_trigger_->getCounter()->getLocation());
             }
 
             const auto header_metadata = getDescriptor().header_metadata_;

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -801,6 +801,11 @@ private:
         for (auto & r : reports_) {
             auto & header = r->getHeader();
             populate_header_content(header);
+
+            const auto header_metadata getDescriptor().header_metadata_;
+            for(auto [key, value] : header_metadata) {
+                header.set(key, value);
+            }
         }
     }
 

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -730,15 +730,21 @@ private:
         for (auto & r : reports_) {
             auto & header = r->getHeader();
 
-            if (report_start_trigger_ && report_start_trigger_->getCounter()) {
-                header.set("start_counter", report_start_trigger_->getCounter()->getLocation());
-            }
-            if (report_stop_trigger_ && report_stop_trigger_->getCounter()) {
-                header.set("stop_counter", report_stop_trigger_->getCounter()->getLocation());
-            }
-            if (report_update_trigger_ && report_update_trigger_->getCounter()) {
-                header.set("update_counter", report_update_trigger_->getCounter()->getLocation());
-            }
+            auto set_header_trigger_content =
+                [this](report::format::ReportHeader & header,
+                       const std::string key,
+                       const trigger::ExpiringExpressionTrigger & trigger) {
+                if (trigger) {
+                    const auto counter = trigger->getCounter();
+                    if(counter) {
+                        header.set(key, counter->getLocation());
+                    }
+                }
+            };
+
+            set_header_trigger_content(header, "start_counter",  report_start_trigger_);
+            set_header_trigger_content(header, "stop_counter",   report_stop_trigger_);
+            set_header_trigger_content(header, "update_counter", report_update_trigger_);
 
             const auto header_metadata = getDescriptor().header_metadata_;
             for(auto [key, value] : header_metadata) {

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -802,7 +802,7 @@ private:
             auto & header = r->getHeader();
             populate_header_content(header);
 
-            const auto header_metadata getDescriptor().header_metadata_;
+            const auto header_metadata = getDescriptor().header_metadata_;
             for(auto [key, value] : header_metadata) {
                 header.set(key, value);
             }

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -731,9 +731,9 @@ private:
             auto & header = r->getHeader();
 
             auto set_header_trigger_content =
-                [this](report::format::ReportHeader & header,
-                       const std::string key,
-                       const trigger::ExpiringExpressionTrigger & trigger) {
+                [](report::format::ReportHeader & header,
+                   const std::string key,
+                   const trigger::ExpiringExpressionTrigger & trigger) {
                 if (trigger) {
                     const auto counter = trigger->getCounter();
                     if(counter) {

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -131,36 +131,6 @@ public:
         on_triggered_notifier_ = on_triggered_notifier;
     }
 
-    void writeTriggerMetadata(sparta::db::ReportHeader & db_header) const {
-        db_header.getObjectRef().getObjectManager().safeTransaction([&]() {
-            const std::string period =
-                report_update_trigger_ ?
-                report_update_trigger_->toString() :
-                "none";
-            db_header.setStringMetadata("period", period);
-
-            const std::string terminate =
-                report_stop_trigger_ ?
-                report_stop_trigger_->toString() :
-                "none";
-            db_header.setStringMetadata("terminate", terminate);
-
-            const std::string enabled =
-                report_toggle_trigger_ ?
-                report_toggle_trigger_->toString() :
-                "none";
-            db_header.setStringMetadata("enabled", enabled);
-
-            //Whether we write the "warmup" metadata right now
-            //or later depends on whether we have a report start
-            //trigger. If we *do* have such a trigger, we'll write
-            //the warmup value when the trigger hits.
-            if (report_start_trigger_ == nullptr) {
-                db_header.setStringMetadata("warmup", "none");
-            }
-        });
-    }
-
     void doPostProcessing(
         simdb::AsyncTaskEval * task_queue,
         simdb::ObjectManager * sim_db)
@@ -542,29 +512,14 @@ private:
         this->initializeReportInstantiations_();
 
         if (needs_header_overwrite_) {
-            const utils::ValidValue<uint64_t> warmup_insts = getMaxInstRetired_();
             db::ReportHeader * db_header = desc_.getTimeseriesDatabaseHeader();
-            if (warmup_insts.isValid() && db_header != nullptr) {
-                //The timeseries database is featured off by default, but this
-                //writes the warmup inst value to a database record.
-                const std::string warmup_str =
-                    boost::lexical_cast<std::string>(warmup_insts);
-                db_header->setStringMetadata("warmup", warmup_str);
-
+            if (db_header != nullptr) {
                 sparta_assert(reports_.size() == 1);
                 if (reports_[0]->hasHeader()) {
                     auto & header = reports_[0]->getHeader();
                     const std::map<std::string, std::string> stringified = header.getAllStringified();
                     for (const auto & meta : stringified) {
                         db_header->setStringMetadata(meta.first, meta.second);
-                    }
-                }
-            } else if (warmup_insts.isValid()) {
-                //CSV report files go through the report::format::ReportHeader
-                for (auto &r : reports_) {
-                    if (r->hasHeader()) {
-                        auto & header = r->getHeader();
-                        header.set("warmup", warmup_insts.getValue());
                     }
                 }
             }
@@ -772,35 +727,12 @@ private:
 
     void setHeaderInfoForReports_()
     {
-        auto populate_header_content = [this](report::format::ReportHeader & header) {
-            if (report_start_trigger_ != nullptr) {
-                header.reservePlaceholder("warmup");
-            } else {
-                header.set("warmup", "none");
-            }
-
-            if (report_update_trigger_ != nullptr) {
-                header.set("period", report_update_trigger_->toString());
-            } else {
-                header.set("period", "none");
-            }
-
-            if (report_stop_trigger_ != nullptr) {
-                header.set("terminate", report_stop_trigger_->toString());
-            } else {
-                header.set("terminate", "none");
-            }
-
-            if (report_toggle_trigger_ != nullptr) {
-                header.set("enabled", report_toggle_trigger_->toString());
-            } else {
-                header.set("enabled", "none");
-            }
-        };
-
         for (auto & r : reports_) {
             auto & header = r->getHeader();
-            populate_header_content(header);
+
+            if (start_trigger_counter_.isValid()) {
+                header.set("counter", start_trigger_counter_.getValue()->getLocation());
+            }
 
             const auto header_metadata = getDescriptor().header_metadata_;
             for(auto [key, value] : header_metadata) {
@@ -1302,8 +1234,6 @@ private:
                 //Write any report trigger metadata into the header object
                 auto db_header = rd.getTimeseriesDatabaseHeader();
                 if (db_header) {
-                    dir.second->writeTriggerMetadata(*db_header);
-
                     //Simulation name is written as hidden metadata by
                     //by prefixing the name with "__"
                     db_header->setStringMetadata(


### PR DESCRIPTION
Added mechanism to specify metadata to include in report files. Also removed all implicitly added report header metadata except for the counter location.

**Example**
Report definition file:
```
header_metadata:
  period: %TS_PERIOD%
  warmup: %WARMUP_INSTS%
content:
  report:
    pattern: top 
    def_file: reports/crit_stats.yaml
    dest_file: %OUT_BASE%_time_series_crit.csv
    format: csv 
    trigger:
      start:  'core_complex.core.retire.stats.insts_retired >= %WARMUP_INSTS% -> post.WarmupTrigger'
      update-count: top.core_complex.core.retire.stats.insts_retired %TS_PERIOD%
```
Report header:
```
# counter=top.core_complex.core.retire.stats.insts_retired,period=10,warmup=29223
```

Closes #279 