### PR TITLE
Fix NameError: name 'ScheduleLineElement' is not defined error in Argos

### DIFF
--- a/helios/pipeViewer/pipe_view/model/element_value.py
+++ b/helios/pipeViewer/pipe_view/model/element_value.py
@@ -8,9 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 from . import content_options as content
 from . import highlighting_utils
 from .element import Element, FakeElement, PropertyValue
-
-if TYPE_CHECKING:
-    from .schedule_element import ScheduleLineElement
+from .schedule_element import ScheduleLineElement
 
 
 TimedVal = Tuple[Optional[Union[int, str]], Tuple[int, int]]

--- a/helios/pipeViewer/pipe_view/model/schedule_element.py
+++ b/helios/pipeViewer/pipe_view/model/schedule_element.py
@@ -16,7 +16,9 @@ from .element import (Element,
                       PropertyValue,
                       ValidatedPropertyDict)
 from . import element_propsvalid as valid
-from .element_value import Element_Value, FakeElementValue
+
+if TYPE_CHECKING:
+    from .element_value import Element_Value, FakeElementValue
 
 if TYPE_CHECKING:
     from .clock_manager import ClockManager
@@ -387,6 +389,8 @@ class ScheduleLineElement(LocationallyKeyedElement):
     def DetectCollision(self,
                         pt: Union[Tuple[int, int], wx.Point],
                         pair: Element_Value) -> FakeElementValue:
+        from .element_value import FakeElementValue
+
         mx, my = pt
 
         period = pair.GetClockPeriod()


### PR DESCRIPTION
Fixes the following error that can occur when advancing Argos quickly:

```
NameError: name 'ScheduleLineElement' is not defined
```