### PR TITLE
Add simdb report verif test cases for various CSV configurations

### DIFF
--- a/sparta/scripts/simdb/all_csv_cumulative_formats.yaml
+++ b/sparta/scripts/simdb/all_csv_cumulative_formats.yaml
@@ -1,0 +1,220 @@
+content:
+
+  # format: csv_cumulative
+  # trigger(s): start and stop triggers (no update triggers)
+  # location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_start_stop_triggered_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      start:    rob.stats.total_number_retired >= 3500
+      stop:     rob.stats.total_number_retired >= 5000  
+
+  # format: csv_cumulative
+  # trigger(s): start and stop triggers (no update triggers)
+  # location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_start_stop_triggered_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      start:    cpu.core0.rob.stats.total_number_retired >= 3500
+      stop:     cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv_cumulative
+## trigger(s): start and stop triggers (no update triggers)
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_stop_triggered_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      start:    top.cpu.core0.rob.stats.total_number_retired >= 3500
+      stop:     top.cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv_cumulative
+## trigger(s): start trigger only (no update triggers)
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_start_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      start:    rob.stats.total_number_retired >= 3500
+
+## format: csv_cumulative
+## trigger(s): start trigger only (no update triggers)
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_start_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      start:    cpu.core0.rob.stats.total_number_retired >= 3500
+
+## format: csv_cumulative
+## trigger(s): start trigger only (no update triggers)
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      start:    top.cpu.core0.rob.stats.total_number_retired >= 3500
+
+## format: csv_cumulative
+## trigger(s): stop trigger only (no update triggers)
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_stop_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      stop:     rob.stats.total_number_retired >= 5000
+
+## format: csv_cumulative
+## trigger(s): stop trigger only (no update triggers)
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_stop_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      stop:     cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv_cumulative
+## trigger(s): stop trigger only (no update triggers)
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_stop_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      stop:     top.cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv_cumulative
+## trigger(s): update-count trigger only
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_update_count_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-count: rob.stats.total_number_retired 75
+
+## format: csv_cumulative
+## trigger(s): update-count trigger only
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_update_count_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-count: cpu.core0.rob.stats.total_number_retired 75
+
+## format: csv_cumulative
+## trigger(s): update-count trigger only
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_update_count_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-count: top.cpu.core0.rob.stats.total_number_retired 75
+
+## format: csv_cumulative
+## trigger(s): update-cycles trigger only
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_update_cycles_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-cycles: 500
+
+## format: csv_cumulative
+## trigger(s): update-cycles trigger only
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_update_cycles_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-cycles: 500
+
+## format: csv_cumulative
+## trigger(s): update-cycles trigger only
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_update_cycles_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-cycles: 500
+
+## format: csv_cumulative
+## trigger(s): update-time trigger only
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_update_time_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-time: 100 ps
+
+## format: csv_cumulative
+## trigger(s): update-time trigger only
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_update_time_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-time: 100 ps
+
+## format: csv_cumulative
+## trigger(s): update-time trigger only
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_update_time_triggered_only_cumulative.csv
+    format:     csv_cumulative
+    trigger:
+      update-time: 100 ps

