### PR TITLE
Cleaned Up Scripts to Generate Register Definition JSONs

### DIFF
--- a/sparta/scripts/GenRISCVRegisterDefinitions.py
+++ b/sparta/scripts/GenRISCVRegisterDefinitions.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Script for generating RISC-V register definition JSON files.
+"""
+
+from enum import Enum
+import os
+
+from GenRegisterJSON import GenRegisterJSON
+from GenRegisterJSON import RegisterGroup
+
+def main():
+    # Make rv64 directory if it doesn't exist
+    if not os.path.exists("rv64"):
+        os.makedirs("rv64")
+    os.chdir("rv64")
+
+    # Generate rv64g int, fp and CSR registers
+    RV64_XLEN = 8
+    VLEN = 32
+    reg_int = GenRegisterJSON(RegisterGroup.INT, 32, RV64_XLEN)
+    reg_fp  = GenRegisterJSON(RegisterGroup.FP,  32, RV64_XLEN)
+    reg_vec = GenRegisterJSON(RegisterGroup.VEC, 32, VLEN)
+    reg_csr = GenRegisterJSON(RegisterGroup.CSR, 0,  RV64_XLEN)
+
+    # Add register for the PC
+    num = 32
+    reg_int.add_custom_register("pc", num, "Program counter", 8, [], {}, 0, True)
+
+    # Add registers for atomic load-reservation and store-conditional instructions
+    num += 1
+    reg_int.add_custom_register("resv_addr", num, "Load reservation address", 8, [], {}, 0, True)
+    num += 1
+    reg_int.add_custom_register("resv_valid", num, "Load reservation valid", 8, [], {}, 0, True)
+
+    reg_int.write_json("reg_int.json")
+    reg_fp.write_json("reg_fp.json")
+    reg_vec.write_json("reg_vec.json")
+    reg_csr.write_json("reg_csr.json")
+
+    # Make rv32 directory if it doesn't exist
+    os.chdir("..")
+    if not os.path.exists("rv32"):
+        os.makedirs("rv32")
+    os.chdir("rv32")
+
+    # Generate rv32g int, fp and CSR registers
+    RV32_XLEN = 4
+    reg_int = GenRegisterJSON(RegisterGroup.INT, 32, RV32_XLEN)
+    reg_fp  = GenRegisterJSON(RegisterGroup.FP,  32, RV32_XLEN)
+    reg_vec = GenRegisterJSON(RegisterGroup.VEC, 32, VLEN)
+    reg_csr = GenRegisterJSON(RegisterGroup.CSR, 0,  RV32_XLEN)
+
+    reg_int.write_json("reg_int.json");
+    reg_fp.write_json("reg_fp.json");
+    reg_vec.write_json("reg_vec.json")
+    reg_csr.write_json("reg_csr.json");
+
+
+if __name__ == "__main__":
+    main()

--- a/sparta/scripts/GenRegisterJSON.py
+++ b/sparta/scripts/GenRegisterJSON.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
-"""Helper script for regenerating register definition JSON files.
+"""Helper script for generating register definition JSON files.
 """
 
 from enum import IntEnum
 import json
 import math
-import sys
-import pdb
 
 from RV64_CSR import CSR64_DEFS
 from RV32_CSR import CSR32_DEFS
-
-from RV64_CONSTANT import RV64_CONSTS
-from RV64_CONSTANT import ATHENA_INTERNAL_REGISTERS
 
 class RegisterGroup(IntEnum):
     INT = 0
@@ -135,52 +130,16 @@ VEC_ALIASES = {
     "v31": [],
 }
 
