### PR TITLE
Remove unused member ev_producing_event_(SkeletonPipeline)

### DIFF
--- a/sparta/example/SkeletonPipeline/src/Producer.hpp
+++ b/sparta/example/SkeletonPipeline/src/Producer.hpp
@@ -61,10 +61,6 @@ private:
     // Producer's producer handler
     void produceData_();
 
-    // Event to drive data, phase Tick, 1 cycle delay
-    sparta::UniqueEvent<> ev_producing_event_{&unit_event_set_, "ev_producing_event",
-            CREATE_SPARTA_HANDLER(Producer, produceData_), 1 /* delay */};
-
     // Internal count
     const uint32_t max_ints_to_send_;
     uint32_t current_ints_count_ = 0;


### PR DESCRIPTION
The class member ev_producing_event_ of Producer is unused, the 1 cycle delay is configured in Consumer `consumer_in_port_` member like below. Removing it to avoid misunderstanding.

```c++
class Consumer : public sparta::Unit
{
    // Consumer's InPort to get data
    sparta::DataInPort<uint32_t> consumer_in_port_{&unit_port_set_, "consumer_in_port", 1};
}
```