### PR TITLE
Changes for Sparta @ C++23

### DIFF
--- a/sparta/simdb/include/simdb/schema/ColumnMetaStructs.hpp
+++ b/sparta/simdb/include/simdb/schema/ColumnMetaStructs.hpp
@@ -11,6 +11,7 @@
 #include "simdb/schema/ColumnTypedefs.hpp"
 #include "simdb/schema/DatabaseTypedefs.hpp"
 #include "simdb/Errors.hpp"
+#include "simdb/utils/CompatUtils.hpp"
 
 #include <string>
 #include <type_traits>
@@ -23,12 +24,6 @@ namespace simdb {
 template <typename ColumnT, typename Enable = void>
 struct column_info;
 
-template<typename T>
-struct is_pod {
-  static constexpr bool value = std::is_trivial<T>::value
-                             && std::is_standard_layout<T>::value;
-};
-
 //! int8_t
 template <>
 struct column_info<int8_t> {
@@ -36,7 +31,7 @@ struct column_info<int8_t> {
         return ColumnDataType::int8_t;
     }
     using value_type = int8_t;
-    static constexpr bool is_fixed_size = is_pod<int8_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<int8_t>::value;
 };
 
 //! uint8_t
@@ -46,7 +41,7 @@ struct column_info<uint8_t> {
         return ColumnDataType::uint8_t;
     }
     using value_type = uint8_t;
-    static constexpr bool is_fixed_size = is_pod<uint8_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<uint8_t>::value;
 };
 
 //! int16_t
@@ -56,7 +51,7 @@ struct column_info<int16_t> {
         return ColumnDataType::int16_t;
     }
     using value_type = int16_t;
-    static constexpr bool is_fixed_size = is_pod<int16_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<int16_t>::value;
 };
 
 //! uint16_t
@@ -66,7 +61,7 @@ struct column_info<uint16_t> {
         return ColumnDataType::uint16_t;
     }
     using value_type = uint16_t;
-    static constexpr bool is_fixed_size = is_pod<uint16_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<uint16_t>::value;
 };
 
 //! int32_t
@@ -76,7 +71,7 @@ struct column_info<int32_t> {
         return ColumnDataType::int32_t;
     }
     using value_type = int32_t;
-    static constexpr bool is_fixed_size = is_pod<int32_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<int32_t>::value;
 };
 
 //! uint32_t
@@ -86,7 +81,7 @@ struct column_info<uint32_t> {
         return ColumnDataType::uint32_t;
     }
     using value_type = uint32_t;
-    static constexpr bool is_fixed_size = is_pod<uint32_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<uint32_t>::value;
 };
 
 //! int64_t
@@ -96,7 +91,7 @@ struct column_info<int64_t> {
         return ColumnDataType::int64_t;
     }
     using value_type = int64_t;
-    static constexpr bool is_fixed_size = is_pod<int64_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<int64_t>::value;
 };
 
 //! uint64_t
@@ -106,7 +101,7 @@ struct column_info<uint64_t> {
         return ColumnDataType::uint64_t;
     }
     using value_type = uint64_t;
-    static constexpr bool is_fixed_size = is_pod<uint64_t>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<uint64_t>::value;
 };
 
 //! float
@@ -116,7 +111,7 @@ struct column_info<float> {
         return ColumnDataType::float_t;
     }
     using value_type = float;
-    static constexpr bool is_fixed_size = is_pod<float>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<float>::value;
 };
 
 //! double
@@ -126,7 +121,7 @@ struct column_info<double> {
         return ColumnDataType::double_t;
     }
     using value_type = double;
-    static constexpr bool is_fixed_size = is_pod<double>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<double>::value;
 };
 
 //! string
@@ -139,7 +134,7 @@ struct column_info<ColumnT, typename std::enable_if<
         return ColumnDataType::string_t;
     }
     using value_type = ColumnT;
-    static constexpr bool is_fixed_size = is_pod<std::string>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<std::string>::value;
 };
 
 //! char
@@ -149,7 +144,7 @@ struct column_info<char> {
         return ColumnDataType::char_t;
     }
     using value_type = char;