-CSR_BF_HEADER_FILE_NAME = "CSRBitMasks{reg_size}.hpp"
-
-CSR_HEADER_FILE_NAME = "CSRNums.hpp"
-CSR_NUM_FILE_HEADER = """
-#pragma once
-
-#include <cinttypes>
-
-//
-// This is generated file from scripts/GenRegisterJSON.py
-//
-// DO NOT MODIFY THIS FILE BY HAND
-//
-
-namespace athena
-{
-"""
-
-CSR_NUM_FILE_CSRNUM_COMMENT = """
-    // CSR Nums
-"""
-
-CSR_NUM_FILE_CONSTANT_COMMENT = """
-    // Constants defined for RISC-V
-"""
-
-CSR_NUM_FILE_INTERNAL_REGS_COMMENT = """
-    // Constants defined for RISC-V
-"""
-
-CSR_NUM_FILE_FOOTER = """
-}
-"""
-
 class GenRegisterJSON():
     """Generates register definition JSON files.
 
     Args:
-        group_name (RegisterGroup): Name of register group.
+        group (RegisterGroup): Register group.
         num_regs (int): Number of registers in the group.
         reg_size (int): Size of the registers in bytes (must be power of 2)
     """
-
-    def __init__(self, group_num, num_regs, reg_size):
-        self.group_num = int(group_num)
-        self.group_name = GetGroupName(group_num)
+    def __init__(self, group, num_regs, reg_size):
+        self.group = group
         self.num_regs = num_regs
         assert math.log(reg_size, 2).is_integer(), 'reg_size must be a power of 2!'
         self.reg_size = reg_size
@@ -196,32 +155,20 @@ class GenRegisterJSON():
                                           "high_bit": 63,
                                           "readonly": True}
 
-        for num in range(0, self.num_regs):
-            name = self.get_int_reg_name(num)
-        if group_num is RegisterGroup.INT:
+        if self.group is RegisterGroup.INT:
             self.gen_int_reg_defs()
-        elif group_num is RegisterGroup.FP:
+        elif self.group is RegisterGroup.FP:
             self.gen_fp_reg_defs()
-        elif group_num is RegisterGroup.CSR:
-            self.gen_csr_reg_defs()
-            self.gen_csr_header_file()
-            self.gen_csr_bit_fields()
-        elif group_num is RegisterGroup.VEC:
+        elif self.group is RegisterGroup.VEC:
             self.gen_vec_reg_defs()
-
-    def get_int_reg_name(self, num):
-        """Returns int register name from register number"""
-        return "x"+str(num)
-
-    def get_int_reg_desc(self, num):
-        """Returns int register description from register number"""
-        return "int register "+str(num)
+        elif self.group is RegisterGroup.CSR:
+            self.gen_csr_reg_defs()
 
     def gen_int_reg_defs(self):
         """Generates integer register definitions
         """
         for num in range(0, self.num_regs):
-            name = self.get_int_reg_name(num)
+            name = f"x{num}"
             alias = INT_ALIASES[name] if (name in INT_ALIASES.keys()) else []
             fields = {}
             if (num == 0):
@@ -233,25 +180,16 @@ class GenRegisterJSON():
             self.reg_defs.append(self.__CreateRegDict({
                 "name":          name,
                 "num":           num,
-                "desc":          self.get_int_reg_desc(num),
+                "desc":          f"int register {num}",
                 "size":          self.reg_size,
                 "aliases":       alias,
                 "fields":        fields,
                 "initial_value": 0,
                 "enabled":       True}))
 
-    def get_fp_reg_name(self, num):
-        """Returns fp register name from register number"""
-        return "f"+str(num)
-
-    def get_fp_reg_desc(self, num):
-        """Returns fp register description from register number"""
-        return "floating point register "+str(num)
-
     def gen_fp_reg_defs(self):
         """Generates floating point register definitions
         """
-
         fields = {}
         fields["sp"] = {"desc":     "single precision",
                         "low_bit":  0,
@@ -263,17 +201,36 @@ class GenRegisterJSON():
                         "readonly": False}
 
         for num in range(0, self.num_regs):
-            name = self.get_fp_reg_name(num)
+            name = f"f{num}"
             alias = FP_ALIASES[name] if (name in FP_ALIASES.keys()) else []
             self.reg_defs.append(self.__CreateRegDict({
                 "name":          name,
                 "num":           num,
-                "desc":          self.get_fp_reg_desc(num),
+                "desc":          f"floating point register {num}",
                 "size":          8,
                 "aliases":       alias,
                 "fields":        fields,
                 "initial_value": 0,
                 "enabled":       True}))
