### PR TITLE
Replaced boost::filesystem::extension() calls with path::extension()

### DIFF
--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -15,6 +15,7 @@
 #include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/iterator/iterator_facade.hpp>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
@@ -121,7 +122,7 @@ bool ReportDescriptor::isSingleTimeseriesReport() const
         return false;
     }
 
-    std::string extension = boost::filesystem::extension(dest_file);
+    std::string extension = std::filesystem::path(dest_file).extension();
     utils::lowercase_string ext(extension);
     return ext.getString() == ".csv";
 }
@@ -529,7 +530,7 @@ report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,
                                      run_metadata.begin(),
                                      run_metadata.end());
 
-            const std::string extension = boost::filesystem::extension(filename);
+            const std::string extension = std::filesystem::path(filename).extension();
             if (sim_config->getDisabledPrettyPrintFormats().count(extension)) {
                 formatter->disablePrettyPrint();
             }

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <ctime>
 #include <exception>
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -1959,10 +1960,9 @@ ReportDescVec Simulation::expandReportDescriptor_(const ReportDescriptor & rd) c
             expanded.format = fmt;
             auto underscore_idx = fmt.find("_");
             if (underscore_idx != std::string::npos) {
-                boost::filesystem::path dest_file_path(expanded.dest_file);
                 auto dot_idx = expanded.dest_file.find(".");
                 const std::string stem = expanded.dest_file.substr(0, dot_idx);
-                const std::string ext = boost::filesystem::extension(dest_file_path);
+                const std::string ext = std::filesystem::path(expanded.dest_file).extension();
                 expanded.dest_file = stem + fmt.substr(underscore_idx) + ext;
             }
             rds_out.emplace_back(expanded);


### PR DESCRIPTION
the macOS clang build was failing complaining about `boost::filesystem::extension()` being deprecated.