### PR TITLE
Scoreboard View Fix

### DIFF
--- a/sparta/src/Scoreboard.cpp
+++ b/sparta/src/Scoreboard.cpp
@@ -309,14 +309,8 @@ namespace sparta
 
         // Try to find the master scoreboard, if it's available (has
         // been created by the Sparta framework)
-
-        // Go as high as the CPU node in this Tree.  If we go higher,
-        // we could bind to a Scoreboard in another CPU!  That'd be
-        // bad.
-
-        // Search from the root
-        auto cpu_node = parent->getRoot();
-        sparta_assert(cpu_node != nullptr, "Could not find the core nodes in this simulation");
+        
+        // Search for scoreboards from parent
 
         std::function<Scoreboard*(sparta::TreeNode *)> findScoreboard =
             [&] (sparta::TreeNode * node) -> Scoreboard * {
@@ -350,7 +344,7 @@ namespace sparta
                 return scoreboard;
             };
 
-        Scoreboard * master_sb = findScoreboard(cpu_node);
+        Scoreboard * master_sb = findScoreboard(parent);
 
         // Gotta be more than 0
         sparta_assert(master_sb != nullptr,

--- a/sparta/src/Scoreboard.cpp
+++ b/sparta/src/Scoreboard.cpp
@@ -314,6 +314,10 @@ namespace sparta
         // we could bind to a Scoreboard in another CPU!  That'd be
         // bad.
         auto cpu_node = parent->findAncestorByName("core*");
+        // if a core node is not available, search from the root
+        if(cpu_node == nullptr){
+            cpu_node = parent->getRoot();
+        }
         sparta_assert(cpu_node != nullptr, "Could not find the core nodes in this simulation");
 
         std::function<Scoreboard*(sparta::TreeNode *)> findScoreboard =

--- a/sparta/src/Scoreboard.cpp
+++ b/sparta/src/Scoreboard.cpp
@@ -313,11 +313,9 @@ namespace sparta
         // Go as high as the CPU node in this Tree.  If we go higher,
         // we could bind to a Scoreboard in another CPU!  That'd be
         // bad.
-        auto cpu_node = parent->findAncestorByName("core*");
-        // if a core node is not available, search from the root
-        if(cpu_node == nullptr){
-            cpu_node = parent->getRoot();
-        }
+
+        // Search from the root
+        auto cpu_node = parent->getRoot();
         sparta_assert(cpu_node != nullptr, "Could not find the core nodes in this simulation");
 
         std::function<Scoreboard*(sparta::TreeNode *)> findScoreboard =

--- a/sparta/test/Scoreboard/Scoreboard_test.cpp
+++ b/sparta/test/Scoreboard/Scoreboard_test.cpp
@@ -559,6 +559,41 @@ void testScoreboardClearing()
     rtn.enterTeardown();
 }
 
+void testScoreboardNonCore()
+{
+    // testing scoreboard view is able to find scoreboards when there is not a "core" node
+    sparta::RootTreeNode rtn;
+    sparta::Scheduler    sched;
+    sparta::ClockManager cm(&sched);
+    sparta::Clock::Handle root_clk;
+    root_clk = cm.makeRoot(&rtn, "root_clk");
+    cm.normalize();
+    rtn.setClock(root_clk.get());
+
+    sparta::TreeNode cpu(&rtn, "custom", "Dummy CPU");
+
+    sparta::ResourceFactory<sparta::Scoreboard,
+                            sparta::Scoreboard::ScoreboardParameters> fact;
+
+    sparta::ResourceTreeNode sbtn(&cpu,
+                                  SB_NAMES[0],
+                                  sparta::TreeNode::GROUP_NAME_NONE,
+                                  sparta::TreeNode::GROUP_IDX_NONE,
+                                  "Test scoreboard",
+                                  &fact);
+
+    sparta::Scoreboard::ScoreboardParameters * params =
+        dynamic_cast<sparta::Scoreboard::ScoreboardParameters *>(sbtn.getParameterSet());
+    params->latency_matrix = GPR_FORWARDING_MATRIX;
+
+    rtn.enterConfiguring();
+    rtn.enterFinalized();
+    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &sbtn);
+
+    auto is_set = view.isSet({0b1000});
+    EXPECT_TRUE(is_set);
+    rtn.enterTeardown();
+}
 void testPrintBits()
 {
     sparta::Scoreboard::RegisterBitMask some_bits(0b011000110011);
@@ -576,6 +611,8 @@ int main ()
     testScoreboardUnitCreation();
 
     testScoreboardClearing();
+
+    testScoreboardNonCore();
 
     testPrintBits();
 

--- a/sparta/test/Scoreboard/Scoreboard_test.cpp
+++ b/sparta/test/Scoreboard/Scoreboard_test.cpp
@@ -152,7 +152,7 @@ public:
         my_scoreboard_view_.reset
             (new sparta::ScoreboardView(getContainer()->getName(), // ALU0, ALU1, LSU, FPU, etc
                                         sb_unit_type_,             // integer, fp, vector
-                                        getContainer()));          // Used to find the Scoreboard
+                                        getContainer()->getRoot()));          // Used to find the Scoreboard
         advance_->schedule();
     }
 
@@ -316,7 +316,7 @@ void testScoreboardRegistration()
     sched.finalize();
 
     // view from ALU0, integer
-    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &sbtn);
+    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &cpu);
     bool ready = false;
     auto ready_callback = [&ready](const sparta::Scoreboard::RegisterBitMask &) { ready = true; };
 
@@ -523,7 +523,7 @@ void testScoreboardClearing()
     rtn.enterConfiguring();
     rtn.enterFinalized();
     sparta::Scoreboard * master_sb = sbtn.getResourceAs<sparta::Scoreboard>();
-    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &sbtn);
+    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &cpu);
 
     auto is_set = view.isSet({0b1000});
     EXPECT_TRUE(is_set);
@@ -561,7 +561,7 @@ void testScoreboardClearing()
 
 void testScoreboardNonCore()
 {
-    // testing scoreboard view is able to find scoreboards when there is not a "core" node
+    // testing scoreboard view is able to find scoreboards when there is a non core.*
     sparta::RootTreeNode rtn;
     sparta::Scheduler    sched;
     sparta::ClockManager cm(&sched);
@@ -588,7 +588,7 @@ void testScoreboardNonCore()
 
     rtn.enterConfiguring();
     rtn.enterFinalized();
-    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &sbtn);
+    sparta::ScoreboardView view(UNIT_NAMES[0], SB_NAMES[0], &cpu);
 
     auto is_set = view.isSet({0b1000});
     EXPECT_TRUE(is_set);


### PR DESCRIPTION
Scoreboard view is hardcoded to look for scoreboards along `core.*` only. I hit this bug when working on development work for [Olympia](https://github.com/riscv-software-src/riscv-perf-model), where our unit tests initialize a simulation without a core node, thus resulting in the [sparta assert](https://github.com/sparcians/map/blob/4626e0dbbee6ebd07bf035e4ed9b85ac959abbb3/sparta/src/Scoreboard.cpp#L317) triggering. The proposed fix is to check if the `cpu_node` is null, then use the root node to search for scoreboards. An additional test for a cpu not named "core" is added to verify these changes.