+
+    def gen_vec_reg_defs(self):
+        """Generates vector register definitions
+        """
+        fields = {}
+        alias = []
+
+        for num in range(0, self.num_regs):
+            name = f"v{num}"
+            self.reg_defs.append(self.__CreateRegDict({
+                "name":          name,
+                "num":           num,
+                "desc":          f"vector register {num}",
+                "size":          self.reg_size,
+                "aliases":       alias,
+                "fields":        fields,
+                "initial_value": 0,
+                "enabled":       True}))
+
 
     def gen_csr_reg_defs(self):
         """Generate control and status register definitions
@@ -291,119 +248,17 @@ class GenRegisterJSON():
                 "initial_value": v[3],
                 "enabled":       True}))
 
-    def gen_csr_header_file(self):
-        """Generate the CSR CPP header file
-        """
-
-        csr_header_file = open(CSR_HEADER_FILE_NAME, "w")
-        csr_header_file.write(CSR_NUM_FILE_HEADER)
-
-        # TODO: Can we get keys in JSON to be printed in hex?
-        CSR_DEFS = CSR32_DEFS.copy()
-        CSR_DEFS.update(CSR64_DEFS)
-        CONST = RV64_CONSTS
-
-        csr_header_file.write(CSR_NUM_FILE_CSRNUM_COMMENT)
-        csr_largest_value = -1;
-        for k, v in CSR_DEFS.items():
-            csr_header_file.write("    static constexpr uint32_t "+
-                                  (v[0]).upper()+
-                                  " = "+
-                                  str(hex(k))+
-                                  "; // "+
-                                  str(k)+
-                                  "\n")
-            csr_largest_value = max(csr_largest_value, k)
-
-        csr_header_file.write("    static constexpr uint32_t CSR_LARGEST_VALUE = "+
-                              str(hex(csr_largest_value)) +
-                              ";\n")
-
-        csr_header_file.write(CSR_NUM_FILE_CONSTANT_COMMENT)
-        for k, v in CONST.items():
-            csr_header_file.write("    static constexpr uint64_t "+
-                                  k.upper()+
-                                  " = "+
-                                  str(hex(v[0]))+
-                                  "; // "+
-                                  str(v[1])+
-                                  "\n")
-
-        csr_header_file.write(CSR_NUM_FILE_INTERNAL_REGS_COMMENT)
-        for k, v in ATHENA_INTERNAL_REGISTERS.items():
-            csr_header_file.write("    static constexpr uint64_t "+
-                                  k.upper()+
-                                  " = "+
-                                  str(hex(v[0]))+
-                                  "; // "+
-                                  str(v[1])+
-                                  "\n")
-
-        csr_header_file.write(CSR_NUM_FILE_FOOTER)
-        csr_header_file.close()
-
-    def gen_csr_bit_fields(self):
-        """Generate the CSR header file with bitfields
-        """
-        data_width = self.reg_size*8
-        csr_bf_header_file = open(CSR_BF_HEADER_FILE_NAME.format(reg_size=data_width), "w")
-        csr_bf_header_file.write(CSR_NUM_FILE_HEADER)
-
-        CSR_DEFS = CSR32_DEFS if (self.reg_size == 4) else CSR64_DEFS
-        FILL_MASK = 0xffffffffffffffff
-        SIZE = 64
-
-        for k, v in CSR_DEFS.items():
-            # Print only if there are bit flags
-            if v[2]:
-                csr_bf_header_file.write("    namespace "+
-                                         (v[0]).upper()+
-                                         "_" + str(data_width) + "_bitmasks {\n")
-                fields = v[2]
-                for name in fields:
-                    if name.lower() != "resv" and name.lower() != "wpri":
-                        high_bit = fields[name]['high_bit']
-                        low_bit = fields[name]['low_bit']
-                        mask = (FILL_MASK >> (SIZE - (high_bit - low_bit + 1))) << low_bit
-                        csr_bf_header_file.write("        static constexpr uint64_t " +
-                                                 name + " = " + hex(mask) + ";\n")
-
-                csr_bf_header_file.write("    } // namespace "+
-                                         (v[0]).upper()+
-                                         "_" + str(data_width) + "_bitfield\n\n")
-
-
-
-        csr_bf_header_file.write(CSR_NUM_FILE_FOOTER)
-        csr_bf_header_file.close()
-
-
-    def get_vec_reg_name(self, num):
-        """Returns v register name from register number"""
-        return "v"+str(num)
-
-    def get_vec_reg_desc(self, num):
-        """Returns v register description from register number"""
-        return "vector register "+str(num)
-
-    def gen_vec_reg_defs(self):
-        """Generates vector register definitions
-        """
-
-        fields = {}
-        alias = []
-
-        for num in range(0, self.num_regs):
-            name = self.get_vec_reg_name(num)
-            self.reg_defs.append(self.__CreateRegDict({
-                "name":          name,
-                "num":           num,
-                "desc":          self.get_vec_reg_desc(num),
-                "size":          self.reg_size,
-                "aliases":       alias,
-                "fields":        fields,
-                "initial_value": 0,
-                "enabled":       True}))
+    def add_custom_register(self, name, num, desc, size, aliases, fields, initial_value, enabled):
+        self.reg_defs.append(self.__CreateRegDict({
+            "name":          name,
+            "num":           num,
+            "desc":          desc,
+            "size":          size,
+            "aliases":       aliases,
+            "fields":        fields,
+            "initial_value": initial_value,
+            "enabled":       enabled
+        }))
 
     def write_json(self, filename):
         """Write register definitions to a JSON file"""
@@ -426,38 +281,7 @@ class GenRegisterJSON():
             del reg_dict["enabled"]
 
         # Add group num and group name
-        reg_dict["group_num"] = self.group_num
-        reg_dict["group_name"] = self.group_name
+        reg_dict["group_num"] = int(self.group)
+        reg_dict["group_name"] = GetGroupName(self.group)
 
         return reg_dict
-
-def main():
-
-    if len(sys.argv) != 2:
-        print("Usage: GenRegisterJSON.py <rv32|rv64>")
-        exit(1)
-
-    isa_string = sys.argv[1]
-
-    if isa_string not in ["rv32", "rv64"]:
-        print("Usage: GenRegisterJSON.py <rv32|rv64>")
-        exit(1)
-
-    # Default to RV64
-    xlen = 4 if "32" in isa_string else 8
-    vlen = 32
-
-    # Generate rv64g int, fp and CSR registers
-    reg_int = GenRegisterJSON(RegisterGroup.INT, 32, xlen);
-    reg_fp  = GenRegisterJSON(RegisterGroup.FP, 32, xlen);
-    reg_vec = GenRegisterJSON(RegisterGroup.VEC, 32, vlen)
-    reg_csr = GenRegisterJSON(RegisterGroup.CSR, 0, xlen);
-
-    isa_string = ''.join(i for i in isa_string if not i.isdigit())
-    reg_int.write_json("reg_int.json");
-    reg_fp.write_json("reg_fp.json");
-    reg_vec.write_json("reg_vec.json")
-    reg_csr.write_json("reg_csr.json");
-
-if __name__ == "__main__":
-    main()

--- a/sparta/scripts/RV64_CONSTANT.py
+++ b/sparta/scripts/RV64_CONSTANT.py
@@ -14,9 +14,3 @@ RV64_CONSTS = {
     "PMP_MIN_GRANULARITY": [4, "The minimum PMP granularity"],
     "PMP_MIN_GRANULARITY_SHIFT": [2, "The minimum PMP granularity (in shift values)"],
 }
-
-ATHENA_INTERNAL_REGISTERS = {
-    "ATHENA_INTERNAL_PC": [0x20, "Athena internal register to hold the program counter"],
-    "ATHENA_INTERNAL_RESV_ADDR": [0x21, "Athena internal register to hold the load reservation address"],
-    "ATHENA_INTERNAL_RESV_VALID": [0x22, "Athena internal register to hold whether the load reservation is valid"],
-}


### PR DESCRIPTION
- Created example script that generates register definitions for RISC-V
- Removed irrelevant CSR header file support
- Replaced methods for generating register names and descriptions with format strings