### PR TITLE
Additional options for displaying tree nodes

### DIFF
--- a/sparta/sparta/app/CommandLineSimulator.hpp
+++ b/sparta/sparta/app/CommandLineSimulator.hpp
@@ -386,44 +386,44 @@ protected:
     bool no_show_config_ = false;
 
     /*!
-     * \brief Display the device tree at every opportunity
+     * \brief Bit field for displaying the device tree at every opportunity
      */
     uint32_t show_tree_ = 0;
 
     /*!
-     * \brief Display all parameters in the device tree after building
+     * \brief Bit field for displaying all parameters in the device tree after building
      */
     uint32_t show_parameters_ = 0;
 
     /*!
-     * \brief Display all ports in the device tree after finalization
+     * \brief Bit field for displaying all ports in the device tree after finalization
      */
     uint32_t show_ports_ = 0;
 
     /*!
-     * \brief Display all counters and stats in the device tree after
+     * \brief Bit field for displaying all counters and stats in the device tree after
      * finalization
      */
     uint32_t show_counters_ = 0;
 
     /*!
-     * \brief Display all the clocks in the tree
+     * \brief Bit field for displaying all the clocks in the tree
      */
     uint32_t show_clocks_ = 0;
 
     /*!
-     * \brief Display all the pevent types in the tree.
+     * \brief Display all the pevent types in the tree
      */
     bool show_pevents_ = false;
     /*!
-     * \brief Display all notifications in the device tree after finalization
-     * excluding log messages
+     * \brief Bit field for displaying all notifications in the device tree after 
+     * finalization, excluding log messages
      */
     uint32_t show_notifications_ = 0;
 
     /*!
-     * \brief Display all notifications in the device tree after finalization
-     * excluding log messages
+     * \brief Bit field for displaying all notifications in the device tree after
+     * finalization, excluding log messages
      */
     uint32_t show_loggers_ = 0;
 

--- a/sparta/sparta/app/CommandLineSimulator.hpp
+++ b/sparta/sparta/app/CommandLineSimulator.hpp
@@ -404,7 +404,7 @@ protected:
      * \brief Display all counters and stats in the device tree after
      * finalization
      */
-    bool show_counters_ = false;
+    uint32_t show_counters_ = 0;
 
     /*!
      * \brief Display all the clocks in the tree

--- a/sparta/sparta/app/CommandLineSimulator.hpp
+++ b/sparta/sparta/app/CommandLineSimulator.hpp
@@ -388,17 +388,17 @@ protected:
     /*!
      * \brief Display the device tree at every opportunity
      */
-    bool show_tree_ = false;
+    uint32_t show_tree_ = 0;
 
     /*!
      * \brief Display all parameters in the device tree after building
      */
-    bool show_parameters_ = false;
+    uint32_t show_parameters_ = 0;
 
     /*!
      * \brief Display all ports in the device tree after finalization
      */
-    bool show_ports_ = false;
+    uint32_t show_ports_ = 0;
 
     /*!
      * \brief Display all counters and stats in the device tree after
@@ -409,7 +409,7 @@ protected:
     /*!
      * \brief Display all the clocks in the tree
      */
-    bool show_clocks_ = false;
+    uint32_t show_clocks_ = 0;
 
     /*!
      * \brief Display all the pevent types in the tree.
@@ -419,13 +419,13 @@ protected:
      * \brief Display all notifications in the device tree after finalization
      * excluding log messages
      */
-    bool show_notifications_ = false;
+    uint32_t show_notifications_ = 0;
 
     /*!
      * \brief Display all notifications in the device tree after finalization
      * excluding log messages
      */
-    bool show_loggers_ = false;
+    uint32_t show_loggers_ = 0;
 
     /*!
      * \brief Show hidden treenodes when displaying the device tree

--- a/sparta/sparta/simulation/TreeNode.hpp
+++ b/sparta/sparta/simulation/TreeNode.hpp
@@ -411,16 +411,16 @@ namespace sparta
          */
         static const std::vector<std::pair<const char*, std::function<void (std::string&)>>> TREE_NODE_PATTERN_SUBS;
 
