### PR TITLE
Add debugging support for DAG

### DIFF
--- a/sparta/sparta/kernel/DAG.hpp
+++ b/sparta/sparta/kernel/DAG.hpp
@@ -74,15 +74,9 @@ namespace sparta
         ////////////////////////////////////////////////////////////
 
         // DAG Nabbit
-        DAG(sparta::Scheduler * scheduler, const bool& check_cycles = false);
+        DAG(sparta::Scheduler * scheduler);
 
         DAG() =delete;
-
-        //! Turn on early cycle detection -- as items are linked in
-        //! the DAG, it will look for a cycle.
-        void enableEarlyCycleDetect() {
-            early_cycle_detect_ = true;
-        }
 
         //! \brief Initialize the DAG
         //! Creates new vertices from the VertexFactory
@@ -217,10 +211,13 @@ namespace sparta
 
         std::vector<Vertex*>                    alloc_vertices_;
         uint32_t                                num_groups_ = 1;
-        bool                                    early_cycle_detect_;
         VertexMap                               gops_;
         bool                                    finalized_ = false;
         sparta::Scheduler*                      my_scheduler_ = nullptr;
+
+        //! Debug log message source
+        const log::MessageSource                debug_logger_;
+        const bool                              early_cycle_detect_;
     };//End class DAG
 
 

--- a/sparta/sparta/kernel/DAG.hpp
+++ b/sparta/sparta/kernel/DAG.hpp
@@ -74,9 +74,15 @@ namespace sparta
         ////////////////////////////////////////////////////////////
 
         // DAG Nabbit
-        DAG(sparta::Scheduler * scheduler);
+        DAG(sparta::Scheduler * scheduler, const bool& check_cycles = false);
 
         DAG() =delete;
+
+        //! Turn on early cycle detection -- as items are linked in
+        //! the DAG, it will look for a cycle.
+        void enableEarlyCycleDetect() {
+            early_cycle_detect_ = true;
+        }
 
         //! \brief Initialize the DAG
         //! Creates new vertices from the VertexFactory
@@ -211,13 +217,10 @@ namespace sparta
 
         std::vector<Vertex*>                    alloc_vertices_;
         uint32_t                                num_groups_ = 1;
+        bool                                    early_cycle_detect_;
         VertexMap                               gops_;
         bool                                    finalized_ = false;
         sparta::Scheduler*                      my_scheduler_ = nullptr;
-
-        //! Debug log message source
-        const log::MessageSource                debug_logger_;
-        const bool                              early_cycle_detect_;
     };//End class DAG
 
 

--- a/sparta/sparta/kernel/DAG.hpp
+++ b/sparta/sparta/kernel/DAG.hpp
@@ -221,6 +221,7 @@ namespace sparta
         VertexMap                               gops_;
         bool                                    finalized_ = false;
         sparta::Scheduler*                      my_scheduler_ = nullptr;
+        const log::MessageSource                debug_logger_;
     };//End class DAG
 
 

--- a/sparta/src/DAG.cpp
+++ b/sparta/src/DAG.cpp
@@ -122,10 +122,17 @@ namespace sparta
         num_groups_(1),
         early_cycle_detect_(check_cycles),
         gops_(),
-        my_scheduler_(scheduler)
+        my_scheduler_(scheduler),
+        debug_logger_(scheduler,
+                      sparta::log::categories::DEBUG,
+                      "Scheduler's constructing DAG debug messages")
     {
         initializeDAG_();
-
+        // Enable early cycle detection when the debug logger is
+        // enabled for the convenience of debugging ...
+        if(debug_logger_.observed()){
+            early_cycle_detect_ = true;
+        }
     }
 
     void DAG::initializeDAG_()
@@ -171,20 +178,20 @@ namespace sparta
             dest_vertex->setInDAG(true);
         }
 
