### PR TITLE
Fix compilation errors with Clang v16+. Also includes fixes for compiling with -std=c++23.

### DIFF
--- a/sparta/sparta/log/MessageSource.hpp
+++ b/sparta/sparta/log/MessageSource.hpp
@@ -149,7 +149,7 @@ namespace sparta
                 //! Move constructor
                 LogObject(LogObject&& rhp) :
                     src_(rhp.src_),
-                    s_(std::move(rhp.s_.str())) // May unfortunately involve a copy
+                    s_(rhp.s_.str()) // May unfortunately involve a copy
                 { }
 
                 //! \brief Not Copy-constructable

--- a/sparta/sparta/pipeViewer/Outputter.hpp
+++ b/sparta/sparta/pipeViewer/Outputter.hpp
@@ -187,7 +187,7 @@ namespace sparta::pipeViewer
                     if(!dat.stringVector[i].empty()){
                         // We check if we have seen this exact pair, field and value before or not.
                         if(const auto& [val, str] = std::tie(dat.valueVector[i].first, dat.stringVector[i]);
-                           stringMap.try_emplace(std::make_tuple(dat.pairId, i, val), str).second) {
+                           stringMap.emplace(std::piecewise_construct, std::forward_as_tuple(dat.pairId, i, val), std::forward_as_tuple(str)).second) {
                             // We add this mapping into out String Map file which we will
                             // use when reading back from the database.
                             string_file_ << dat.pairId
@@ -238,7 +238,7 @@ namespace sparta::pipeViewer
                     if(!dat.stringVector[i].empty()){
                         // We check if we have seen this exact pair, field and value before or not.
                         if(const auto& [val, str] = std::tie(dat.valueVector[i].first, dat.stringVector[i]);
-                           stringMap.try_emplace(std::make_tuple(dat.pairId, i, val), str).second) {
+                           stringMap.emplace(std::piecewise_construct, std::forward_as_tuple(dat.pairId, i, val), std::forward_as_tuple(str)).second) {
                             // We add this mapping into out String Map file which we will
                             // use when reading back from the database.
                             string_file_ << dat.pairId

--- a/sparta/sparta/resources/Buffer.hpp
+++ b/sparta/sparta/resources/Buffer.hpp
@@ -95,7 +95,7 @@ namespace sparta
          */
         struct DataPointer {
         private:
-            typename std::aligned_storage<sizeof(value_type), alignof(value_type)>::type object_memory_;
+            alignas(value_type) std::byte object_memory_[sizeof(value_type)];
 
         public:
             DataPointer() { }

--- a/sparta/sparta/statistics/dispatch/archives/ArchiveNode.hpp
+++ b/sparta/sparta/statistics/dispatch/archives/ArchiveNode.hpp
@@ -37,9 +37,7 @@ public:
     ArchiveNode() = default;
 
     //! Construct a named node
-    ArchiveNode(const std::string & name) :
-        name_(name)
-    {}
+    ArchiveNode(const std::string & name);
 
     //! Archive trees are built with the help of the
     //! ReportStatisticsHierTree class. That class is
@@ -61,7 +59,7 @@ public:
         ArchiveNode(name)
     {}
 
-    virtual ~ArchiveNode() {}
+    virtual ~ArchiveNode();
 
     //! Return the name that this node was originally created with
     const std::string & getName() const {

--- a/sparta/sparta/utils/SpartaSharedPointerAllocator.hpp
+++ b/sparta/sparta/utils/SpartaSharedPointerAllocator.hpp
@@ -285,16 +285,20 @@ namespace sparta
         friend SpartaSharedPointer<PtrT>
         allocate_sparta_shared_pointer(SpartaSharedPointerAllocator<PtrT> &, Args&&...args);
 
+        template<typename T>
+        struct AlignedStorage
+        {
+            alignas(T) std::byte buf[sizeof(T)];
+        };
+
         // Internal MemoryBlock
         struct MemBlock : public BaseAllocator::MemBlockBase
         {
             using RefCountType = typename SpartaSharedPointer<PointerT>::RefCount;
 
-            using RefCountAlignedStorage =
-                typename std::aligned_storage<sizeof(RefCountType), alignof(RefCountType)>::type;
+            using RefCountAlignedStorage = AlignedStorage<RefCountType>;
 
-            using PointerTAlignedStorage =
-                typename std::aligned_storage<sizeof(PointerT), alignof(PointerT)>::type;
+            using PointerTAlignedStorage = AlignedStorage<PointerT>;
 
             template<typename ...ObjArgs>
             MemBlock(SpartaSharedPointerAllocator * alloc_in, ObjArgs&&...obj_args) :
@@ -323,8 +327,7 @@ namespace sparta
         class MemBlockVector
         {
             // Align the storage for the MemBlock
-            using MemBlockAlignedStorage =
-                typename std::aligned_storage<sizeof(MemBlock), alignof(MemBlock)>::type;
+            using MemBlockAlignedStorage = AlignedStorage<MemBlock>;
 
             std::vector<MemBlockAlignedStorage> data_;
             std::size_t size_ = 0;

--- a/sparta/sparta/utils/Utils.hpp
+++ b/sparta/sparta/utils/Utils.hpp
@@ -27,56 +27,56 @@
 /*!
  * \brief Custom literal for uint64
  */
-constexpr inline uint64_t operator "" _u64(unsigned long long i) {
+constexpr inline uint64_t operator ""_u64(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for uint32
  */
-constexpr inline uint32_t operator "" _u32(unsigned long long i) {
+constexpr inline uint32_t operator ""_u32(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for uint16
  */
-constexpr inline uint16_t operator "" _u16(unsigned long long i) {
+constexpr inline uint16_t operator ""_u16(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for uint8
  */
-constexpr inline uint8_t operator "" _u8(unsigned long long i) {
+constexpr inline uint8_t operator ""_u8(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for int64
  */
-constexpr inline int64_t operator "" _64(unsigned long long i) {
+constexpr inline int64_t operator ""_64(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for int32
  */
-constexpr inline int32_t operator "" _32(unsigned long long i) {
+constexpr inline int32_t operator ""_32(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for int16
  */
-constexpr inline int16_t operator "" _16(unsigned long long i) {
+constexpr inline int16_t operator ""_16(unsigned long long i) {
     return i;
 }
 
 /*!
  * \brief Custom literal for int8
  */
-constexpr inline int8_t operator "" _8(unsigned long long i) {
+constexpr inline int8_t operator ""_8(unsigned long long i) {
     return i;
 }
 

--- a/sparta/src/StatisticsArchives.cpp
+++ b/sparta/src/StatisticsArchives.cpp
@@ -196,6 +196,15 @@ void RootArchiveNode::saveTo(const std::string & dir)
     archive_controller_->saveTo(dir);
 }
 
+ArchiveNode::ArchiveNode(const std::string & name) :
+    name_(name)
+{
+}
+
+ArchiveNode::~ArchiveNode()
+{
+}
+
 //Lazily walk up to the top of the tree to get the root node
 RootArchiveNode * ArchiveNode::getRoot()
 {


### PR DESCRIPTION
This PR fixes compilation errors I observed trying to compile with clang v16 and v17, as well as some errors from bumping the C++ standard to C++23.