-	    /*!
-	     * \brief 
-	     *
-	     */
-	    enum CONTENTS_TO_OUTPUT
-	    {
+        /*!
+         * \brief Enum for creating and manipulating bitmasks, which in turn
+         * control what type(s) of information gets outputted. 
+        */
+        enum CONTENTS_TO_OUTPUT
+        {
             NAME,
             STRINGIZATION,
             DESCRIPTION,
-	    };
+        };
 
         ////////////////////////////////////////////////////////////////////////
         //! @}

--- a/sparta/sparta/simulation/TreeNode.hpp
+++ b/sparta/sparta/simulation/TreeNode.hpp
@@ -412,10 +412,10 @@ namespace sparta
         static const std::vector<std::pair<const char*, std::function<void (std::string&)>>> TREE_NODE_PATTERN_SUBS;
 
 	    /*!
-	    * \brief 
+	     * \brief 
 	     *
 	     */
-	    enum CONTENTS_FOR_OUTPUT
+	    enum CONTENTS_TO_OUTPUT
 	    {
             NAME,
             STRINGIZATION,

--- a/sparta/sparta/simulation/TreeNode.hpp
+++ b/sparta/sparta/simulation/TreeNode.hpp
@@ -411,6 +411,17 @@ namespace sparta
          */
         static const std::vector<std::pair<const char*, std::function<void (std::string&)>>> TREE_NODE_PATTERN_SUBS;
 
+	    /*!
+	    * \brief 
+	     *
+	     */
+	    enum CONTENTS_FOR_OUTPUT
+	    {
+            NAME,
+            STRINGIZATION,
+            DESCRIPTION,
+	    };
+
         ////////////////////////////////////////////////////////////////////////
         //! @}
 
@@ -1829,7 +1840,7 @@ namespace sparta
          */
         std::string renderSubtree(int32_t max_depth=-1,
                                   bool show_builtins=false,
-                                  bool names_only=false,
+                                  uint32_t enabled_contents=0,
                                   bool hide_hidden=false,
                                   bool(*leaf_filt_fxn)(const TreeNode*) = nullptr) const;
 
@@ -2419,7 +2430,7 @@ namespace sparta
                                 uint32_t indent,
                                 int32_t max_depth,
                                 bool show_builtins,
-                                bool names_only,
+                                uint32_t enabled_contents,
                                 bool hide_hidden,
                                 bool(*leaf_filt_fxn)(const TreeNode*)) const;
 

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -237,6 +237,13 @@ CommandLineSimulator::CommandLineSimulator(const std::string& usage,
          "Sets --no-run and shows the pevents types in the model after finalization. "
          )
 