-        // TODO: REMOVE DEBUGGING STATEMENTS
-        //std::cout << "DAG::link()" << std::endl;
-        //std::cout << "\t" << std::string(*source_vertex) << " -> " << std::string(*dest_vertex) << std::endl;
+        if(SPARTA_EXPECT_FALSE(debug_logger_)){
+            debug_logger_ << SPARTA_CURRENT_COLOR_GREEN
+                          << "=== SCHEDULER: Add DAG link for "
+                          << reason << ": "
+                          << SPARTA_CURRENT_COLOR_NORMAL
+                          << std::string(*source_vertex) << " -> "
+                          << std::string(*dest_vertex);
+        }
 
         if (source_vertex->link(e_factory_, dest_vertex, reason)) {
             if (early_cycle_detect_ && detectCycle()) {
                 throw CycleException(getCycles_());
             }
         }
-
-        // TODO: DEBUGGING - remove this
-        //if (detectCycle()) {
-            //throw CycleException(getCycles_());
-        //}
     }
 
 

--- a/sparta/src/DAG.cpp
+++ b/sparta/src/DAG.cpp
@@ -118,11 +118,18 @@ namespace sparta
         return group_count;
     }
 
-    DAG::DAG(sparta::Scheduler * scheduler, const bool& check_cycles):
+    DAG::DAG(sparta::Scheduler * scheduler):
         num_groups_(1),
-        early_cycle_detect_(check_cycles),
         gops_(),
-        my_scheduler_(scheduler)
+        my_scheduler_(scheduler),
+        debug_logger_(scheduler,
+                      sparta::log::categories::DEBUG,
+                      "Scheduler's constructing DAG debug messages"),
+        // Cycle-checking tells the DAG to flag a cycle at the earliest opportunity
+        // This means checking for a cycle as each edge is added to the DAG (DAG::link)
+        // It's expensive, but can save time in debugging precedence problems
+        // Turned on when the debug logger is enabled
+        early_cycle_detect_(debug_logger_.observed())
     {
         initializeDAG_();
 
@@ -171,20 +178,20 @@ namespace sparta
             dest_vertex->setInDAG(true);
         }
 
-        // TODO: REMOVE DEBUGGING STATEMENTS
-        //std::cout << "DAG::link()" << std::endl;
-        //std::cout << "\t" << std::string(*source_vertex) << " -> " << std::string(*dest_vertex) << std::endl;
+        if(SPARTA_EXPECT_FALSE(debug_logger_)){
+            debug_logger_ << SPARTA_CURRENT_COLOR_GREEN
+                          << "=== SCHEDULER: Add DAG link for "
+                          << reason << ": "
+                          << SPARTA_CURRENT_COLOR_NORMAL
+                          << std::string(*source_vertex) << " -> "
+                          << std::string(*dest_vertex);
+        }
 
         if (source_vertex->link(e_factory_, dest_vertex, reason)) {
             if (early_cycle_detect_ && detectCycle()) {
                 throw CycleException(getCycles_());
             }
         }
-
-        // TODO: DEBUGGING - remove this
-        //if (detectCycle()) {
-            //throw CycleException(getCycles_());
-        //}
     }
 
 

--- a/sparta/src/DAG.cpp
+++ b/sparta/src/DAG.cpp
@@ -118,18 +118,11 @@ namespace sparta
         return group_count;
     }
 
-    DAG::DAG(sparta::Scheduler * scheduler):
+    DAG::DAG(sparta::Scheduler * scheduler, const bool& check_cycles):
         num_groups_(1),
+        early_cycle_detect_(check_cycles),
         gops_(),
-        my_scheduler_(scheduler),
-        debug_logger_(scheduler,
-                      sparta::log::categories::DEBUG,
-                      "Scheduler's constructing DAG debug messages"),
-        // Cycle-checking tells the DAG to flag a cycle at the earliest opportunity
-        // This means checking for a cycle as each edge is added to the DAG (DAG::link)
-        // It's expensive, but can save time in debugging precedence problems
-        // Turned on when the debug logger is enabled
-        early_cycle_detect_(debug_logger_.observed())
+        my_scheduler_(scheduler)
     {
         initializeDAG_();
 
@@ -178,20 +171,20 @@ namespace sparta
             dest_vertex->setInDAG(true);
         }
 
