### PR TITLE
[fix]: add paused check before pthread_mutex_lock.

### DIFF
--- a/sparta/sparta/kernel/SleeperThread.hpp
+++ b/sparta/sparta/kernel/SleeperThread.hpp
@@ -380,8 +380,11 @@ public:
     void pause() override
     {
         if (thread_spawned_){
-            paused_ = true;
-            pthread_mutex_lock(&pause_mutex_);
+            if(!paused_)
+            {
+                paused_ = true;
+                pthread_mutex_lock(&pause_mutex_);
+            }
         }
     }
 

--- a/sparta/sparta/kernel/SleeperThread.hpp
+++ b/sparta/sparta/kernel/SleeperThread.hpp
@@ -379,12 +379,10 @@ public:
     //! Force the sleeper thread to pause. Should be called before the Scheduler exits running
     void pause() override
     {
+        if(paused_) { return; }
         if (thread_spawned_){
-            if(!paused_)
-            {
-                paused_ = true;
-                pthread_mutex_lock(&pause_mutex_);
-            }
+            paused_ = true;
+            pthread_mutex_lock(&pause_mutex_);
         }
     }
 


### PR DESCRIPTION
In my simulator based on sparta，I need flush all inflight events in my flush process, which means I need stop, clear events and re-run the scheduler. 
While my flush function is in one event handler, so actually I use scheduler->run() in recursive.
I found there is no paused check before pthread_mutex_lock, and the second lock will hang.
So add this check in case of that.

Bellow is the flush event handler in my flush manager
```
      void FlushManager::ForwardingFlushSignal(const FlushingCriteria& flush_criteria) {
        auto tick = scheduler_->getCurrentTick();
        scheduler_->stopRunning();
        scheduler_->restartAt(tick);
        flush_criteria_ = flush_criteria;
        flush_event_.schedule(1);
        scheduler_->run();
    }
```