+        ("describe-counters",
+         "Sets --no-run and shows the device tree Counters, Statistics, and other instrumentation "
+         "after finalization. Shown in a separate tree printout from all other --show-* parameters")
+
+        ("name-counters",
+         "Sets --no-run and shows the device tree Counters, Statistics, and other instrumentation "
+         "after finalization. Shown in a separate tree printout from all other --show-* parameters")
 
         // Validation & Debug
         ("validate-post-run",
@@ -1763,7 +1770,7 @@ bool CommandLineSimulator::parse(int argc,
     show_tree_ = vm_.count("show-tree") > 0;
     show_parameters_ = vm_.count("show-parameters") > 0;
     show_ports_ = vm_.count("show-ports") > 0;
-    show_counters_ = vm_.count("show-counters") > 0 || vm_.count("show-stats");
+    show_counters_ = (vm_.count("show-counters") > 0 || vm_.count("show-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::STRINGIZATION;
     show_clocks_ = vm_.count("show-clocks") > 0;
     show_notifications_ = vm_.count("show-notifications") > 0;
     show_loggers_ = vm_.count("show-loggers") > 0;
@@ -1777,7 +1784,7 @@ bool CommandLineSimulator::parse(int argc,
     show_ports_ |= vm_.count("help-ports") > 0;
     no_run_mode_ |= vm_.count("help-ports") > 0;
     // help-counters
-    show_counters_ |= vm_.count("help-counters") > 0 || vm_.count("help-stats");
+    show_counters_ |= (vm_.count("help-counters") > 0 || vm_.count("help-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-counters") > 0;
     // help-notifications
     show_notifications_ |= vm_.count("help-notifications") > 0;
@@ -1791,6 +1798,13 @@ bool CommandLineSimulator::parse(int argc,
     // help-pevents
     show_pevents_ |= vm_.count("help-pevents") > 0;
     no_run_mode_ |= vm_.count("help-pevents") > 0;
+    // describe-counters
+    show_counters_ |= (vm_.count("describe-counters") > 0 || vm_.count("describe-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-counters") > 0;
+    // name-counters
+    show_counters_ |= (vm_.count("name-counters") > 0 || vm_.count("name-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-counters") > 0;
+
 
     show_hidden_ = vm_.count("show-hidden") > 0;
     if(show_hidden_){
@@ -2208,7 +2222,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nCounters (After Finalization):" << std::endl;
             std::cout << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                          true,
-                                                                         false,
+                                                                         show_counters_,
                                                                          !show_hidden_,
                                                                          filter_counters);
         }

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -237,13 +237,27 @@ CommandLineSimulator::CommandLineSimulator(const std::string& usage,
          "Sets --no-run and shows the pevents types in the model after finalization. "
          )
 
+        ("describe-tree","")
+        ("describe-parameters","")
+        ("describe-ports","")
         ("describe-counters",
          "Sets --no-run and shows the device tree Counters, Statistics, and other instrumentation "
          "after finalization. Shown in a separate tree printout from all other --show-* parameters")
+        ("describe-stats","")
+        ("describe-notifications","")
+        ("describe-loggers","")
+        ("describe-clocks","")
 
+        ("name-tree","")
+        ("name-parameters","")
+        ("name-ports","")
         ("name-counters",
          "Sets --no-run and shows the device tree Counters, Statistics, and other instrumentation "
          "after finalization. Shown in a separate tree printout from all other --show-* parameters")
+        ("name-stats","")
+        ("name-notifications","")
+        ("name-loggers","")
+        ("name-clocks","")
 
         // Validation & Debug
         ("validate-post-run",
@@ -1767,43 +1781,81 @@ bool CommandLineSimulator::parse(int argc,
                     << "'. This should have been caught during parsing");
     }
 
-    show_tree_ = vm_.count("show-tree") > 0;
-    show_parameters_ = vm_.count("show-parameters") > 0;
-    show_ports_ = vm_.count("show-ports") > 0;
-    show_counters_ = (vm_.count("show-counters") > 0 || vm_.count("show-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::STRINGIZATION;
-    show_clocks_ = vm_.count("show-clocks") > 0;
-    show_notifications_ = vm_.count("show-notifications") > 0;
-    show_loggers_ = vm_.count("show-loggers") > 0;
+    show_tree_ = (vm_.count("show-tree") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
+    show_parameters_ = (vm_.count("show-parameters") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
+    show_ports_ = (vm_.count("show-ports") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
+    show_counters_ = (vm_.count("show-counters") > 0 || vm_.count("show-stats")) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
+    show_clocks_ = (vm_.count("show-clocks") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
+    show_notifications_ = (vm_.count("show-notifications") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
+    show_loggers_ = (vm_.count("show-loggers") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     // help-tree
-    show_tree_ |= vm_.count("help-tree") > 0;
+    show_tree_ |= (vm_.count("help-tree") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-tree") > 0;
     // help-parameters
-    show_parameters_ |= vm_.count("help-parameters") > 0;
+    show_parameters_ |= (vm_.count("help-parameters") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-parameters") > 0;
     // help-ports
-    show_ports_ |= vm_.count("help-ports") > 0;
+    show_ports_ |= (vm_.count("help-ports") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-ports") > 0;
     // help-counters
-    show_counters_ |= (vm_.count("help-counters") > 0 || vm_.count("help-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::STRINGIZATION;
+    show_counters_ |= (vm_.count("help-counters") > 0 || vm_.count("help-stats")) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-counters") > 0;
     // help-notifications
-    show_notifications_ |= vm_.count("help-notifications") > 0;
+    show_notifications_ |= (vm_.count("help-notifications") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-notifications") > 0;
     // help-loggers
-    show_loggers_ |= vm_.count("help-loggers") > 0;
+    show_loggers_ |= (vm_.count("help-loggers") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-loggers") > 0;
     // help-clocks
-    show_clocks_ |= vm_.count("help-clocks") > 0;
+    show_clocks_ |= (vm_.count("help-clocks") > 0) << TreeNode::CONTENTS_TO_OUTPUT::STRINGIZATION;
     no_run_mode_ |= vm_.count("help-clocks") > 0;
     // help-pevents
     show_pevents_ |= vm_.count("help-pevents") > 0;
     no_run_mode_ |= vm_.count("help-pevents") > 0;
+
+    // describe-tree
+    show_tree_ |= (vm_.count("describe-tree") > 0) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-tree") > 0;
+    // describe-parameters
+    show_parameters_ |= (vm_.count("describe-parameters") > 0) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-parameters") > 0;
+    // describe-ports
+    show_ports_ |= (vm_.count("describe-ports") > 0) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-ports") > 0;
     // describe-counters
-    show_counters_ |= (vm_.count("describe-counters") > 0 || vm_.count("describe-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::DESCRIPTION;
+    show_counters_ |= (vm_.count("describe-counters") > 0 || vm_.count("describe-stats")) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
     no_run_mode_ |= vm_.count("describe-counters") > 0;
+    // describe-notifications
+    show_notifications_ |= (vm_.count("describe-notifications") > 0) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-notifications") > 0;
+    // describe-loggers
+    show_loggers_ |= (vm_.count("describe-loggers") > 0) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-loggers") > 0;
+    // describe-clocks
+    show_clocks_ |= (vm_.count("describe-clocks") > 0) << TreeNode::CONTENTS_TO_OUTPUT::DESCRIPTION;
+    no_run_mode_ |= vm_.count("describe-clocks") > 0;
+
+    // name-tree
+    show_tree_ |= (vm_.count("name-tree") > 0) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-tree") > 0;
+    // name-parameters
+    show_parameters_ |= (vm_.count("name-parameters") > 0) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-parameters") > 0;
+    // name-ports
+    show_ports_ |= (vm_.count("name-ports") > 0) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-ports") > 0;
     // name-counters
-    show_counters_ |= (vm_.count("name-counters") > 0 || vm_.count("name-stats")) << TreeNode::CONTENTS_FOR_OUTPUT::NAME;
+    show_counters_ |= (vm_.count("name-counters") > 0 || vm_.count("name-stats")) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
     no_run_mode_ |= vm_.count("name-counters") > 0;
+    // name-notifications
+    show_notifications_ |= (vm_.count("name-notifications") > 0) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-notifications") > 0;
+    // name-loggers
+    show_loggers_ |= (vm_.count("name-loggers") > 0) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-loggers") > 0;
+    // name-clocks
+    show_clocks_ |= (vm_.count("name-clocks") > 0) << TreeNode::CONTENTS_TO_OUTPUT::NAME;
+    no_run_mode_ |= vm_.count("name-clocks") > 0;
 
 
     show_hidden_ = vm_.count("show-hidden") > 0;
@@ -2018,7 +2070,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nBuilt Tree:" << std::endl;
             std::cout << sim->getRoot()->renderSubtree(-1,
                                                        true,
-                                                       false,
+                                                       show_tree_,
                                                        !show_hidden_);
         }
 
@@ -2027,7 +2079,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nConfigured Tree:" << std::endl;
             std::cout << sim->getRoot()->renderSubtree(-1,
                                                        true,
-                                                       false,
+                                                       show_tree_,
                                                        !show_hidden_);
         }
 
@@ -2038,7 +2090,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nParameters (After Configuration):" << std::endl;
             std::cout << sim->getRoot()->renderSubtree(-1,
                                                        true,
-                                                       false,
+                                                       show_parameters_,
                                                        !show_hidden_,
                                                        filter_parameters);
         }
@@ -2177,7 +2229,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nFinalized Tree" << std::endl;
             std::cout << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                          true,
-                                                                         false,
+                                                                         show_tree_,
                                                                          !show_hidden_);
         }
 
@@ -2208,7 +2260,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nPorts (After Finalization):" << std::endl;
             std::cout << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                          true,
-                                                                         false,
+                                                                         show_ports_,
                                                                          !show_hidden_,
                                                                          filter_ports);
         }
@@ -2234,7 +2286,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nClocks (After Finalization):" << std::endl;
             std::cout << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                          true,
-                                                                         false,
+                                                                         show_clocks_,
                                                                          !show_hidden_,
                                                                          filter_clocks);
         }
@@ -2252,7 +2304,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nNotifications (After Finalization):" << std::endl;
             std::cout << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                          true,
-                                                                         false,
+                                                                         show_notifications_,
                                                                          !show_hidden_,
                                                                          filter_notis);
         }
@@ -2265,7 +2317,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
             std::cout << "\nLoggers (After Finalization):" << std::endl;
             std::cout << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                          true,
-                                                                         false,
+                                                                         show_loggers_,
                                                                          !show_hidden_,
                                                                          filter_loggers);
         }
@@ -2282,7 +2334,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
                 << std::endl
                 << sim->getRoot()->getSearchScope()->renderSubtree(-1,
                                                                    true,
-                                                                   false,
+                                                                   show_tree_,
                                                                    !show_hidden_);
         }else{
             std::cerr << "\nTo display the device tree here, run with --show-tree" << std::endl;
@@ -2371,7 +2423,7 @@ void CommandLineSimulator::runSimulator_(Simulation* sim, uint64_t ticks)
 
     if(show_tree_){
         std::cout << "\nTree After Running" << std::endl
-                  << sim->getRoot()->renderSubtree(-1, true, false, !show_hidden_)
+                  << sim->getRoot()->renderSubtree(-1, true, show_tree_, !show_hidden_)
                   << std::endl;
     }
 }

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -237,27 +237,23 @@ CommandLineSimulator::CommandLineSimulator(const std::string& usage,
          "Sets --no-run and shows the pevents types in the model after finalization. "
          )
 
-        ("describe-tree","")
-        ("describe-parameters","")
-        ("describe-ports","")
-        ("describe-counters",
-         "Sets --no-run and shows the device tree Counters, Statistics, and other instrumentation "
-         "after finalization. Shown in a separate tree printout from all other --show-* parameters")
-        ("describe-stats","")
-        ("describe-notifications","")
-        ("describe-loggers","")
-        ("describe-clocks","")
+        ("describe-tree","Same as --help-tree, but prints descriptions instead.")
+        ("describe-parameters","Same as --help-parameters, but prints descriptions instead.")
+        ("describe-ports","Same as --help-ports, but prints descriptions instead.")
+        ("describe-counters","Same as --help-counters, but prints descriptions instead.")
+        ("describe-stats","Same as --help-stats, but prints descriptions instead.")
+        ("describe-notifications","Same as --help-notifications, but prints descriptions instead.")
+        ("describe-loggers","Same as --help-loggers, but prints descriptions instead.")
+        ("describe-clocks","Same as --help-clocks, but prints descriptions instead.")
 
-        ("name-tree","")
-        ("name-parameters","")
-        ("name-ports","")
-        ("name-counters",
-         "Sets --no-run and shows the device tree Counters, Statistics, and other instrumentation "
-         "after finalization. Shown in a separate tree printout from all other --show-* parameters")
-        ("name-stats","")
-        ("name-notifications","")
-        ("name-loggers","")
-        ("name-clocks","")
+        ("name-tree","Same as --help-tree, but only prints names.")
+        ("name-parameters","Same as --help-parameters, but only prints names.")
+        ("name-ports","Same as --help-ports, but only prints names.")
+        ("name-counters","Same as --help-counters, but only prints names.")
+        ("name-stats","Same as --help-stats, but only prints names.")
+        ("name-notifications","Same as --help-notifications, but only prints names.")
+        ("name-loggers","Same as --help-loggers, but only prints names.")
+        ("name-clocks","Same as --help-clocks, but only prints names.")
 
         // Validation & Debug
         ("validate-post-run",
@@ -1911,14 +1907,14 @@ bool CommandLineSimulator::parse(int argc,
         std::cout << "  debug-sim:           " << std::boolalpha << sim_config_.debug_sim << std::endl;
         std::cout << "  report-on-error:     " << std::boolalpha << sim_config_.report_on_error << std::endl;
         std::cout << std::endl;
-        std::cout << "  show-tree:           " << std::boolalpha << show_tree_ << std::endl;
-        std::cout << "  show-parameters:     " << std::boolalpha << show_parameters_ << std::endl;
-        std::cout << "  show-ports:          " << std::boolalpha << show_ports_ << std::endl;
-        std::cout << "  show-counters/stats: " << std::boolalpha << show_counters_ << std::endl;
-        std::cout << "  show-clocks:         " << std::boolalpha << show_clocks_ << std::endl;
+        std::cout << "  show-tree:           " << std::boolalpha << static_cast<bool>(show_tree_) << std::endl;
+        std::cout << "  show-parameters:     " << std::boolalpha << static_cast<bool>(show_parameters_) << std::endl;
+        std::cout << "  show-ports:          " << std::boolalpha << static_cast<bool>(show_ports_) << std::endl;
+        std::cout << "  show-counters/stats: " << std::boolalpha << static_cast<bool>(show_counters_) << std::endl;
+        std::cout << "  show-clocks:         " << std::boolalpha << static_cast<bool>(show_clocks_) << std::endl;
         std::cout << "  show-pevents:        " << std::boolalpha << show_pevents_ << std::endl;
-        std::cout << "  show-notifications:  " << std::boolalpha << show_notifications_ << std::endl;
-        std::cout << "  show-loggers:        " << std::boolalpha << show_loggers_ << std::endl;
+        std::cout << "  show-notifications:  " << std::boolalpha << static_cast<bool>(show_notifications_) << std::endl;
+        std::cout << "  show-loggers:        " << std::boolalpha << static_cast<bool>(show_loggers_) << std::endl;
         std::cout << "  no-colors:           " << std::boolalpha << disable_colors_ << std::endl;
         if(show_hidden_ == true){
             std::cout << " (show-hidden on)";

--- a/sparta/src/TreeNode.cpp
+++ b/sparta/src/TreeNode.cpp
@@ -1957,9 +1957,9 @@ uint32_t TreeNode::renderSubtree_(std::stringstream& ss,
     ss << SPARTA_CURRENT_COLOR_NORMAL;
 
     if(enabled_contents){
-        if(enabled_contents & (1U << CONTENTS_FOR_OUTPUT::DESCRIPTION))
+        if(enabled_contents & (1U << CONTENTS_TO_OUTPUT::DESCRIPTION))
             ss << " : " << getDesc();
-        if(enabled_contents & (1U << CONTENTS_FOR_OUTPUT::STRINGIZATION))
+        if(enabled_contents & (1U << CONTENTS_TO_OUTPUT::STRINGIZATION))
             ss << " : " << stringize();
     }
 

--- a/sparta/src/TreeNode.cpp
+++ b/sparta/src/TreeNode.cpp
@@ -1350,7 +1350,7 @@ std::string TreeNode::getDisplayLocation() const {
 
 std::string TreeNode::renderSubtree(int32_t max_depth,
                                     bool show_builtins,
-                                    bool names_only,
+                                    uint32_t enabled_contents,
                                     bool hide_hidden,
                                     bool(*leaf_filt_fxn)(const TreeNode*)) const {
     std::stringstream ss;
@@ -1358,7 +1358,7 @@ std::string TreeNode::renderSubtree(int32_t max_depth,
                    0,
                    max_depth,
                    show_builtins,
-                   names_only,
+                   enabled_contents,
                    hide_hidden,
                    leaf_filt_fxn);
     return ss.str();
@@ -1883,7 +1883,7 @@ uint32_t TreeNode::renderSubtree_(std::stringstream& ss,
                                   uint32_t indent,
                                   int32_t max_depth,
                                   bool show_builtins,
-                                  bool names_only,
+                                  uint32_t enabled_contents,
                                   bool hide_hidden,
                                   bool(*leaf_filt_fxn)(const TreeNode*)) const {
     if(isBuiltin() && !show_builtins){
@@ -1906,7 +1906,7 @@ uint32_t TreeNode::renderSubtree_(std::stringstream& ss,
                                       indent + RENDER_SUBTREE_INDENT,
                                       max_depth-1,
                                       show_builtins,
-                                      names_only,
+                                      enabled_contents,
                                       hide_hidden,
                                       leaf_filt_fxn);
         }
@@ -1956,8 +1956,11 @@ uint32_t TreeNode::renderSubtree_(std::stringstream& ss,
     // Restore to normal coloring for rest of line
     ss << SPARTA_CURRENT_COLOR_NORMAL;
 
-    if(!names_only){
-        ss << " : " << stringize();
+    if(enabled_contents){
+        if(enabled_contents & (1U << CONTENTS_FOR_OUTPUT::DESCRIPTION))
+            ss << " : " << getDesc();
+        if(enabled_contents & (1U << CONTENTS_FOR_OUTPUT::STRINGIZATION))
+            ss << " : " << stringize();
     }
 
     if(isBuiltin()){


### PR DESCRIPTION
Hi. This is a PR to add the capability of displaying different contents during tree renders. I know the code is probably not very pretty (sorry in advance), so I would love to get some feedback. (any feedback, really).  

In short, every option in the form of `--help-XXX` (except `--help-pevents`) now has two alternatives, `--describe-XXX` and `--name-XXX`.
For example, while we already have `--help-counters` which displays every counter and their string representations, we now have:

1. `--describe-counters` : which displays **descriptions** of the counters along with their name.
example output : 
```
| | | +-retire : Retire Unit (privacy: 0)
| | | | +-stats : Statistic and Counter Set {builtin} (privacy: 0)
| | | | | +-insts_retired : Number of instructions retired (privacy: 0)
| | | | | +-actual_insts_retired : Number of instructions retired by hardware (privacy: 0)
| | | | | +-virtual_insts_retired : Number of virtual instructions retired (a.k.a. uops) (privacy: 0)
| | | | | +-uops_retired : Number of uops retired (privacy: 0)
| | | | | +-rob_entries_retired : Number of ROB entries retired (privacy: 0)
```
2. `--name-counters` : which displays only counter names and nothing more.
```
| | | +-retire (privacy: 0)                                                                                                                         
| | | | +-stats {builtin} (privacy: 0)                                                                                                              
| | | | | +-insts_retired (privacy: 0)                                                                                                              
| | | | | +-actual_insts_retired (privacy: 0)                                                                                                       
| | | | | +-virtual_insts_retired (privacy: 0)                                                                                                      
| | | | | +-uops_retired (privacy: 0)                                                                                                               
| | | | | +-rob_entries_retired (privacy: 0)     
```  
Also, to not mess with anyone's established workflow, changes are made deliberately to allow all existing options to work the way they previously did.