### PR TITLE
Add support for turning off signal handler that prints backtrace

### DIFF
--- a/sparta/sparta/app/Simulation.hpp
+++ b/sparta/sparta/app/Simulation.hpp
@@ -92,8 +92,9 @@ public:
      *        must be made before building/configuring/finalizing.
      * \param sim_name Name of the simulator
      * \param scheduler Pointer to the Scheduler that this Simulation operates with
+     * \param en_backtrace Enable backtrace on error (including SIGSEGV, SIGFPE, SIGILL, SIGABRT, SIGBUS), default is true
      */
-    Simulation(const std::string& sim_name, Scheduler * scheduler);
+    Simulation(const std::string& sim_name, Scheduler * scheduler, bool en_backtrace=true);
 
     /*!
      * \brief Virtual destructor

--- a/sparta/sparta/app/Simulation.hpp
+++ b/sparta/sparta/app/Simulation.hpp
@@ -92,9 +92,8 @@ public:
      *        must be made before building/configuring/finalizing.
      * \param sim_name Name of the simulator
      * \param scheduler Pointer to the Scheduler that this Simulation operates with
-     * \param en_backtrace Enable backtrace on error (including SIGSEGV, SIGFPE, SIGILL, SIGABRT, SIGBUS), default is true
      */
-    Simulation(const std::string& sim_name, Scheduler * scheduler, bool en_backtrace=true);
+    Simulation(const std::string& sim_name, Scheduler * scheduler);
 
     /*!
      * \brief Virtual destructor

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -478,7 +478,7 @@ void Simulation::configure(const int argc,
         throw SpartaException("Logging ennoblement is currently not supported with debug-roi. Use --debug or --debug-on-icount");
     }
 
-    if (SignalMode::ENABLE_BACKTRACE_SIGNALS == signal_mode) {
+    if (SimulationConfiguration::SignalMode::ENABLE_BACKTRACE_SIGNALS == sim_config_->signal_mode) {
         // Handle illegal signals.
         // Note: Update documentation if these signals are modified
         backtrace_.setAsHandler(SIGSEGV);

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -318,8 +318,7 @@ const DatabaseAccessor * Simulation::getSimulationDatabaseAccessor() const
 }
 
 Simulation::Simulation(const std::string& sim_name,
-                       Scheduler * scheduler,
-                       bool en_backtrace) :
+                       Scheduler * scheduler) :
     clk_manager_(scheduler),
     sim_name_(sim_name),
     scheduler_(scheduler),
@@ -335,16 +334,6 @@ Simulation::Simulation(const std::string& sim_name,
 
     // Watch for created nodes to which we will apply taps
     root_.getNodeAttachedNotification().REGISTER_FOR_THIS(rootDescendantAdded_);
-
-    if (en_backtrace) {
-        // Handle illegal signals.
-        // Note: Update documentation if these signals are modified
-        backtrace_.setAsHandler(SIGSEGV);
-        backtrace_.setAsHandler(SIGFPE);
-        backtrace_.setAsHandler(SIGILL);
-        backtrace_.setAsHandler(SIGABRT);
-        backtrace_.setAsHandler(SIGBUS);
-    }
 
     report_repository_.reset(new sparta::ReportRepository(this));
 
@@ -487,6 +476,16 @@ void Simulation::configure(const int argc,
     if(sim_config_->trigger_on_type == SimulationConfiguration::TriggerSource::TRIGGER_ON_ROI &&
        !sim_config_->getTaps().empty()) {
         throw SpartaException("Logging ennoblement is currently not supported with debug-roi. Use --debug or --debug-on-icount");
+    }
+
+    if (SignalMode::ENABLE_BACKTRACE_SIGNALS == signal_mode) {
+        // Handle illegal signals.
+        // Note: Update documentation if these signals are modified
+        backtrace_.setAsHandler(SIGSEGV);
+        backtrace_.setAsHandler(SIGFPE);
+        backtrace_.setAsHandler(SIGILL);
+        backtrace_.setAsHandler(SIGABRT);
+        backtrace_.setAsHandler(SIGBUS);
     }
 
     // If there are nodes already existing in the tree (e.g. root or "") then

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -318,7 +318,8 @@ const DatabaseAccessor * Simulation::getSimulationDatabaseAccessor() const
 }
 
 Simulation::Simulation(const std::string& sim_name,
-                       Scheduler * scheduler) :
+                       Scheduler * scheduler,
+                       bool en_backtrace) :
     clk_manager_(scheduler),
     sim_name_(sim_name),
     scheduler_(scheduler),
@@ -335,13 +336,15 @@ Simulation::Simulation(const std::string& sim_name,
     // Watch for created nodes to which we will apply taps
     root_.getNodeAttachedNotification().REGISTER_FOR_THIS(rootDescendantAdded_);
 
-    // Handle illegal signals.
-    // Note: Update documentation if these signals are modified
-    backtrace_.setAsHandler(SIGSEGV);
-    backtrace_.setAsHandler(SIGFPE);
-    backtrace_.setAsHandler(SIGILL);
-    backtrace_.setAsHandler(SIGABRT);
-    backtrace_.setAsHandler(SIGBUS);
+    if (en_backtrace) {
+        // Handle illegal signals.
+        // Note: Update documentation if these signals are modified
+        backtrace_.setAsHandler(SIGSEGV);
+        backtrace_.setAsHandler(SIGFPE);
+        backtrace_.setAsHandler(SIGILL);
+        backtrace_.setAsHandler(SIGABRT);
+        backtrace_.setAsHandler(SIGBUS);
+    }
 
     report_repository_.reset(new sparta::ReportRepository(this));
 


### PR DESCRIPTION
Enable modelers to disable Sparta's signal handlers, since it conflicts with other framework like SST. No change to default behavior.