-        if(SPARTA_EXPECT_FALSE(debug_logger_)){
-            debug_logger_ << SPARTA_CURRENT_COLOR_GREEN
-                          << "=== SCHEDULER: Add DAG link for "
-                          << reason << ": "
-                          << SPARTA_CURRENT_COLOR_NORMAL
-                          << std::string(*source_vertex) << " -> "
-                          << std::string(*dest_vertex);
-        }
+        // TODO: REMOVE DEBUGGING STATEMENTS
+        //std::cout << "DAG::link()" << std::endl;
+        //std::cout << "\t" << std::string(*source_vertex) << " -> " << std::string(*dest_vertex) << std::endl;
 
         if (source_vertex->link(e_factory_, dest_vertex, reason)) {
             if (early_cycle_detect_ && detectCycle()) {
                 throw CycleException(getCycles_());
             }
         }
+
+        // TODO: DEBUGGING - remove this
+        //if (detectCycle()) {
+            //throw CycleException(getCycles_());
+        //}
     }
 
 

--- a/sparta/src/Scheduler.cpp
+++ b/sparta/src/Scheduler.cpp
@@ -119,7 +119,7 @@ Scheduler::Scheduler(const std::string& name, GlobalTreeNode* search_scope) :
     // Cycle-checking tells the DAG to flag a cycle at the earliest opportunity
     // This means checking for a cycle as each edge is added to the DAG (DAG::link)
     // It's expensive, but can save time in debugging precedence problems
-    dag_.reset(new DAG(this, false));
+    dag_.reset(new DAG(this));
 
     // Added to support sparta::GlobalEvent, must follow dag_ initialization
     for (uint32_t phase = 0; phase < sparta::NUM_SCHEDULING_PHASES; phase++) {
@@ -165,7 +165,7 @@ void Scheduler::reset()
     enterTeardown(); // On RootTreeNode
     clearEvents();
 
-    dag_.reset(new DAG(this, false));
+    dag_.reset(new DAG(this));
     dag_finalized_ = false;
 
     tick_quantum_allocator_.clear();

--- a/sparta/src/Scheduler.cpp
+++ b/sparta/src/Scheduler.cpp
@@ -165,8 +165,8 @@ void Scheduler::reset()
     enterTeardown(); // On RootTreeNode
     clearEvents();
 
-    dag_.reset(new DAG(this, false));
     dag_finalized_ = false;
+    dag_.reset(new DAG(this, false));
 
     tick_quantum_allocator_.clear();
 }

--- a/sparta/src/Scheduler.cpp
+++ b/sparta/src/Scheduler.cpp
@@ -119,7 +119,7 @@ Scheduler::Scheduler(const std::string& name, GlobalTreeNode* search_scope) :
     // Cycle-checking tells the DAG to flag a cycle at the earliest opportunity
     // This means checking for a cycle as each edge is added to the DAG (DAG::link)
     // It's expensive, but can save time in debugging precedence problems
-    dag_.reset(new DAG(this));
+    dag_.reset(new DAG(this, false));
 
     // Added to support sparta::GlobalEvent, must follow dag_ initialization
     for (uint32_t phase = 0; phase < sparta::NUM_SCHEDULING_PHASES; phase++) {
@@ -165,7 +165,7 @@ void Scheduler::reset()
     enterTeardown(); // On RootTreeNode
     clearEvents();
 
-    dag_.reset(new DAG(this));
+    dag_.reset(new DAG(this, false));
     dag_finalized_ = false;
 
     tick_quantum_allocator_.clear();


### PR DESCRIPTION
It would make modelers' lives easier to debug Event ordering by just enabling scheduler debug logger `-l scheduler debug 1`.

I implicitly turn on the early cycle detection when the debug logger is enabled. I think that would be useful since that seems never be enabled 🤔 There is a method to turn it on but you would need to re-compile the software during debugging. Let me know your thoughts.