### PR TITLE
Fix building step commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ installed and would like to build everything (not just sparta).
    * `make`
    * `cmake --install . --prefix $CONDA_PREFIX`
 1. To build Helios/Argos transaction viewer:
-   * `conda activate sparta`
    * `cd helios && mkdir release && cd release`
    * `cmake -DCMAKE_BUILD_TYPE=Release ..`
    * `make`

--- a/README.md
+++ b/README.md
@@ -52,14 +52,13 @@ installed and would like to build everything (not just sparta).
 1. Activate the environment
    * `conda activate sparta`
 1. To build Sparta framework components:
-   * `conda activate sparta`
-   * `cd map/sparta; mkdir release; cd release`
+   * `cd sparta && mkdir release && cd release`
    * `cmake -DCMAKE_BUILD_TYPE=Release ..`
    * `make`
    * `cmake --install . --prefix $CONDA_PREFIX`
 1. To build Helios/Argos transaction viewer:
    * `conda activate sparta`
-   * `cd map/helios; mkdir release; cd release`
+   * `cd helios && mkdir release && cd release`
    * `cmake -DCMAKE_BUILD_TYPE=Release ..`
    * `make`
    * `cmake --install . --prefix $CONDA_PREFIX`


### PR DESCRIPTION
Hi,

When I follow the building steps, I encounter some errors like bellow, this PR fix these errors.

1. Step 3 already cd to `map` dir, so step 7 `cd map/sparta` should change to `cd sparta`. Step 8 has the same problem.
2. Step 6 already active the `sparta` conda env, so step 7 `conda activate sparta` is no needed. Step 8 has the same problem.
3. In step 7 `cd map/sparta; mkdir release; cd release` , failure of a previous command does not prevent a subsequent command from running when using `;`  to run multiple command. Changing to `&&` is more friendly since we want all commands success. Step 8 has the same problem.

Best,
Lehua