-    static constexpr bool is_fixed_size = is_pod<char>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<char>::value;
 };
 
 //! Vectors of raw bytes are stored as blobs (void* / opaque)
@@ -161,7 +156,7 @@ struct column_info<ColumnT, typename std::enable_if<
         return ColumnDataType::blob_t;
     }
     using value_type = typename is_container<ColumnT>::value_type;
-    static constexpr bool is_fixed_size = is_pod<ColumnT>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<ColumnT>::value;
 };
 
 //! Blob descriptor
@@ -173,11 +168,11 @@ struct column_info<ColumnT, typename std::enable_if<
         return ColumnDataType::blob_t;
     }
     using value_type = Blob;
-    static constexpr bool is_fixed_size = is_pod<ColumnT>::value;
+    static constexpr bool is_fixed_size = utils::is_pod<ColumnT>::value;
 };
 
 //! See if the given column data type has a fixed number
-//! of bytes, as determined by is_pod<T>
+//! of bytes, as determined by utils::is_pod<T>
 inline bool getColumnIsFixedSize(const ColumnDataType dtype)
 {
     using dt = ColumnDataType;

--- a/sparta/simdb/include/simdb/schema/ColumnMetaStructs.hpp
+++ b/sparta/simdb/include/simdb/schema/ColumnMetaStructs.hpp
@@ -23,6 +23,12 @@ namespace simdb {
 template <typename ColumnT, typename Enable = void>
 struct column_info;
 
+template<typename T>
+struct is_pod {
+  static constexpr bool value = std::is_trivial<T>::value
+                             && std::is_standard_layout<T>::value;
+};
+
 //! int8_t
 template <>
 struct column_info<int8_t> {
@@ -30,7 +36,7 @@ struct column_info<int8_t> {
         return ColumnDataType::int8_t;
     }
     using value_type = int8_t;
-    static constexpr bool is_fixed_size = std::is_pod<int8_t>::value;
+    static constexpr bool is_fixed_size = is_pod<int8_t>::value;
 };
 
 //! uint8_t
@@ -40,7 +46,7 @@ struct column_info<uint8_t> {
         return ColumnDataType::uint8_t;
     }
     using value_type = uint8_t;
-    static constexpr bool is_fixed_size = std::is_pod<uint8_t>::value;
+    static constexpr bool is_fixed_size = is_pod<uint8_t>::value;
 };
 
 //! int16_t
@@ -50,7 +56,7 @@ struct column_info<int16_t> {
         return ColumnDataType::int16_t;
     }
     using value_type = int16_t;
-    static constexpr bool is_fixed_size = std::is_pod<int16_t>::value;
+    static constexpr bool is_fixed_size = is_pod<int16_t>::value;
 };
 
 //! uint16_t
@@ -60,7 +66,7 @@ struct column_info<uint16_t> {
         return ColumnDataType::uint16_t;
     }
     using value_type = uint16_t;
-    static constexpr bool is_fixed_size = std::is_pod<uint16_t>::value;
+    static constexpr bool is_fixed_size = is_pod<uint16_t>::value;
 };
 
 //! int32_t
@@ -70,7 +76,7 @@ struct column_info<int32_t> {
         return ColumnDataType::int32_t;
     }
     using value_type = int32_t;
-    static constexpr bool is_fixed_size = std::is_pod<int32_t>::value;
+    static constexpr bool is_fixed_size = is_pod<int32_t>::value;
 };
 
 //! uint32_t
@@ -80,7 +86,7 @@ struct column_info<uint32_t> {
         return ColumnDataType::uint32_t;
     }
     using value_type = uint32_t;
-    static constexpr bool is_fixed_size = std::is_pod<uint32_t>::value;
+    static constexpr bool is_fixed_size = is_pod<uint32_t>::value;
 };
 
 //! int64_t
@@ -90,7 +96,7 @@ struct column_info<int64_t> {
         return ColumnDataType::int64_t;
     }
     using value_type = int64_t;
