### PR TITLE
find script needs to export ALL include dirs needed to parse sparta headers

### DIFF
--- a/sparta/cmake/FindSparta.cmake
+++ b/sparta/cmake/FindSparta.cmake
@@ -66,8 +66,10 @@ if(NOT SPARTA_FOUND)
         set_property(TARGET SPARTA::libsimdb PROPERTY IMPORTED_LOCATION "${SPARTA_simdb_LIBRARY}")
 
         add_library(SPARTA::sparta INTERFACE IMPORTED)
+        # Workaround as per https://github.com/jbeder/yaml-cpp/issues/774#issuecomment-927357017
+        get_target_property(YAML_CPP_INCLUDE_DIR yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
         set_property(TARGET SPARTA::sparta
-          PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SPARTA_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIR} ${RapidJSON_INCLUDE_DIR})
+          PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SPARTA_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${SQLite3_INCLUDE_DIRS} ${HDF5_CXX_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIR} ${RapidJSON_INCLUDE_DIR} ${YAML_CPP_INCLUDE_DIR})
         set_property(TARGET SPARTA::sparta
           PROPERTY INTERFACE_LINK_LIBRARIES SPARTA::libsparta SPARTA::libsimdb HDF5::HDF5 SQLite::SQLite3
           Boost::filesystem Boost::serialization Boost::timer Boost::program_options


### PR DESCRIPTION
You won't see the issue if you always build with `target_link_libraries(<mytarget> SPARTA::sparta)`, but if you need include dirs separately, you need hdf5, sqlite3, boost and yaml-cpp headers to parse all sparta headers.

If every dependency is installed in a system default location (either by `apt install` or `conda install`) you probably won't have an issue, but if one or more dependency is in a weird non-standard location, this fix is needed.