### PR TITLE
Define custom copy/move constructors/operators for SharedData and GlobalEvent

### DIFF
--- a/sparta/sparta/events/GlobalEvent.hpp
+++ b/sparta/sparta/events/GlobalEvent.hpp
@@ -106,6 +106,43 @@ namespace sparta
             ev_sched_ptr_(clk->getScheduler()->getGlobalPhasedPayloadEventPtr<sched_phase_T>())
         {}
 
+        GlobalEvent(const GlobalEvent& rhs) :
+            local_clk_(rhs.local_clk_),
+            event_handler_(rhs.event_handler_),
+            ev_handler_lifetime_(&event_handler_),
+            ev_sched_ptr_(rhs.ev_sched_ptr_)
+        {
+        }
+
+        GlobalEvent(GlobalEvent&& rhs) :
+            local_clk_(rhs.local_clk_),
+            event_handler_(std::move(rhs.event_handler_)),
+            ev_handler_lifetime_(&event_handler_),
+            ev_sched_ptr_(rhs.ev_sched_ptr_)
+        {
+            rhs.ev_handler_lifetime_.reset();
+        }
+
+        GlobalEvent& operator=(const GlobalEvent& rhs) {
+            local_clk_ = rhs.local_clk_;
+            event_handler_ = rhs.event_handler_;
+            ev_handler_lifetime_ = utils::LifeTracker<SpartaHandler>(&event_handler_);
+            ev_sched_ptr_ = rhs.ev_sched_ptr_;
+
+            return *this;
+        }
+
+        GlobalEvent& operator=(GlobalEvent&& rhs) {
+            local_clk_ = rhs.local_clk_;
+            event_handler_ = std::move(rhs.event_handler_);
+            ev_handler_lifetime_ = utils::LifeTracker<SpartaHandler>(&event_handler_);
+            ev_sched_ptr_ = rhs.ev_sched_ptr_;
+
+            rhs.ev_handler_lifetime_.reset();
+
+            return *this;
+        }
+
         void schedule(const Clock::Cycle & delay, const Clock * clk) {
             sparta_assert(ev_sched_ptr_ != nullptr);
             sparta_assert(ev_sched_ptr_->getSchedulingPhase() == sched_phase_T);

--- a/sparta/sparta/resources/SharedData.hpp
+++ b/sparta/sparta/resources/SharedData.hpp
@@ -49,6 +49,11 @@ namespace sparta
             return current_state_;
         }
 
+        void resetHandler_()
+        {
+            ev_update_.resetHandler(CREATE_SPARTA_HANDLER(SharedData, update_));
+        }
+
     public:
         /**
          * \brief Construct a SharedData item
@@ -63,6 +68,44 @@ namespace sparta
             ev_update_(clk, CREATE_SPARTA_HANDLER(SharedData, update_))
         {
             writePS(std::forward<U>(init_val));
+        }
+
+        SharedData(const SharedData& rhs) :
+            ev_update_(rhs.ev_update_),
+            current_state_(rhs.current_state_),
+            data_(rhs.data_)
+        {
+            resetHandler_();
+        }
+
+        SharedData(SharedData&& rhs) :
+            ev_update_(std::move(rhs.ev_update_)),
+            current_state_(std::move(rhs.current_state_)),
+            data_(std::move(rhs.data_))
+        {
+            resetHandler_();
+        }
+
+        SharedData& operator=(const SharedData& rhs)
+        {
+            ev_update_ = rhs.ev_update_;
+            resetHandler_();
+
+            current_state_ = rhs.current_state_;
+            data_ = rhs.data_;
+
+            return *this;
+        }
+
+        SharedData& operator=(SharedData&& rhs)
+        {
+            ev_update_ = std::move(rhs.ev_update_);
+            resetHandler_();
+
+            current_state_ = std::move(rhs.current_state_);
+            data_ = std::move(rhs.data_);
+
+            return *this;
         }
 
         /**


### PR DESCRIPTION
I ran into a segfault when I tried to create an `std::vector` of `SharedData`. There were two underlying causes for this:

1. When `GlobalEvent` is moved/copied, it doesn't update `ev_handler_lifetime_` to point to the new instance of `event_handler_`. If the original `GlobalEvent` was later destroyed, the copy would segfault when it tried to fire its handler.
2. When `SharedData` is moved/copied, its `ev_update_` receives a copy of the handler in the original `SharedData`. If the original was later destroyed, the copy would segfault when it tried to perform its state update.

This PR defines copy/move constructors and assignment operators for both classes so that everything gets updated properly and the copies can continue to function after the originals are destroyed.