--- a/sparta/scripts/simdb/all_csv_formats.yaml
+++ b/sparta/scripts/simdb/all_csv_formats.yaml
@@ -1,0 +1,220 @@
+content:
+
+  # format: csv
+  # trigger(s): start and stop triggers (no update triggers)
+  # location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_start_stop_triggered.csv
+    format:     csv
+    trigger:
+      start:    rob.stats.total_number_retired >= 3500
+      stop:     rob.stats.total_number_retired >= 5000  
+
+  # format: csv
+  # trigger(s): start and stop triggers (no update triggers)
+  # location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_start_stop_triggered.csv
+    format:     csv
+    trigger:
+      start:    cpu.core0.rob.stats.total_number_retired >= 3500
+      stop:     cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv
+## trigger(s): start and stop triggers (no update triggers)
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_stop_triggered.csv
+    format:     csv
+    trigger:
+      start:    top.cpu.core0.rob.stats.total_number_retired >= 3500
+      stop:     top.cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv
+## trigger(s): start trigger only (no update triggers)
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_start_triggered_only.csv
+    format:     csv
+    trigger:
+      start:    rob.stats.total_number_retired >= 3500
+
+## format: csv
+## trigger(s): start trigger only (no update triggers)
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_start_triggered_only.csv
+    format:     csv
+    trigger:
+      start:    cpu.core0.rob.stats.total_number_retired >= 3500
+
+## format: csv
+## trigger(s): start trigger only (no update triggers)
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_triggered_only.csv
+    format:     csv
+    trigger:
+      start:    top.cpu.core0.rob.stats.total_number_retired >= 3500
+
+## format: csv
+## trigger(s): stop trigger only (no update triggers)
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_stop_triggered_only.csv
+    format:     csv
+    trigger:
+      stop:     rob.stats.total_number_retired >= 5000
+
+## format: csv
+## trigger(s): stop trigger only (no update triggers)
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_stop_triggered_only.csv
+    format:     csv
+    trigger:
+      stop:     cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv
+## trigger(s): stop trigger only (no update triggers)
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_stop_triggered_only.csv
+    format:     csv
+    trigger:
+      stop:     top.cpu.core0.rob.stats.total_number_retired >= 5000
+
+## format: csv
+## trigger(s): update-count trigger only
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_update_count_triggered_only.csv
+    format:     csv
+    trigger:
+      update-count: rob.stats.total_number_retired 75
+
+## format: csv
+## trigger(s): update-count trigger only
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_update_count_triggered_only.csv
+    format:     csv
+    trigger:
+      update-count: cpu.core0.rob.stats.total_number_retired 75
+
+## format: csv
+## trigger(s): update-count trigger only
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_update_count_triggered_only.csv
+    format:     csv
+    trigger:
+      update-count: top.cpu.core0.rob.stats.total_number_retired 75
+
+## format: csv
+## trigger(s): update-cycles trigger only
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_update_cycles_triggered_only.csv
+    format:     csv
+    trigger:
+      update-cycles: 500
+
+## format: csv
+## trigger(s): update-cycles trigger only
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_update_cycles_triggered_only.csv
+    format:     csv
+    trigger:
+      update-cycles: 500
+
+## format: csv
+## trigger(s): update-cycles trigger only
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_update_cycles_triggered_only.csv
+    format:     csv
+    trigger:
+      update-cycles: 500
+
+## format: csv
+## trigger(s): update-time trigger only
+## location: core0
+  report:
+    name:       'Core0 stats report'
+    pattern:    top.cpu.core0
+    def_file:   core_stats.yaml
+    dest_file:  core0_update_time_triggered_only.csv
+    format:     csv
+    trigger:
+      update-time: 100 ps
+
+## format: csv
+## trigger(s): update-time trigger only
+## location: top
+  report:
+    name:       'Top stats report'
+    pattern:    top
+    def_file:   top_stats.yaml
+    dest_file:  top_update_time_triggered_only.csv
+    format:     csv
+    trigger:
+      update-time: 100 ps
+
+## format: csv
+## trigger(s): update-time trigger only
+## location: global
+  report:
+    name:       'Global stats report'
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_update_time_triggered_only.csv
+    format:     csv
+    trigger:
+      update-time: 100 ps

--- a/sparta/scripts/simdb/tests.yaml
+++ b/sparta/scripts/simdb/tests.yaml
@@ -1,15 +1,215 @@
-- name: timeseries_basic
-  group: csv
-  args: --report $yamldir$/all_timeseries_formats.yaml
+## SimDB test group: start and stop triggers (no update triggers)
+## format: csv
+- name: core0_stats
+  group: csv/start_stop_triggered
+  args: --report all_csv_formats.yaml
   verif:
-  - core0_stats.csv
-  - top_stats.csv
-  - global_stats.csv
-  - autopop_update_count.csv
-  - autopop_update_cycles.csv
-  - autopop_rob_update_time.csv
-- name: timeseries_cumulative
-  group: csv
-  args: --report $yamldir$/all_timeseries_formats.yaml
+  - core0_start_stop_triggered.csv
+- name: top_stats
+  group: csv/start_stop_triggered
+  args: --report all_csv_formats.yaml
   verif:
