### PR TITLE
ROI: Use uint64_t instead of enumerate as the type

### DIFF
--- a/sparta/sparta/trigger/RegionOfInterest.hpp
+++ b/sparta/sparta/trigger/RegionOfInterest.hpp
@@ -10,11 +10,9 @@ namespace sparta
 {
     namespace roi
     {
-        enum Triggers : uint64_t {
-            STOP = 0,
-            START = 1
-        };
-
+        using Triggers = uint64_t;
+        static constexpr Triggers STOP = 0;
+        static constexpr Triggers START = 1;
         static const std::string NOTIFICATION_SRC_NAME = "roi_start_stop";
     }
 }


### PR DESCRIPTION
I have a use case that the ROI notification source is used in ExpressionTrigger. ExpressionTrigger registers notification by `uint64_t`. It would be nice to have `roi::Triggers` declared as uint64_t directly.