### PR TITLE
Fix addition of osx_arm64

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'False'
         SHORT_CONFIG: osx_64_
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'False'
+        SHORT_CONFIG: osx_arm64_
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,0 +1,45 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.1'
+boost:
+- 1.78.0
+boost_cpp:
+- 1.78.0
+c_compiler:
+- clang
+c_compiler_version:
+- '15'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '15'
+hdf5:
+- 1.12.2
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.21'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+sqlite:
+- '3'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - python
+  - numpy
+zlib:
+- '1.2'

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,9 +10,12 @@ skip_render:
 provider:
   linux_64: circle
   osx_64: azure
+  osx_arm64: azure
   win: None
   linux_ppc64le: None
   linux_aarch64: None
+build_platform:
+  osx_arm64: osx_arm64
 azure:
   force: False
   upload_packages: False

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -58,18 +58,24 @@ cmake -DCMAKE_BUILD_TYPE=Release \
 df -h /
 cmake --build . -j "$CPU_COUNT" || cmake --build . -v
 df -h /
-cmake --build . -j "$CPU_COUNT" --target regress
-df -h /
-cmake --build . -j "$CPU_COUNT" --target simdb_regress
-df -h /
 
-# The example tests are built as a part of the toplevel 'regress'
-# target but they aren't run.  We have to explicitly run
-# by cd'ing into the example subdir and running ctest
-# because not all of the subdirs of example create their
-# own <subdir>_regress target like the core example.
-(cd example && CTEST_OUTPUT_ON_FAILURE=1 ctest -j "$CPU_COUNT" --test-action test)
-df -h /
+if [[ "$OSX_ARCH" != "arm64" ]]; then
+    # skip running tests on osx_arm64 because CI is cross-compiling and the
+    # tests don't have support for cross-executing on arm64
+
+    cmake --build . -j "$CPU_COUNT" --target regress
+    df -h /
+    cmake --build . -j "$CPU_COUNT" --target simdb_regress
+    df -h /
+
+    # The example tests are built as a part of the toplevel 'regress'
+    # target but they aren't run.  We have to explicitly run
+    # by cd'ing into the example subdir and running ctest
+    # because not all of the subdirs of example create their
+    # own <subdir>_regress target like the core example.
+    (cd example && CTEST_OUTPUT_ON_FAILURE=1 ctest -j "$CPU_COUNT" --test-action test)
+    df -h /
+fi
 
 # if we want to create individual packages this should move into a separate install script for only SPARTA
 # and we might want to create separate install targets for the headers and the libs and the doc


### PR DESCRIPTION
When I quickly adjusted #419 and pushed it, I broke the conda env creation scripts because I completely removed `.ci_support/osx_arm64_.yaml` when I removed `osx_arm64` from CI.  Instead of doing that, we need to leave `osx_arm64` in CI but change the build.sh to skip running the tests.  `osx_arm64` cross-compiles in CI, using an x86 host.  However we don't have the ability in our scripts to run the tests from x86 host targeting arm.

As I mentioned in https://github.com/sparcians/map/pull/419#issuecomment-1509867284, native arm64 executors are coming later this year and will resolve this problem.