-    static constexpr bool is_fixed_size = std::is_pod<int64_t>::value;
+    static constexpr bool is_fixed_size = is_pod<int64_t>::value;
 };
 
 //! uint64_t
@@ -100,7 +106,7 @@ struct column_info<uint64_t> {
         return ColumnDataType::uint64_t;
     }
     using value_type = uint64_t;
-    static constexpr bool is_fixed_size = std::is_pod<uint64_t>::value;
+    static constexpr bool is_fixed_size = is_pod<uint64_t>::value;
 };
 
 //! float
@@ -110,7 +116,7 @@ struct column_info<float> {
         return ColumnDataType::float_t;
     }
     using value_type = float;
-    static constexpr bool is_fixed_size = std::is_pod<float>::value;
+    static constexpr bool is_fixed_size = is_pod<float>::value;
 };
 
 //! double
@@ -120,7 +126,7 @@ struct column_info<double> {
         return ColumnDataType::double_t;
     }
     using value_type = double;
-    static constexpr bool is_fixed_size = std::is_pod<double>::value;
+    static constexpr bool is_fixed_size = is_pod<double>::value;
 };
 
 //! string
@@ -133,7 +139,7 @@ struct column_info<ColumnT, typename std::enable_if<
         return ColumnDataType::string_t;
     }
     using value_type = ColumnT;
-    static constexpr bool is_fixed_size = std::is_pod<std::string>::value;
+    static constexpr bool is_fixed_size = is_pod<std::string>::value;
 };
 
 //! char
@@ -143,7 +149,7 @@ struct column_info<char> {
         return ColumnDataType::char_t;
     }
     using value_type = char;
-    static constexpr bool is_fixed_size = std::is_pod<char>::value;
+    static constexpr bool is_fixed_size = is_pod<char>::value;
 };
 
 //! Vectors of raw bytes are stored as blobs (void* / opaque)
@@ -155,7 +161,7 @@ struct column_info<ColumnT, typename std::enable_if<
         return ColumnDataType::blob_t;
     }
     using value_type = typename is_container<ColumnT>::value_type;
-    static constexpr bool is_fixed_size = std::is_pod<ColumnT>::value;
+    static constexpr bool is_fixed_size = is_pod<ColumnT>::value;
 };
 
 //! Blob descriptor
@@ -167,11 +173,11 @@ struct column_info<ColumnT, typename std::enable_if<
         return ColumnDataType::blob_t;
     }
     using value_type = Blob;
-    static constexpr bool is_fixed_size = std::is_pod<ColumnT>::value;
+    static constexpr bool is_fixed_size = is_pod<ColumnT>::value;
 };
 
 //! See if the given column data type has a fixed number
