### PR TITLE
Add debug-roi option support for pipeline collection

### DIFF
--- a/sparta/sparta/app/AppTriggers.hpp
+++ b/sparta/sparta/app/AppTriggers.hpp
@@ -139,7 +139,6 @@ private:
     const bool multiple_triggers_;
     sparta::Clock * clk_;
     sparta::RootTreeNode * root_;
-    bool triggered_ = false;
     uint32_t num_collections_ = 0;
 };
 

--- a/sparta/sparta/app/AppTriggers.hpp
+++ b/sparta/sparta/app/AppTriggers.hpp
@@ -32,15 +32,17 @@ public:
     PipelineTrigger(const std::string& pipeline_collection_path,
                     const std::set<std::string>& pipeline_enabled_node_names,
                     uint64_t pipeline_heartbeat,
+                    bool multiple_triggers,
                     sparta::Clock * clk, sparta::RootTreeNode * rtn) :
         pipeline_collection_path_(pipeline_collection_path),
         pipeline_enabled_node_names_(pipeline_enabled_node_names),
         pipeline_heartbeat_(pipeline_heartbeat),
+        multiple_triggers_(multiple_triggers),
         clk_(clk),
         root_(rtn)
     {
         pipeline_collector_.
-            reset(new sparta::collection::PipelineCollector(pipeline_collection_path_,
+            reset(new sparta::collection::PipelineCollector(multiple_triggers_ ? getCollectionPath_() : pipeline_collection_path_,
                                                             pipeline_heartbeat_,
                                                             clk_,
                                                             root_));
@@ -49,10 +51,33 @@ public:
 
     void go() override
     {
+        sparta_assert(!triggered_, "Why has pipeline trigger been triggered?");
         triggered_ = true;
         std::cout << "Pipeline collection started, output to files with prefix '"
                   << pipeline_collector_->getFilePath() << "'" << std::endl;
+        startCollection_();
 
+        if(multiple_triggers_) {
+            std::cout << "#" << num_collections_ << " pipeline collection started" << std::endl;
+        }
+    }
+
+    void stop() override
+    {
+        sparta_assert(triggered_, "Why stop an inactivated trigger?");
+        triggered_ = false;
+        stopCollection_();
+
+        if(multiple_triggers_) {
+            std::cout << "#" << num_collections_ << " pipeline collection ended" << std::endl;
+            ++num_collections_;
+            pipeline_collector_->reactivate(getCollectionPath_());
+        }
+    }
+
+private:
+    void startCollection_()
+    {
         if(pipeline_enabled_node_names_.empty()) {
             // Start collection at the root node
             pipeline_collector_->startCollection(root_);
@@ -78,76 +103,23 @@ public:
         }
     }
 
-    void stop() override
+    void stopCollection_()
     {
-        if(triggered_) {
-            if(pipeline_enabled_node_names_.empty()) {
-                // Start collection at the root node
-                pipeline_collector_->stopCollection(root_);
-            }
-            else {
-                // Find the nodes in the root and enable them
-                for(const auto & node_name : pipeline_enabled_node_names_) {
-                    std::vector<TreeNode*> results;
-                    root_->getSearchScope()->findChildren(node_name, results);
-                    for(auto & tn : results) {
-                        pipeline_collector_->stopCollection(tn);
-                    }
-                }
-            }
-            pipeline_collector_->destroy();
-        }
-        triggered_ = false;
-    }
-
-protected:
-
-    std::unique_ptr<collection::PipelineCollector> pipeline_collector_;
-    const std::string pipeline_collection_path_;
-    const std::set<std::string> pipeline_enabled_node_names_;
-    const uint64_t pipeline_heartbeat_;
-    sparta::Clock * clk_;
-    sparta::RootTreeNode * root_;
-    bool triggered_ = false;
-};
-
-class PipelineNotifSrcTrigger : public PipelineTrigger
-{
-public:
-    PipelineNotifSrcTrigger(const std::string& notif_src_name,
-                            const std::string& pipeline_collection_path,
-                            const std::set<std::string>& pipeline_enabled_node_names,
-                            uint64_t pipeline_heartbeat,
-                            sparta::Clock * clk, sparta::RootTreeNode * rtn) :
-        PipelineTrigger(pipeline_collection_path,
-                        pipeline_enabled_node_names,
-                        pipeline_heartbeat,
-                        clk, rtn)
-    {
-        pipeline_collector_.
-                reset(new sparta::collection::PipelineCollector(getCollectionPath_(),
-                                                                pipeline_heartbeat_,
-                                                                clk_,
-                                                                root_));
-        rtn->getRoot()->REGISTER_FOR_NOTIFICATION(onReportTriggered_, uint64_t, notif_src_name);
-    }
-
-private:
-
-    void onReportTriggered_(const uint64_t & trigger)
-    {
-        sparta_assert(triggered_ ^ trigger, "Trigger has to be different from the current state");
-
-        if(triggered_) {
-            std::cout << "#" << num_collections_ << " pipeline collection ended" << std::endl;
-            stop();
-            ++num_collections_;
-            pipeline_collector_->reactivate(getCollectionPath_());
+        if(pipeline_enabled_node_names_.empty()) {
+            // Start collection at the root node
+            pipeline_collector_->stopCollection(root_);
         }
         else {
-            std::cout << "#" << num_collections_ << " pipeline collection started" << std::endl;
-            go();
+            // Find the nodes in the root and enable them
+            for(const auto & node_name : pipeline_enabled_node_names_) {
+                std::vector<TreeNode*> results;
+                root_->getSearchScope()->findChildren(node_name, results);
+                for(auto & tn : results) {
+                    pipeline_collector_->stopCollection(tn);
+                }
+            }
         }
+        pipeline_collector_->destroy();
     }
 
     std::string getCollectionPath_() const
@@ -160,6 +132,14 @@ private:
         }
     }
 
+    std::unique_ptr<collection::PipelineCollector> pipeline_collector_;
+    const std::string pipeline_collection_path_;
+    const std::set<std::string> pipeline_enabled_node_names_;
+    const uint64_t pipeline_heartbeat_;
+    const bool multiple_triggers_;
+    sparta::Clock * clk_;
+    sparta::RootTreeNode * root_;
+    bool triggered_ = false;
     uint32_t num_collections_ = 0;
 };
 

--- a/sparta/sparta/app/AppTriggers.hpp
+++ b/sparta/sparta/app/AppTriggers.hpp
@@ -137,8 +137,8 @@ private:
     const std::set<std::string> pipeline_enabled_node_names_;
     const uint64_t pipeline_heartbeat_;
     const bool multiple_triggers_;
-    sparta::Clock * clk_;
-    sparta::RootTreeNode * root_;
+    sparta::Clock * clk_ = nullptr;
+    sparta::RootTreeNode * root_ = nullptr;
     uint32_t num_collections_ = 0;
 };
 

