### PR TITLE
Fix reporting bug where ContextCounters have their per-context counts printed twice

### DIFF
--- a/sparta/sparta/report/Report.hpp
+++ b/sparta/sparta/report/Report.hpp
@@ -401,7 +401,7 @@ namespace sparta
          * by another item immediately in this report (not the name of a
          * subreport or item in a subreport)
          */
-        StatAdder add(const StatisticInstance& si, const std::string& name="");
+        StatAdder add(const StatisticInstance& si, const std::string& name="", const bool recurse=true);
 
         /*!
          * \brief Moves an existing statistic instance into this Report
@@ -414,7 +414,7 @@ namespace sparta
          * by another item immediately in this report (not the name of a
          * subreport or item in a subreport)
          */
-        StatAdder add(StatisticInstance&& si, const std::string& name="");
+        StatAdder add(StatisticInstance&& si, const std::string& name="", const bool recurse=true);
 
         /*!
          * \brief Add a StatisticDef to the report

--- a/sparta/src/Report.cpp
+++ b/sparta/src/Report.cpp
@@ -1150,7 +1150,7 @@ private:
     std::string filename_; //!< For recalling errors
 }; // class ReportFileParserYAML
 
-Report::StatAdder Report::add(const StatisticInstance& si, const std::string& name) {
+Report::StatAdder Report::add(const StatisticInstance& si, const std::string& name, const bool recurse) {
     if(name != "" && stat_names_.find(name) != stat_names_.end()){
         throw SpartaException("There is already a statistic instance in this Report (")
             << getName() << ") named \"" << name << "\" pointing to "
@@ -1164,12 +1164,14 @@ Report::StatAdder Report::add(const StatisticInstance& si, const std::string& na
 
     if(name != ""){ stat_names_.insert(name); }
 
-    addSubStatistics_(&si);
+    if(recurse) {
+        addSubStatistics_(&si);
+    }
 
     return Report::StatAdder(*this);
 }
 
-Report::StatAdder Report::add(StatisticInstance&& si, const std::string& name) {
+Report::StatAdder Report::add(StatisticInstance&& si, const std::string& name, const bool recurse) {
     if(name != "" && stat_names_.find(name) != stat_names_.end()){
         throw SpartaException("There is already a statistic instance in this Report (")
             << getName() << ") named \"" << name << "\" pointing to "
@@ -1183,7 +1185,9 @@ Report::StatAdder Report::add(StatisticInstance&& si, const std::string& name) {
 
     if(name != ""){ stat_names_.insert(name); }
 
-    addSubStatistics_(&si);
+    if(recurse) {
+        addSubStatistics_(&si);
+    }
 
     return Report::StatAdder(*this);
 }
@@ -1416,7 +1420,7 @@ void Report::recursAddSubtree_(const TreeNode* n,
             //for(auto& s : stats_){
             //    std::cerr << "  Stat " << s.second->stringize() << " " << s.second->getLocation() << std::endl;
             //}
-            add(n, child_stat_prefix + n->getName());
+            add(n, child_stat_prefix + n->getName(), false);
         }
     }
 


### PR DESCRIPTION
I ran into a bug where the per-context counts from a ContextCounter would get printed twice in a report:

```
              my_counter = 882885
              my_counter_context0 = 221216
              my_counter_context1 = 220455
              my_counter_context2 = 220124
              my_counter_context3 = 221090
              my_counter.context0 = 221216
              my_counter.context1 = 220455
              my_counter.context2 = 220124
              my_counter.context3 = 221090

```

This PR fixes the report generator so that only the second set (with the `.` separator) is included in the report.