-//! of bytes, as determined by std::is_pod<T>
+//! of bytes, as determined by is_pod<T>
 inline bool getColumnIsFixedSize(const ColumnDataType dtype)
 {
     using dt = ColumnDataType;

--- a/sparta/simdb/include/simdb/utils/CompatUtils.hpp
+++ b/sparta/simdb/include/simdb/utils/CompatUtils.hpp
@@ -1,0 +1,19 @@
+// <CompatUtils> -*- C++ -*-
+
+#pragma once
+
+#include <type_traits>
+
+namespace simdb {
+namespace utils {
+
+//! \brief Replacement for std::is_pod, which was deprecated in C++20
+
+template<typename T>
+struct is_pod {
+    static constexpr bool value = std::is_trivial<T>::value
+                               && std::is_standard_layout<T>::value;
+};
+
+} // namespace utils
+} // namespace simdb

--- a/sparta/simdb/src/ObjectRef.cpp
+++ b/sparta/simdb/src/ObjectRef.cpp
@@ -4,6 +4,7 @@
 #include "simdb/utils/ObjectQuery.hpp"
 #include "simdb/TableRef.hpp"
 #include "simdb/DbConnProxy.hpp"
+#include "simdb/utils/CompatUtils.hpp"
 
 //SQLite-specific headers
 #include "simdb/impl/sqlite/TransactionUtils.hpp"
@@ -96,8 +97,7 @@ PropertyDataT LOCAL_getScalarProperty(const std::string & table_name,
 //! without using ObjectQuery.
 template <typename PropertyDataT>
 typename std::enable_if<
-    std::is_trivial<PropertyDataT>::value &&
-    std::is_standard_layout<PropertyDataT>::value,
+    utils::is_pod<PropertyDataT>::value,
 PropertyDataT>::type
 LOCAL_getScalarPropertyNoObjectQuery(
     const std::string & table_name,

--- a/sparta/simdb/src/ObjectRef.cpp
+++ b/sparta/simdb/src/ObjectRef.cpp
@@ -96,7 +96,8 @@ PropertyDataT LOCAL_getScalarProperty(const std::string & table_name,
 //! without using ObjectQuery.
 template <typename PropertyDataT>
 typename std::enable_if<
-    std::is_pod<PropertyDataT>::value,
+    std::is_trivial<PropertyDataT>::value &&
+    std::is_standard_layout<PropertyDataT>::value,
 PropertyDataT>::type
 LOCAL_getScalarPropertyNoObjectQuery(
     const std::string & table_name,

--- a/sparta/sparta/pairs/SpartaKeyPairs.hpp
+++ b/sparta/sparta/pairs/SpartaKeyPairs.hpp
@@ -30,6 +30,8 @@
 #include "sparta/utils/MetaTypeList.hpp"
 #include "sparta/utils/MetaStructs.hpp"
 #include "sparta/utils/DetectMemberUtils.hpp"
+#include "simdb/utils/CompatUtils.hpp"
+
 
 namespace sparta {
 
@@ -1691,8 +1693,7 @@ namespace sparta {
         template<typename T>
         MetaStruct::enable_if_t<
             std::is_integral<MetaStruct::decay_t<T>>::value &&
-            std::is_trivial<MetaStruct::decay_t<T>>::value &&
-            std::is_standard_layout<MetaStruct::decay_t<T>>::value &&
+            simdb::utils::is_pod<MetaStruct::decay_t<T>>::value &&
             !MetaStruct::is_bool<MetaStruct::decay_t<T>>::value, void>
 
         updateValueInCache_(

--- a/sparta/sparta/pairs/SpartaKeyPairs.hpp
+++ b/sparta/sparta/pairs/SpartaKeyPairs.hpp
@@ -1691,7 +1691,8 @@ namespace sparta {
         template<typename T>
         MetaStruct::enable_if_t<
             std::is_integral<MetaStruct::decay_t<T>>::value &&
-            std::is_pod<MetaStruct::decay_t<T>>::value &&
+            std::is_trivial<MetaStruct::decay_t<T>>::value &&
+            std::is_standard_layout<MetaStruct::decay_t<T>>::value &&
             !MetaStruct::is_bool<MetaStruct::decay_t<T>>::value, void>
 
         updateValueInCache_(

--- a/sparta/sparta/simulation/StateTracker.hpp
+++ b/sparta/sparta/simulation/StateTracker.hpp
@@ -103,7 +103,7 @@ namespace sparta {
                 const std::weak_ptr<StatePool<T>> & weak_pool) :
                 weak_pool_ptr_(weak_pool) {}
 
-            StateTrackerDeleter<T>() : valid_(false) {}
+            StateTrackerDeleter() : valid_(false) {}
 
             inline void operator()(StateTrackerUnit<T> * ptr) const {
                 if(!valid_ || !ptr) {
@@ -178,7 +178,7 @@ namespace sparta {
 
             //! The Default Ctor is deleted because StatePool cannot be created
             //  without a valid state tracking filename.
-            StatePool<T>() = delete;
+            StatePool() = delete;
 
             //! A file name is a must when constructing StatePool.
             explicit StatePool<T>(const std::string & tracking_filename) :


### PR DESCRIPTION
Two changes need to be accounted for:

1. C++20's DR 2237, which forbids writing constructors as templates.
2. std::is_pod<T> is deprecated, and needs to be replaced using std::is_trival<T> && std::is_standard_layout<T>