--- a/sparta/sparta/app/CommandLineSimulator.hpp
+++ b/sparta/sparta/app/CommandLineSimulator.hpp
@@ -460,11 +460,6 @@ protected:
     std::unique_ptr<sparta::InformationWriter>    info_out_;
 
     /*!
-     * \brief Is pipeline collection enabled for ROIs?
-     */
-    bool use_roi_pipeline_collection_ = false;
-
-    /*!
      * \brief Heartbeat period of pipeline collection file (before lexical cast
      * or validation)
      */

--- a/sparta/sparta/app/CommandLineSimulator.hpp
+++ b/sparta/sparta/app/CommandLineSimulator.hpp
@@ -460,6 +460,11 @@ protected:
     std::unique_ptr<sparta::InformationWriter>    info_out_;
 
     /*!
+     * \brief Is pipeline collection enabled for ROIs?
+     */
+    bool use_roi_pipeline_collection_ = false;
+
+    /*!
      * \brief Heartbeat period of pipeline collection file (before lexical cast
      * or validation)
      */

--- a/sparta/sparta/app/SimulationConfiguration.hpp
+++ b/sparta/sparta/app/SimulationConfiguration.hpp
@@ -532,7 +532,8 @@ public:
     enum class TriggerSource {
         TRIGGER_ON_NONE = 0,
         TRIGGER_ON_CYCLE,
-        TRIGGER_ON_INSTRUCTION
+        TRIGGER_ON_INSTRUCTION,
+        TRIGGER_ON_ROI
     };
 
     /*!

--- a/sparta/sparta/collection/PipelineCollector.hpp
+++ b/sparta/sparta/collection/PipelineCollector.hpp
@@ -121,7 +121,9 @@ namespace collection
 
             void enable(CollectableTreeNode * ctn) {
                 enabled_ctns_.insert(ctn);
-                ev_collect_->schedule(sparta::Clock::Cycle(0));
+                // Schedule collect event in the next cycle in case
+                // this is called in an unavailable pphase.
+                ev_collect_->schedule(sparta::Clock::Cycle(1));
             }
 
             void disable(CollectableTreeNode * ctn) {

--- a/sparta/sparta/collection/PipelineCollector.hpp
+++ b/sparta/sparta/collection/PipelineCollector.hpp
@@ -293,9 +293,9 @@ namespace collection
             // XXX This is a little goofy looking.  Should we make sparta_abort that takes conditional
             //    be sparta_abort_unless()?
             sparta_abort(collection_active_ != true,
-               "The PipelineCollector was not torn down properly. Before "
-               "tearing down the simulation tree, you must call "
-               "destroy() on the collector");
+                         "The PipelineCollector was not torn down properly. Before "
+                         "tearing down the simulation tree, you must call "
+                         "destroy() on the collector");
         }
 
         /*!
@@ -317,6 +317,13 @@ namespace collection
             registered_collectables_.clear();
             writer_.reset();
             collection_active_ = false;
+        }
+
+        void reactivate(const std::string& filepath)
+        {
+            sparta_assert(!collection_active_,
+                          "You can only reactivate the PipelineCollector after you destroy it");
+            filepath_ = filepath;
         }
 
         /**

--- a/sparta/sparta/pevents/PeventCollector.hpp
+++ b/sparta/sparta/pevents/PeventCollector.hpp
@@ -114,8 +114,8 @@ namespace pevents{
                 bool is_unique = true;
                 for(const auto& existing_tap : taps_)
                 {
-                    if(existing_tap->getDestination()->compareStrings(file) && (existing_tap->getCategoryName() == lowertype
-                                                                 || lowertype == "all"))
+                    if(existing_tap->getDestination()->compareStrings(file) &&
+                       (existing_tap->getCategoryName() == lowertype || lowertype == "all"))
                     {
                         is_unique = false;
                         break;

--- a/sparta/sparta/trigger/RegionOfInterest.hpp
+++ b/sparta/sparta/trigger/RegionOfInterest.hpp
@@ -1,0 +1,20 @@
+// <RegionOfInterest.hpp> -*- C++ -*-
+
+/**
+ * \file RegionOfInterest.hpp
+ * \brief Types and variables defined for ROI usage
+ */
+#pragma once
+
+namespace sparta
+{
+    namespace roi
+    {
+        enum Triggers : uint64_t {
+            STOP = 0,
+            START = 1
+        };
+
+        static const std::string NOTIFICATION_SRC_NAME = "roi_start_stop";
+    }
+}