-  - global_cumulative_stats.csv
+  - top_start_stop_triggered.csv
+- name: global_stats
+  group: csv/start_stop_triggered
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_start_stop_triggered.csv
+
+## SimDB test group: start trigger only (no update triggers)
+## format: csv
+- name: core0_stats
+  group: csv/start_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - core0_start_triggered_only.csv
+- name: top_stats
+  group: csv/start_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - top_start_triggered_only.csv
+- name: global_stats
+  group: csv/start_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_start_triggered_only.csv
+
+## SimDB test group: stop trigger only (no update triggers)
+## format: csv
+- name: core0_stats
+  group: csv/stop_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - core0_stop_triggered_only.csv
+- name: top_stats
+  group: csv/stop_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - top_stop_triggered_only.csv
+- name: global_stats
+  group: csv/stop_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_stop_triggered_only.csv
+
+## SimDB test group: update-count trigger only
+## format: csv
+- name: core0_stats
+  group: csv/update_count_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - core0_update_count_triggered_only.csv
+- name: top_stats
+  group: csv/update_count_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - top_update_count_triggered_only.csv
+- name: global_stats
+  group: csv/update_count_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_update_count_triggered_only.csv
+
+## SimDB test group: update-cycles trigger only
+## format: csv
+- name: core0_stats
+  group: csv/update_cycles_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - core0_update_cycles_triggered_only.csv
+- name: top_stats
+  group: csv/update_cycles_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - top_update_cycles_triggered_only.csv
+- name: global_stats
+  group: csv/update_cycles_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_update_cycles_triggered_only.csv
+
+## SimDB test group: update-time trigger only
+## format: csv
+- name: core0_stats
+  group: csv/update_time_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - core0_update_time_triggered_only.csv
+- name: top_stats
+  group: csv/update_time_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - top_update_time_triggered_only.csv
+- name: global_stats
+  group: csv/update_time_triggered_only
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_update_time_triggered_only.csv
+
+## SimDB test group: start and stop triggers (no update triggers)
+## format: csv_cumulative
+- name: core0_stats
+  group: csv_cumulative/start_stop_triggered
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - core0_start_stop_triggered_cumulative.csv
+- name: top_stats
+  group: csv_cumulative/start_stop_triggered
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - top_start_stop_triggered_cumulative.csv
+- name: global_stats
+  group: csv_cumulative/start_stop_triggered
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - global_start_stop_triggered_cumulative.csv
+
+## SimDB test group: start trigger only (no update triggers)
+## format: csv_cumulative
+- name: core0_stats
+  group: csv_cumulative/start_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - core0_start_triggered_only_cumulative.csv
+- name: top_stats
+  group: csv_cumulative/start_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - top_start_triggered_only_cumulative.csv
+- name: global_stats
+  group: csv_cumulative/start_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - global_start_triggered_only_cumulative.csv
+
+## SimDB test group: stop trigger only (no update triggers)
+## format: csv_cumulative
+- name: core0_stats
+  group: csv_cumulative/stop_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - core0_stop_triggered_only_cumulative.csv
+- name: top_stats
+  group: csv_cumulative/stop_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - top_stop_triggered_only_cumulative.csv
+- name: global_stats
+  group: csv_cumulative/stop_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - global_stop_triggered_only_cumulative.csv
+
+## SimDB test group: update-count trigger only
+## format: csv_cumulative
+- name: core0_stats
+  group: csv_cumulative/update_count_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - core0_update_count_triggered_only_cumulative.csv
+- name: top_stats
+  group: csv_cumulative/update_count_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - top_update_count_triggered_only_cumulative.csv
+- name: global_stats
+  group: csv_cumulative/update_count_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - global_update_count_triggered_only_cumulative.csv
+
+## SimDB test group: update-cycles trigger only
+## format: csv_cumulative
+- name: core0_stats
+  group: csv_cumulative/update_cycles_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - core0_update_cycles_triggered_only_cumulative.csv
+- name: top_stats
+  group: csv_cumulative/update_cycles_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - top_update_cycles_triggered_only_cumulative.csv
+- name: global_stats
+  group: csv_cumulative/update_cycles_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - global_update_cycles_triggered_only_cumulative.csv
+
+## SimDB test group: update-time trigger only
+## format: csv_cumulative
+- name: core0_stats
+  group: csv_cumulative/update_time_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - core0_update_time_triggered_only_cumulative.csv
+- name: top_stats
+  group: csv_cumulative/update_time_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - top_update_time_triggered_only_cumulative.csv
+- name: global_stats
+  group: csv_cumulative/update_time_triggered_only
+  args: --report all_csv_cumulative_formats.yaml
+  verif:
+  - global_update_time_triggered_only_cumulative.csv


### PR DESCRIPTION
This PR increases the testing for CSV reports to 36 test cases. Here is the result of the verif script:

```
Pass rate by group:
  csv            -- 6/18 tests passed.
  csv_cumulative -- 6/18 tests passed.

Report verification completed. Results saved in 'simdb_verif_results'.
```

The plan is to get a full test suite for all CSV, JSON, and TXT formats by 5/2 to create a "MAP v3 burndown list". Other formats like HTML/pydict will be addressed in v3. When everything is passing and performant for all formats sometime in v3, we can remove all the legacy formatter C++ code and stick with SimDB.