### PR TITLE
Const-ness fixes for Sparta cache classes

### DIFF
--- a/sparta/cache/BasicCacheSet.hpp
+++ b/sparta/cache/BasicCacheSet.hpp
@@ -142,6 +142,11 @@ namespace sparta
                 return line;
             }
 
+            const CacheItemT &peekItemAtWay(uint32_t way_idx) const
+            {
+                assert(way_idx < num_ways_);
+                return ways_[way_idx];
+            }
 
             CacheItemT &getItemAtWay(uint32_t way_idx)
             {

--- a/sparta/cache/Cache.hpp
+++ b/sparta/cache/Cache.hpp
@@ -103,7 +103,7 @@ namespace sparta
             /*
              * \brief Get the cache set for the given index
              */
-            CacheSetT &peekCacheSetAtIndex(uint set_idx) const
+            const CacheSetT &peekCacheSetAtIndex(uint set_idx) const
             {
                 assert(set_idx < num_sets_);
                 return sets_[set_idx];

--- a/sparta/cache/DefaultAddrDecoder.hpp
+++ b/sparta/cache/DefaultAddrDecoder.hpp
@@ -45,9 +45,9 @@ namespace sparta
             virtual uint64_t calcBlockAddr(uint64_t addr) const { return (addr & blk_addr_mask_); }
             virtual uint64_t calcBlockOffset(uint64_t addr) const { return (addr & blk_offset_mask_); }
 
-            uint64_t getIndexMask() { return index_mask_;}
-            uint64_t getIndexShift() { return index_shift_;}
-            uint64_t getBlockOffsetMask() {return blk_offset_mask_;}
+            uint64_t getIndexMask() const { return index_mask_;}
+            uint64_t getIndexShift() const { return index_shift_;}
+            uint64_t getBlockOffsetMask() const { return blk_offset_mask_; }
 
         private:
             uint64_t line_size_;


### PR DESCRIPTION
Add a few fixes that make it possible to use the Sparta cache classes in const contexts.