--- a/sparta/sparta/trigger/Trigger.hpp
+++ b/sparta/sparta/trigger/Trigger.hpp
@@ -8,6 +8,7 @@
 
 #include "sparta/trigger/Triggerable.hpp"
 #include "sparta/trigger/SingleTrigger.hpp"
+#include "sparta/trigger/RegionOfInterest.hpp"
 #include "sparta/simulation/Clock.hpp"
 #include "sparta/events/Event.hpp"
 #include "sparta/utils/Colors.hpp"
@@ -185,6 +186,16 @@ public:
     }
 
     /**
+     * \brief set up the NotificationSource, instead of using triggers
+     * \param node TreeNode to set
+     * \param notif_src_name Notification source name to drive trigger
+     */
+    void setTriggerNotificationDriven(RootTreeNode * node, const std::string & notif_src_name)
+    {
+        node->REGISTER_FOR_NOTIFICATION(onNotificationPosted_, roi::Triggers, notif_src_name);
+    }
+
+    /**
      * \brief print out the details about this trigger.
      */
     void print(std::ostream& o) const
@@ -320,6 +331,24 @@ private:
         }
         //We deactivate any repeat triggers from accuring after this stop.
         triggers_[REPEAT]->deactivate();
+    }
+
+    void onNotificationPosted_(const roi::Triggers & trigger)
+    {
+        if(trigger == roi::START)
+        {
+            for(Triggerable* obj : triggered_objs_)
+            {
+                obj->go();
+            }
+        }
+        else if(trigger == roi::STOP)
+        {
+           for(Triggerable* obj : triggered_objs_)
+            {
+                obj->stop();
+            }
+        }
     }
 
     std::vector<Triggerable*> triggered_objs_;

--- a/sparta/sparta/trigger/Triggerable.hpp
+++ b/sparta/sparta/trigger/Triggerable.hpp
@@ -34,6 +34,12 @@ public:
 
     //! The method to call on periodic repeats of the trigger.
     virtual void repeat() {}
+
+    //! Has been triggered?
+    bool isTriggered() const { return triggered_; }
+
+protected:
+    bool triggered_;
 };
 
     }// namespace trigger

--- a/sparta/sparta/trigger/Triggerable.hpp
+++ b/sparta/sparta/trigger/Triggerable.hpp
@@ -39,7 +39,7 @@ public:
     bool isTriggered() const { return triggered_; }
 
 protected:
