### PR TITLE
Why does `collect()` silently ignore unexpected positional args?

### DIFF
--- a/sparta/test/PEvents/PEventHelper_test.cpp
+++ b/sparta/test/PEvents/PEventHelper_test.cpp
@@ -97,6 +97,7 @@ int main() {
     trigger.go();
     A a(1000, 78, 52, 0.01, "test0");
     pair_pevent.collect(a);
+    EXPECT_THROW(pair_event.collect(a, "unexpected positional pair arg"));
     pair_verbose_pevent.collect(a);
     decode_pevent.collect(a);
     my_pevent.collect(a, 32);


### PR DESCRIPTION
Opening a PR for this because it is the easiest way to see if the added test still fails with latest sparta without creating an updated env locally.

I would expect that `pevent.collect()` should throw if called positional arguments that are:
* unexpected (i.e. the pevent wasn't defined to take any positional args)
* mismatching type (as it looks like compilation doesn't catch this) - didn't commit the test I added for this in this commit
* what other sanity checking is feasible?

The test added in this PR shows that we can call `collect()` with positional args for events that haven't registered any positional args.  Why?

As it is, code in the wild has become quite confusing where positional args are being passed to `collect()` and silently ignored.  I'm looking at how to propose improving this part of sparta but I wanted to start a discussion but first create a PR that will demonstrate that this behavior isn't considered a throwable conidtion in latest sparta.