### PR TITLE
Enable dynamic-sized RegisterBits

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,7 +3,7 @@ boost:
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 hdf5:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -7,7 +7,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 hdf5:
 - 1.14.3
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ boost:
 c_compiler:
 - clang
 c_compiler_version:
-- '16'
+- '17'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '16'
+- '17'
 hdf5:
 - 1.14.3
 macos_machine:

--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ Install `conda smithy` instructions:
 conda install -n root -c conda-forge conda-smithy
 conda install -n root -c conda-forge conda-package-handling
 ```
+If `conda smithy` complains about being out of date:
+```
+conda update -n root conda-smithy
+```

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -89,17 +89,17 @@ popd
 #  BUILD MAP/HELIOS
 #
 ################################################################################
-pushd helios
-mkdir -p release
-pushd release
-cmake -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX:PATH="$PREFIX" \
-      "${CMAKE_PLATFORM_FLAGS[@]}" \
-      ..
-cmake --build . -j "$CPU_COUNT" || cmake --build . -v
-popd
-popd
-
+#pushd helios
+#mkdir -p release
+#pushd release
+#cmake -DCMAKE_BUILD_TYPE=Release \
+#      -DCMAKE_INSTALL_PREFIX:PATH="$PREFIX" \
+#      "${CMAKE_PLATFORM_FLAGS[@]}" \
+#      ..
+#cmake --build . -j "$CPU_COUNT" || cmake --build . -v
+#popd
+#popd
+#
 ################################################################################
 #
 # Preserve build-phase test results so that we can track them individually

--- a/sparta/sparta/functional/Register.hpp
+++ b/sparta/sparta/functional/Register.hpp
@@ -1332,10 +1332,10 @@ protected:
 private:
     RegisterBits computeWriteMask_(const Definition *def) const
     {
-        // Non-power-of-2 size may cause illegal access,
-        // an exception will be thrown in the constructor.
         if(!isPowerOf2(def->bytes)) {
-            return RegisterBits(nullptr);
+            throw SpartaException("Register \"")
+                << getName() << "\" size in bytes must be a power of 2 larger than 0, is "
+                << def->bytes;
         }
 
         const auto mask_size = def->bytes;

--- a/sparta/sparta/functional/Register.hpp
+++ b/sparta/sparta/functional/Register.hpp
@@ -1332,6 +1332,12 @@ protected:
 private:
     RegisterBits computeWriteMask_(const Definition *def) const
     {
+        // Non-power-of-2 size may cause illegal access,
+        // an exception will be thrown in the constructor.
+        if(!isPowerOf2(def->bytes)) {
+            return RegisterBits(nullptr);
+        }
+
         const auto mask_size = def->bytes;
         RegisterBits write_mask(mask_size);
         RegisterBits partial_mask(mask_size);

--- a/sparta/sparta/functional/RegisterBits.hpp
+++ b/sparta/sparta/functional/RegisterBits.hpp
@@ -116,6 +116,7 @@ namespace sparta
                 local_data_ = local_storage_alt_.get();
                 remote_data_ = local_data_;
             }
+            ::memset(local_data_, 0, num_bytes_);
             sparta_assert(sizeof(DataT) <= num_bytes);
             set(data);
         }

--- a/sparta/sparta/functional/RegisterBits.hpp
+++ b/sparta/sparta/functional/RegisterBits.hpp
@@ -725,7 +725,7 @@ namespace sparta
 
     private:
 
-        std::array<uint8_t, 64>  local_storage_; //!< Local storage
+        std::array<uint8_t, 8>   local_storage_; //!< Local storage
         std::unique_ptr<uint8_t> local_storage_alt_; //!< Alternative local storage when register size > 64B
         uint8_t                * local_data_  = nullptr; //!< Points to null if using remote data
         const uint8_t          * remote_data_ = nullptr; //!< Remove data; points to local_data_ if no remote

--- a/sparta/sparta/functional/RegisterBits.hpp
+++ b/sparta/sparta/functional/RegisterBits.hpp
@@ -725,10 +725,10 @@ namespace sparta
 
     private:
 
-        std::array<uint8_t, 8>   local_storage_; //!< Local storage
-        std::unique_ptr<uint8_t> local_storage_alt_; //!< Alternative local storage when register size > 64B
-        uint8_t                * local_data_  = nullptr; //!< Points to null if using remote data
-        const uint8_t          * remote_data_ = nullptr; //!< Remove data; points to local_data_ if no remote
-        const uint64_t           num_bytes_ = 0; //!< Number of bytse
+        std::array<uint8_t, 8>     local_storage_; //!< Local storage
+        std::unique_ptr<uint8_t[]> local_storage_alt_; //!< Alternative local storage when register size > 64B
+        uint8_t                  * local_data_  = nullptr; //!< Points to null if using remote data
+        const uint8_t            * remote_data_ = nullptr; //!< Remove data; points to local_data_ if no remote
+        const uint64_t             num_bytes_ = 0; //!< Number of bytse
     };
 }

--- a/sparta/sparta/functional/RegisterBits.hpp
+++ b/sparta/sparta/functional/RegisterBits.hpp
@@ -16,8 +16,8 @@ namespace sparta
      * \class RegisterBits
      *
      * This class is used in conjuntion with sparta::RegisterBase to
-     * quickly write masked registers of sizes between 1 and 512
-     * bytes.  This class replaces the use of BitArray.
+     * quickly write masked registers. This class replaces the use of
+     * BitArray.
      *
      * The class works by assuming register data is handed to it via a
      * char array.  The class will "view" into this data until it's
@@ -77,7 +77,7 @@ namespace sparta
          * \param num_bytes The number of bytes to allocate
          */
         explicit RegisterBits(const uint64_t num_bytes) :
-            local_storage_(),
+            local_storage_(num_bytes),
             local_data_(local_storage_.data()),
             remote_data_(local_data_),
             num_bytes_(num_bytes)
@@ -96,7 +96,7 @@ namespace sparta
          */
         template<class DataT>
         RegisterBits(const uint64_t num_bytes, const DataT & data) :
-            local_storage_(),
+            local_storage_(num_bytes),
             local_data_(local_storage_.data()),
             remote_data_(local_data_),
             num_bytes_(num_bytes)
@@ -115,6 +115,7 @@ namespace sparta
          * No data is copied
          */
         RegisterBits(uint8_t * data_ptr, const size_t num_bytes) :
+            local_storage_(num_bytes),
             local_data_(data_ptr),
             remote_data_(local_data_),
             num_bytes_(num_bytes)
@@ -131,6 +132,7 @@ namespace sparta
          * No data is copied
          */
         RegisterBits(const uint8_t * data, const size_t num_bytes) :
+            local_storage_(num_bytes),
             remote_data_(data),
             num_bytes_(num_bytes)
         {
@@ -630,7 +632,9 @@ namespace sparta
          */
         void fill(const uint8_t fill_data) {
             convert_();
-            local_storage_.fill(fill_data);
+            std::fill(std::begin(local_storage_),
+                      std::end(local_storage_),
+                      fill_data);
         }
 
         /**
@@ -697,7 +701,7 @@ namespace sparta
 
     private:
 
-        std::array<uint8_t, 64> local_storage_; //!< Local storage
+        std::vector<uint8_t>    local_storage_; //!< Local storage
         uint8_t               * local_data_  = nullptr; //!< Points to null if using remote data
         const uint8_t         * remote_data_ = nullptr; //!< Remove data; points to local_data_ if no remote
         const uint64_t          num_bytes_ = 0; //!< Number of bytse

--- a/sparta/sparta/functional/RegisterBits.hpp
+++ b/sparta/sparta/functional/RegisterBits.hpp
@@ -16,8 +16,8 @@ namespace sparta
      * \class RegisterBits
      *
      * This class is used in conjuntion with sparta::RegisterBase to
-     * quickly write masked registers. This class replaces the use of
-     * BitArray.
+     * quickly write masked registers of sizes between 1 and 512
+     * bytes.  This class replaces the use of BitArray.
      *
      * The class works by assuming register data is handed to it via a
      * char array.  The class will "view" into this data until it's
@@ -77,7 +77,7 @@ namespace sparta
          * \param num_bytes The number of bytes to allocate
          */
         explicit RegisterBits(const uint64_t num_bytes) :
-            local_storage_(num_bytes),
+            local_storage_(),
             local_data_(local_storage_.data()),
             remote_data_(local_data_),
             num_bytes_(num_bytes)
@@ -96,7 +96,7 @@ namespace sparta
          */
         template<class DataT>
         RegisterBits(const uint64_t num_bytes, const DataT & data) :
-            local_storage_(num_bytes),
+            local_storage_(),
             local_data_(local_storage_.data()),
             remote_data_(local_data_),
             num_bytes_(num_bytes)
@@ -115,7 +115,6 @@ namespace sparta
          * No data is copied
          */
         RegisterBits(uint8_t * data_ptr, const size_t num_bytes) :
-            local_storage_(num_bytes),
             local_data_(data_ptr),
             remote_data_(local_data_),
             num_bytes_(num_bytes)
@@ -132,7 +131,6 @@ namespace sparta
          * No data is copied
          */
         RegisterBits(const uint8_t * data, const size_t num_bytes) :
-            local_storage_(num_bytes),
             remote_data_(data),
             num_bytes_(num_bytes)
         {
@@ -632,9 +630,7 @@ namespace sparta
          */
         void fill(const uint8_t fill_data) {
             convert_();
-            std::fill(std::begin(local_storage_),
-                      std::end(local_storage_),
-                      fill_data);
+            local_storage_.fill(fill_data);
         }
 
         /**
@@ -701,7 +697,7 @@ namespace sparta
 
     private:
 
-        std::vector<uint8_t>    local_storage_; //!< Local storage
+        std::array<uint8_t, 64> local_storage_; //!< Local storage
         uint8_t               * local_data_  = nullptr; //!< Points to null if using remote data
         const uint8_t         * remote_data_ = nullptr; //!< Remove data; points to local_data_ if no remote
         const uint64_t          num_bytes_ = 0; //!< Number of bytse

--- a/sparta/test/Register/CMakeLists.txt
+++ b/sparta/test/Register/CMakeLists.txt
@@ -3,3 +3,7 @@ project(Register_test)
 sparta_add_test_executable(Register_test Register_test.cpp)
 
 sparta_test(Register_test Register_test_RUN)
+
+sparta_add_test_executable(RegisterBits_test reg_bit_test.cpp)
+
+sparta_test(RegisterBits_test RegisterBits_test_RUN)

--- a/sparta/test/Register/Register_test.cpp
+++ b/sparta/test/Register/Register_test.cpp
@@ -323,7 +323,6 @@ void testBadRegs()
         3,    // non-power-of-2-count regs not allowed
         5,    // non-power-of-2-count regs not allowed
         9,    // Just to prove that odd-byte-count regs are rejected; not just primes
-        8192  // 8192 Bytes per register is very likely too large
     };
 
     // Test each separately because ALL sizes must fail!

--- a/sparta/test/Register/reg_bit_test.cpp
+++ b/sparta/test/Register/reg_bit_test.cpp
@@ -1,5 +1,5 @@
 
-#include "RegisterBits.hpp"
+#include "sparta/functional/Register.hpp"
 #include <iostream>
 #include <iomanip>
 


### PR DESCRIPTION
Hello Knute,

In some vector processors, we may need registers longer than 512-bit. Was `std::array` used for considering C++ performance? It might work if I just upsize it to 1024-bit, but I think there could be larger ones in the future. Use `std::vector` instead could be once and for all.

Let me know your thoughts! I tried to make `64` as template parameter by default -- But Registerbits seems to be used heavily as return value type, and class template argument deduction can’t work for that case.