-    bool triggered_;
+    bool triggered_ = false;
 };
 
     }// namespace trigger

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -68,6 +68,7 @@
 #include "sparta/pevents/PeventTrigger.hpp"
 #include "sparta/trigger/Trigger.hpp"
 #include "sparta/trigger/Triggerable.hpp"
+#include "sparta/trigger/RegionOfInterest.hpp"
 #include "sparta/utils/Printing.hpp"
 #include "sparta/utils/SmartLexicalCast.hpp"
 
@@ -2091,7 +2092,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
         if(sim_config_.pipeline_collection_file_prefix != NoPipelineCollectionStr)
         {
             if(use_roi_pipeline_collection_) {
-                pipeline_collection_triggerable_.reset(new PipelineNotifSrcTrigger("roi_start_stop",
+                pipeline_collection_triggerable_.reset(new PipelineNotifSrcTrigger(roi::NOTIFICATION_SRC_NAME,
                                                                                    sim_config_.pipeline_collection_file_prefix,
                                                                                    pipeline_enabled_node_names_,
                                                                                    heartbeat,

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -2144,7 +2144,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
                 debug_trigger_->addTriggeredObject(pevent_trigger_.get());
             }
 
-            // Pipeline trigger.
+            // Pipeline trigger
             if(pipeline_collection_triggerable_) {
                 debug_trigger_->addTriggeredObject(pipeline_collection_triggerable_.get());
             }
@@ -2180,7 +2180,8 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
                     try{
                         debug_trigger_->setTriggerNotificationDriven(sim->getRoot(), roi::NOTIFICATION_SRC_NAME);
                     }catch(SpartaException& ex) {
-                        std::cerr << "\nTo use debug-roi option, users have to register notification source for ROI" << std::endl;
+                        std::cerr << "\nTo use debug-roi option, users have to register notification source \""
+                                  << roi::NOTIFICATION_SRC_NAME << "\"" << std::endl;
                         std::cerr << "\n\n" SPARTA_CMDLINE_COLOR_ERROR "Rethrowing..." SPARTA_CMDLINE_COLOR_NORMAL << std::endl;
                         throw;
                     }

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -1945,6 +1945,10 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
     // Pevent
     if(run_pevents_) {
         pevent_trigger_.reset(new sparta::trigger::PeventTrigger(sim->getRoot()));
+        // FIXME: Support debug-roi for pevent collection
+        if(sim_config_.trigger_on_type == SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI) {
+            throw SpartaException("debug-roi hasn't been supported for Pevent collection");
+        }
     }
 
     for (const auto & def_file : report_descriptor_def_files_) {

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -367,14 +367,6 @@ CommandLineSimulator::CommandLineSimulator(const std::string& usage,
          "Example: \"--pipeline-collection data/test1_\"\n"
          "Note: Any directories in this path must already exist.\n",
          "Enable pipline collection to files with names prefixed with OUTPATH") // Brief
-        ("roi-pipeline-collection,Z",
-         named_value<std::vector<std::string>>("OUTPUTPATH", 1, 1)->multitoken(),
-         "Run pipeline collection for ROIs on this simulation, and dump the output files to OUTPUTPATH. "
-         "OUTPUTPATH can be a prefix such as myfiles_ for the pipeline files and may be a "
-         "directory\n"
-         "Example: \"--pipeline-collection data/test1_\"\n"
-         "Note: Any directories in this path must already exist.\n",
-         "Enable pipline collection to files with names prefixed with OUTPATH") // Brief
         ("collection-at,k",
          named_value<std::vector<std::string>>("TREENODE", 1, 1),
          "Specify a treenode to recursively turn on at and below for pipeline collection."

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -1305,7 +1305,7 @@ bool CommandLineSimulator::parse(int argc,
                 delayed_start = true;
 
                 if(sim_config_.trigger_on_type != SimulationConfiguration::TriggerSource::TRIGGER_ON_NONE) {
-                    throw SpartaException("Cannot use either --debug-on, --debug-on-icount or --debug-on-roi simultaneously");
+                    throw SpartaException("Cannot use --debug-on, --debug-on-icount, and --debug-on-roi simultaneously");
                 }
 
                 // Parse the debug trigger on cycle number
@@ -1351,7 +1351,7 @@ bool CommandLineSimulator::parse(int argc,
                 delayed_start = true;
 
                 if(sim_config_.trigger_on_type != SimulationConfiguration::TriggerSource::TRIGGER_ON_NONE){
-                    throw SpartaException("Cannot use either --debug-on, --debug-on-icount or --debug-on-roi simultaneously");
+                    throw SpartaException("Cannot use --debug-on, --debug-on-icount, and --debug-on-roi simultaneously");
                 }
 
                 // Parse the debug trigger on cycle number
@@ -1373,7 +1373,7 @@ bool CommandLineSimulator::parse(int argc,
                 delayed_start = true;
 
                 if(sim_config_.trigger_on_type != SimulationConfiguration::TriggerSource::TRIGGER_ON_NONE){
-                    throw SpartaException("Cannot use either --debug-on, --debug-on-icount or --debug-on-roi simultaneously");
+                    throw SpartaException("Cannot use --debug-on, --debug-on-icount, and --debug-on-roi simultaneously");
                 }
                 sim_config_.trigger_on_type = SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI;
                 ++i;
@@ -1947,7 +1947,7 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
         pevent_trigger_.reset(new sparta::trigger::PeventTrigger(sim->getRoot()));
         // FIXME: Support debug-roi for pevent collection
         if(sim_config_.trigger_on_type == SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI) {
-            throw SpartaException("debug-roi hasn't been supported for Pevent collection");
+            throw SpartaException("Pevent ennoblement is currently not supported with debug-roi. Use --debug or --debug-on-icount");
         }
     }
 

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -2176,7 +2176,15 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
                                                         sim_config_.trigger_on_value);
                 break;
             case SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI:
-                debug_trigger_->setTriggerNotificationDriven(sim->getRoot(), roi::NOTIFICATION_SRC_NAME);
+                {
+                    try{
+                        debug_trigger_->setTriggerNotificationDriven(sim->getRoot(), roi::NOTIFICATION_SRC_NAME);
+                    }catch(SpartaException& ex) {
+                        std::cerr << "\nTo use debug-roi option, users have to register notification source for ROI" << std::endl;
+                        std::cerr << "\n\n" SPARTA_CMDLINE_COLOR_ERROR "Rethrowing..." SPARTA_CMDLINE_COLOR_NORMAL << std::endl;
+                        throw;
+                    }
+                }
                 break;
             default:
                 sparta_assert(!"Unknown tigger on type");

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -483,7 +483,7 @@ void Simulation::configure(const int argc,
     // FIXME: Support debug-roi for loggers
     if(sim_config_->trigger_on_type == SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI &&
        !sim_config_->getTaps().empty()) {
-        throw SpartaException("debug-roi hasn't been supported for loggers");
+        throw SpartaException("Logging ennoblement is currently not supported with debug-roi. Use --debug or --debug-on-icount");
     }
 
     // If there are nodes already existing in the tree (e.g. root or "") then

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -480,6 +480,12 @@ void Simulation::configure(const int argc,
                                                sim_config_->warnings_file));
     }
 
+    // FIXME: Support debug-roi for loggers
+    if(sim_config_->trigger_on_type == SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI &&
+       !sim_config_->getTaps().empty()) {
+        throw SpartaException("debug-roi hasn't been supported for loggers");
+    }
+
     // If there are nodes already existing in the tree (e.g. root or "") then
     // there are no notifications for these TreeNodes since they already exist.
     // Install taps immediately instead of through rootDescendantAdded_


### PR DESCRIPTION
Add `debug-roi` option to enable pipeline collection for multiple ROIs in a program. Users have to define ROI by themselves by sending notification of `sparta::roi::START` and `sparta::roi::STOP`. This PR hasn't added support for pevents and loggers. Enabling either options with `debug-roi` will raise the exception. They will be supported later.

With new option `debug-roi` enabled for pipeline collection, the pipeout files will be supplied with a integer suffix meaning the ROI index. Here is an example of `-z pipeout/` execution:
```
zen@m1: $ ls pipeout/
0_index.bin   1_index.bin   2_index.bin   0_clock.dat  0_display_format.dat  0_map.dat         1_clock.dat  1_display_format.dat  1_map.dat         2_clock.dat  2_display_format.dat  2_map.dat         simulation.info
0_record.bin  1_record.bin  2_record.bin  0_data.dat   0_location.dat        0_string_map.dat  1_data.dat   1_location.dat        1_string_map.dat  2_data.dat   2_location.dat        2_string_map.dat
```

~~Adding a PipelineNotifSrcTrigger to collect data of multiple ROIs. Instead of Triggers, it is driven by NotificationSource. Users will have to post notifications of `sparta::roi::START` and `sparta::roi::STOP` to tell pipeline collector when to start/stop collecting for an ROI.~~

~~As there can be many ROIs in a program, PipelineNotifSrcTrigger will generate pipeout dump "per ROI". ROI names are simply defined by putting the current number of ROI after the pipeout file path.~~