### PR TITLE
Get all SimDB-exported CSV reports to match MAP v2 formatters exactly

### DIFF
--- a/sparta/scripts/simdb/all_csv_formats.yaml
+++ b/sparta/scripts/simdb/all_csv_formats.yaml
@@ -26,9 +26,9 @@ content:
       start:    cpu.core0.rob.stats.total_number_retired >= 3500
       stop:     cpu.core0.rob.stats.total_number_retired >= 5000
 
-## format: csv
-## trigger(s): start and stop triggers (no update triggers)
-## location: global
+  ## format: csv
+  ## trigger(s): start and stop triggers (no update triggers)
+  ## location: global
   report:
     name:       'Global stats report'
     pattern:    _global
@@ -39,9 +39,9 @@ content:
       start:    top.cpu.core0.rob.stats.total_number_retired >= 3500
       stop:     top.cpu.core0.rob.stats.total_number_retired >= 5000
 
-## format: csv
-## trigger(s): start trigger only (no update triggers)
-## location: core0
+  ## format: csv
+  ## trigger(s): start trigger only (no update triggers)
+  ## location: core0
   report:
     name:       'Core0 stats report'
     pattern:    top.cpu.core0
@@ -51,9 +51,9 @@ content:
     trigger:
       start:    rob.stats.total_number_retired >= 3500
 
-## format: csv
-## trigger(s): start trigger only (no update triggers)
-## location: top
+  ## format: csv
+  ## trigger(s): start trigger only (no update triggers)
+  ## location: top
   report:
     name:       'Top stats report'
     pattern:    top
@@ -63,9 +63,9 @@ content:
     trigger:
       start:    cpu.core0.rob.stats.total_number_retired >= 3500
 
-## format: csv
-## trigger(s): start trigger only (no update triggers)
-## location: global
+  ## format: csv
+  ## trigger(s): start trigger only (no update triggers)
+  ## location: global
   report:
     name:       'Global stats report'
     pattern:    _global
@@ -75,9 +75,9 @@ content:
     trigger:
       start:    top.cpu.core0.rob.stats.total_number_retired >= 3500
 
-## format: csv
-## trigger(s): stop trigger only (no update triggers)
-## location: core0
+  ## format: csv
+  ## trigger(s): stop trigger only (no update triggers)
+  ## location: core0
   report:
     name:       'Core0 stats report'
     pattern:    top.cpu.core0
@@ -87,9 +87,9 @@ content:
     trigger:
       stop:     rob.stats.total_number_retired >= 5000
 
-## format: csv
-## trigger(s): stop trigger only (no update triggers)
-## location: top
+  ## format: csv
+  ## trigger(s): stop trigger only (no update triggers)
+  ## location: top
   report:
     name:       'Top stats report'
     pattern:    top
@@ -99,9 +99,9 @@ content:
     trigger:
       stop:     cpu.core0.rob.stats.total_number_retired >= 5000
 
-## format: csv
-## trigger(s): stop trigger only (no update triggers)
-## location: global
+  ## format: csv
+  ## trigger(s): stop trigger only (no update triggers)
+  ## location: global
   report:
     name:       'Global stats report'
     pattern:    _global
@@ -111,9 +111,9 @@ content:
     trigger:
       stop:     top.cpu.core0.rob.stats.total_number_retired >= 5000
 
-## format: csv
-## trigger(s): update-count trigger only
-## location: core0
+  ## format: csv
+  ## trigger(s): update-count trigger only
+  ## location: core0
   report:
     name:       'Core0 stats report'
     pattern:    top.cpu.core0
@@ -123,9 +123,9 @@ content:
     trigger:
       update-count: rob.stats.total_number_retired 75
 
-## format: csv
-## trigger(s): update-count trigger only
-## location: top
+  ## format: csv
+  ## trigger(s): update-count trigger only
+  ## location: top
   report:
     name:       'Top stats report'
     pattern:    top
@@ -135,9 +135,9 @@ content:
     trigger:
       update-count: cpu.core0.rob.stats.total_number_retired 75
 
-## format: csv
-## trigger(s): update-count trigger only
-## location: global
+  ## format: csv
+  ## trigger(s): update-count trigger only
+  ## location: global
   report:
     name:       'Global stats report'
     pattern:    _global
@@ -147,9 +147,9 @@ content:
     trigger:
       update-count: top.cpu.core0.rob.stats.total_number_retired 75
 
-## format: csv
-## trigger(s): update-cycles trigger only
-## location: core0
+  ## format: csv
+  ## trigger(s): update-cycles trigger only
+  ## location: core0
   report:
     name:       'Core0 stats report'
     pattern:    top.cpu.core0
@@ -159,9 +159,9 @@ content:
     trigger:
       update-cycles: 500
 
-## format: csv
-## trigger(s): update-cycles trigger only
-## location: top
+  ## format: csv
+  ## trigger(s): update-cycles trigger only
+  ## location: top
   report:
     name:       'Top stats report'
     pattern:    top
@@ -171,9 +171,9 @@ content:
     trigger:
       update-cycles: 500
 
-## format: csv
-## trigger(s): update-cycles trigger only
-## location: global
+  ## format: csv
+  ## trigger(s): update-cycles trigger only
+  ## location: global
   report:
     name:       'Global stats report'
     pattern:    _global
@@ -183,9 +183,9 @@ content:
     trigger:
       update-cycles: 500
 
-## format: csv
-## trigger(s): update-time trigger only
-## location: core0
+  ## format: csv
+  ## trigger(s): update-time trigger only
+  ## location: core0
   report:
     name:       'Core0 stats report'
     pattern:    top.cpu.core0
@@ -195,9 +195,9 @@ content:
     trigger:
       update-time: 100 ps
 
-## format: csv
-## trigger(s): update-time trigger only
-## location: top
+  ## format: csv
+  ## trigger(s): update-time trigger only
+  ## location: top
   report:
     name:       'Top stats report'
     pattern:    top
@@ -207,9 +207,9 @@ content:
     trigger:
       update-time: 100 ps
 
-## format: csv
-## trigger(s): update-time trigger only
-## location: global
+  ## format: csv
+  ## trigger(s): update-time trigger only
+  ## location: global
   report:
     name:       'Global stats report'
     pattern:    _global
@@ -218,3 +218,42 @@ content:
     format:     csv
     trigger:
       update-time: 100 ps
+
+  ## format: csv
+  ## trigger(s): start, update-count, and toggle triggers
+  ## location: global
+  report:
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_toggle_update_count.csv
+    format:     csv
+    trigger:
+     whenever: notif.stats_profiler == 1
+     update-count: top.cpu.core0.rob.stats.total_number_retired 100
+     start:    top.cpu.core0.rob.stats.total_number_retired >= 1000
+
+  ## format: csv
+  ## trigger(s): start, update-cycles, and toggle triggers
+  ## location: global
+  report:
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_toggle_update_cycles.csv
+    format:     csv
+    trigger:
+      whenever: notif.stats_profiler == 1
+      update-cycles: 175
+      start:    top.cpu.core0.rob.stats.total_number_retired >= 1000
+
+  ## format: csv
+  ## trigger(s): start, update-time, and toggle triggers
+  ## location: global
+  report:
+    pattern:    _global
+    def_file:   simple_stats.yaml
+    dest_file:  global_start_toggle_update_time.csv
+    format:     csv
+    trigger:
+      whenever: notif.stats_profiler == 1
+      update-time: 1 ns
+      start:    top.cpu.core0.rob.stats.total_number_retired >= 1000

--- a/sparta/scripts/simdb/create_tests.py
+++ b/sparta/scripts/simdb/create_tests.py
@@ -1,0 +1,171 @@
+import os, sys 
+import yaml 
+import argparse
+import re
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sparta_dir = os.path.dirname(os.path.dirname(script_dir))
+core_model_dir = os.path.join(sparta_dir, "example", "CoreModel")
+default_cmake_list_file = os.path.join(core_model_dir, "CMakeLists.txt")
+
+parser = argparse.ArgumentParser(description='Create test definition YAML file from CMakeLists.txt for verif_simdb_reports')
+parser.add_argument('--cmake-list-file', type=str, default=default_cmake_list_file,
+                    help='Path to the CMakeLists.txt file to parse for test definitions')
+parser.add_argument('--outfile', type=str, default='tests.yaml', help='Output YAML file name')
+args = parser.parse_args()
+
+class SpartaTest:
+    @classmethod
+    def CreateFromCMake(cls, cmake_text, cmake_dir):
+        # Only create tests that include "--report" in the cmake_text,
+        # and that start with "sparta_named_test".
+        if not cmake_text.startswith("sparta_named_test("):
+            return None
+
+        # We only support the use of --report like this:
+        #    --report descriptor.yaml
+        # Not this:
+        #    --report top defn.yaml out.json
+        
+        # Use a regex to extract the test name and the sim command.
+        #   e.g. "sparta_named_test(json_reports sparta_core_example -i 10k --report all_json_formats.yaml)"
+        #   becomes:
+        #   test_name = "json_reports"
+        #   sim_cmd = "sparta_core_example -i 10k --report all_json_formats.yaml"
+        match = re.match(r'sparta_named_test\(([^ ]+) ([^ ]+.*)\)', cmake_text)
+        if match:
+            test_name = match.group(1)
+            sim_cmd = match.group(2)
+        else:
+            return None
+
+        top_level_yamls = []
+        for i, arg in enumerate(sim_cmd.split()):
+            if arg == "--report" and i + 1 < len(sim_cmd.split()):
+                # The next argument is the report descriptor file.
+                report_descriptor = sim_cmd.split()[i + 1]
+                if not report_descriptor.endswith(".yaml"):
+                    return None
+                top_level_yamls.append(report_descriptor)
+            elif arg == "--report":
+                return None
+
+        if not top_level_yamls:
+            return None
+
+        return cls(test_name, sim_cmd, cmake_dir, top_level_yamls)
+
+    def __init__(self, test_name, sim_cmd, cmake_dir, top_level_yamls):
+        self.test_name = test_name
+        self.sim_cmd = sim_cmd
+        self.cmake_dir = cmake_dir
+        self.top_level_yamls = top_level_yamls
+
+    def ExtractVerifTests(self):
+        test_yamls = []
+        for top_level_yaml in self.top_level_yamls:
+            yaml_file = os.path.join(self.cmake_dir, top_level_yaml)
+            # Ideally we could use yaml.load() here, but the format
+            # we use in CMakeLists.txt is not exactly valid YAML.
+            # The form is not really a list like it should be:
+            #
+            #   content:
+            #     report:
+            #       pattern:   <pattern>
+            #       def_file:  <def_file>
+            #       dest_file: <dest_file>
+            #       format:    <format>
+            #     report:
+            #       pattern:   <pattern>
+            #       def_file:  <def_file>
+            #       dest_file: <dest_file>
+            #       format:    <format>
+            #     ...
+            #
+            # So we will parse the file ourselves.
+            descriptors = []
+            with open(yaml_file, 'r') as fin:
+                for line in fin.readlines():
+                    line = line.strip()
+                    if line in ('report:', '- report:'):
+                        descriptors.append(ReportDescriptor())
+                    elif line.startswith('pattern:'):
+                        pattern = line.split(':')[1].strip()
+                        descriptors[-1].pattern = pattern
+                    elif line.startswith('def_file:'):
+                        def_file = line.split(':')[1].strip()
+                        descriptors[-1].def_file = def_file
+                    elif line.startswith('dest_file:'):
+                        dest_file = line.split(':')[1].strip()
+                        descriptors[-1].dest_file = dest_file
+                    elif line.startswith('format:'):
+                        format = line.split(':')[1].strip()
+                        descriptors[-1].format = format
+
+            # Make sure the format field is set, else infer it from the dest_file extension.
+            for descriptor in descriptors:
+                if not isinstance(descriptor.format, str) or not descriptor.format:
+                    extension = os.path.splitext(descriptor.dest_file)[1]
+                    descriptor.format = extension.lstrip('.')
+
+        # Group the descriptors by format.
+        descriptors_by_format = {}
+        for descriptor in descriptors:
+            # Skip over any descriptor that doesn't have a format.
+            # The only way this happens is if the dest_file is '1'
+            # which means "print to stdout".
+            if not descriptor.format:
+                continue
+
+            if descriptor.format not in descriptors_by_format:
+                descriptors_by_format[descriptor.format] = []
+            descriptors_by_format[descriptor.format].append(descriptor)
+
+        # The yaml format for one SimDB report verif test is:
+        #
+        #     - name:  <test_name>_<format>
+        #       group: <format>/<test_name>
+        #       args:  <sim_cmd>         // not including executable
+        #       verif:
+        #       - report1.<format>
+        #       - report2.<format>
+        #       ...
+        for format, descriptors in descriptors_by_format.items():
+            sim_args = self.sim_cmd.split()
+            sim_args = ' '.join(sim_args[1:])  # Remove the executable name.
+
+            test_yaml = {
+                'name': f"{self.test_name}_{format}",
+                'group': format + "/" + self.test_name,
+                'args': sim_args,
+                'verif': [desc.dest_file for desc in descriptors]
+            }
+            test_yamls.append(test_yaml)
+
+        return test_yamls
+
+class ReportDescriptor:
+    def __init__(self):
+        self.pattern = None
+        self.def_file = None
+        self.dest_file = None
+        self.format = None
+
+# Go through the CMakeLists.txt file and find all the Sparta tests.
+sparta_tests = []
+with open(args.cmake_list_file, 'r') as f:
+    cmake_dir = os.path.dirname(args.cmake_list_file)
+    cmake_text = f.read()
+    for line in cmake_text.splitlines():
+        test = SpartaTest.CreateFromCMake(line, cmake_dir)
+        if test:
+            sparta_tests.append(test)
+
+# Each SpartaTest can "expand" into multiple verif_simdb_reports tests.
+verif_tests = []
+for test in sparta_tests:
+    verif_tests.extend(test.ExtractVerifTests())
+
+# Write the tests to the output YAML file.
+with open(args.outfile, 'w') as fout:
+    yaml.dump(verif_tests, fout, default_flow_style=False)

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -16,6 +16,10 @@ class CSVReportExporter:
 
         cmd = f'SELECT MetaName, MetaValue FROM ReportMetadata WHERE ReportDescID={descriptor_id} '
         cmd += 'AND MetaName NOT IN (\'OmitZeros\', \'PrettyPrint\')'
+
+        # Sort alphabetically by name to match std::map<string, string> in C++.
+        cmd += ' ORDER BY MetaName ASC'
+
         cursor.execute(cmd)
 
         meta_kvpairs = []

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -114,8 +114,14 @@ class CSVReportExporter:
         fout.write(','.join(meta_kvpairs))
         fout.write('\n')
 
-        for trigger_name, trigger_loc in trigger_locs:
-            fout.write(f'# {trigger_name}={trigger_loc}\n')
+        # Write the trigger locations if provided
+        if trigger_locs:
+            fout.write('# ')
+            strs = []
+            for name, loc in trigger_locs:
+                strs.append(f'{name}={loc}')
+            fout.write(','.join(strs))
+            fout.write('\n')
 
     def __RecurseGetStatHeaders(self, cursor, report_id, prefix, stat_headers):
         cmd = f'SELECT StatisticName, StatisticLoc FROM StatisticInsts WHERE ReportID={report_id}'

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -26,6 +26,19 @@ class CSVReportExporter:
         for meta_name, meta_value in cursor.fetchall():
             meta_kvpairs.append((meta_name, meta_value))
 
+        # Force the "report_format" metadata to be visible at the top of the CSV file.
+        has_report_format = False
+        for meta_name, meta_value in meta_kvpairs:
+            if meta_name == 'report_format':
+                has_report_format = True
+                break
+
+        if not has_report_format:
+            cmd = f'SELECT Format FROM ReportDescriptors WHERE Id={descriptor_id}'
+            cursor.execute(cmd)
+            format = cursor.fetchone()[0]
+            meta_kvpairs.append(('report_format', format))
+
         with open(dest_file, 'w') as fout:
             self.__WriteHeader(fout, report_name, start_tick, end_tick, meta_kvpairs)
 

--- a/sparta/scripts/simdb/tests.yaml
+++ b/sparta/scripts/simdb/tests.yaml
@@ -213,3 +213,21 @@
   args: --report all_csv_cumulative_formats.yaml
   verif:
   - global_update_time_triggered_only_cumulative.csv
+
+## SimDB test group: start, update, and toggle triggers
+## format: csv
+- name: toggled_with_update_count
+  group: csv/toggled
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_start_toggle_update_count.csv
+- name: toggled_with_update_cycles
+  group: csv/toggled
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_start_toggle_update_cycles.csv
+- name: toggled_with_update_time
+  group: csv/toggled
+  args: --report all_csv_formats.yaml
+  verif:
+  - global_start_toggle_update_time.csv

--- a/sparta/scripts/simdb/verif_simdb_reports.py
+++ b/sparta/scripts/simdb/verif_simdb_reports.py
@@ -387,32 +387,18 @@ class CSVReportComparator(Comparator):
         Comparator.__init__(self)
 
     def Compare(self, baseline_report, simdb_report):
-        with open(baseline_report, "r", encoding="utf-8") as bf, open(simdb_report, "r", encoding="utf-8") as ef:
-            baseline_reader = list(csv.reader(bf))
-            export_reader = list(csv.reader(ef))
+        with open(baseline_report, "r") as bf, open(simdb_report, "r") as ef:
+            bf_lines = bf.readlines()
+            ef_lines = ef.readlines()
 
-        if len(baseline_reader) != len(export_reader):
-            return False
-
-        for row, (baseline_text, export_text) in enumerate(zip(baseline_reader, export_reader)):
-            if len(baseline_text) != len(export_text):
+            if len(bf_lines) != len(ef_lines):
                 return False
 
-            if row <= 1:
-                # Metadata and stat locations headers: soft compare
-                norm1 = [self.NormalizeText(cell) for cell in baseline_text]
-                norm2 = [self.NormalizeText(cell) for cell in export_text]
-                if norm1 != norm2:
-                    return False
-            else:
-                # Data rows: strict float compare
-                try:
-                    floats1 = [float(cell) for cell in baseline_text]
-                    floats2 = [float(cell) for cell in export_text]
-                except ValueError as e:
-                    return False
+            for i in range(len(bf_lines)):
+                bf_line = self.NormalizeText(bf_lines[i])
+                ef_line = self.NormalizeText(ef_lines[i])
 
-                if floats1 != floats2:
+                if bf_line != ef_line:
                     return False
 
         return True

--- a/sparta/scripts/simdb/verif_simdb_reports.py
+++ b/sparta/scripts/simdb/verif_simdb_reports.py
@@ -290,9 +290,9 @@ class TestSuite:
 
             if subdir not in test_results_summary:
                 test_results_summary[subdir] = {}
-            if test_case.test_group not in test_results_summary[subdir]:
-                test_results_summary[subdir][test_case.test_group] = []
-            test_results_summary[subdir][test_case.test_group].append(test_case.test_name)
+            if test_group not in test_results_summary[subdir]:
+                test_results_summary[subdir][test_group] = []
+            test_results_summary[subdir][test_group].append(test_name)
 
             for artifact in test_artifacts:
                 # The artifacts can be something like "basic.csv" or "simdb_reports/basic.csv" so

--- a/sparta/scripts/simdb/verif_simdb_reports.py
+++ b/sparta/scripts/simdb/verif_simdb_reports.py
@@ -91,6 +91,14 @@ class TestCase:
         MakeExecutable("sim.rerun.cmd")
         self.test_artifacts.append("sim.rerun.cmd")
 
+        # Ensure the --report <file.yaml> is copied to the results directory,
+        # so that the sim.cmd and sim.rerun.cmd can be run as-is.
+        cmd_args = self.sim_cmd.split()
+        for i, arg in enumerate(cmd_args):
+            if cmd_args[i] == "--report" and i + 1 < len(cmd_args):
+                report_yaml = cmd_args[i + 1]
+                self.test_artifacts.append(report_yaml)
+
         # Verify that the baseline reports all exist, else this test is
         # considered a failure.
         failed = False

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -231,6 +231,14 @@ namespace sparta {
              */
             void sweepSimDbStats_();
 
+            /*!
+             * \brief Add a row of empty values to the SimDB collection system. This
+             * is used to support toggle triggers for timeseries reports. The resulting
+             * CSV report will just have row(s) of empty values for the scheduler ticks
+             * that the report was not active.
+             */
+            void skipSimDbStats_();
+
             friend class ReportDescriptorCollection;
 
         public:

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -389,8 +389,14 @@ namespace sparta {
             /*!
              * \brief Write all metadata about our report (and its subreports
              * and statistics) to SimDB.
+             * 
+             * \return Returns the database ID of the report descriptor in the 
+             * ReportDescriptors table. Returns 0 if:
+             *    - SIMDB_ENABLED is false
+             *    - this descriptor is not enabled
+             *    - this descriptor has no reports
              */
-            void configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root);
+            int configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root);
 
             //! \brief Report descriptors may be triggered to stop early - ensure no
             //! further updates are written to disk

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -318,6 +318,19 @@ void ReportDescriptor::sweepSimDbStats_()
 #endif
 }
 
+void ReportDescriptor::skipSimDbStats_()
+{
+#if SIMDB_ENABLED
+    if (db_mgr_ == nullptr || skipped_annotator_ == nullptr) {
+        return;
+    }
+
+    const std::string annotation = dest_file + "_skipped_anno_" + skipped_annotator_->currentAnnotation();
+    const auto tick = scheduler_->getCurrentTick();
+    db_mgr_->getCollectionMgr()->sweep("root", tick, annotation, true);
+#endif
+}
+
 report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,
                                                                   Simulation* sim,
                                                                   std::ostream* out)
@@ -518,6 +531,9 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
                     inst.second->skip(skipped_annotator_.get());
                     inst.first->start();
                     capture_update_values = false;
+                    if (db_mgr_) {
+                        skipSimDbStats_();
+                    }
                 }
                 skipped_annotator_->reset();
             }

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -186,16 +186,16 @@ std::shared_ptr<statistics::StreamNode> ReportDescriptor::createRootStatisticsSt
     return nullptr;
 }
 
-void ReportDescriptor::configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root)
+int ReportDescriptor::configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root)
 {
 #if SIMDB_ENABLED
     if (!isEnabled()) {
-        return;
+        return 0;
     }
 
     const std::vector<Report*> reports = getAllInstantiations();
     if (reports.empty()) {
-        return;
+        return 0;
     }
 
     db_mgr_ = db_mgr;
@@ -221,9 +221,12 @@ void ReportDescriptor::configSimDbReports(simdb::DatabaseManager* db_mgr, RootTr
     for (const auto r : reports) {
         configSimDbReport_(r, visited_stats, report_desc_id);
     }
+
+    return report_desc_id;
 #else
     (void) db_mgr;
     (void) root;
+    return 0;
 #endif
 }
 

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -529,6 +529,7 @@ private:
             domain_for_pending_update_trigger_.clearValid();
         }
 
+        const bool first = formatters_.empty();
         this->initializeReportInstantiations_();
 
         if (is_cumulative_) {
@@ -538,7 +539,7 @@ private:
         }
 
     #if SIMDB_ENABLED
-        if (db_mgr_ != nullptr && desc_simdb_id_ != 0) {
+        if (first && db_mgr_ != nullptr && desc_simdb_id_ != 0) {
             // Note that all of our reports (and their subreports) have
             // the same start tick.
             std::ostringstream cmd;

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -727,6 +727,45 @@ private:
 
     void setHeaderInfoForReports_()
     {
+    #if SIMDB_ENABLED
+        std::string start_counter_loc;
+        std::string stop_counter_loc;
+        std::string update_counter_loc;
+
+        if (report_start_trigger_ != nullptr) {
+            auto ctr = report_start_trigger_->getCounter();
+            if (ctr != nullptr) {
+                start_counter_loc = ctr->getLocation();
+            }
+        }
+
+        if (report_stop_trigger_ != nullptr) {
+            auto ctr = report_stop_trigger_->getCounter();
+            if (ctr != nullptr) {
+                stop_counter_loc = ctr->getLocation();
+            }
+        }
+
+        if (report_update_trigger_ != nullptr) {
+            auto ctr = report_update_trigger_->getCounter();
+            if (ctr != nullptr) {
+                update_counter_loc = ctr->getLocation();
+            }
+        }
+
+        if (db_mgr_ != nullptr && desc_simdb_id_ != 0) {
+            std::ostringstream cmd;
+            cmd << "UPDATE Reports SET "
+                << "StartCounter = '" << start_counter_loc << "', "
+                << "StopCounter = '" << stop_counter_loc << "', "
+                << "UpdateCounter = '" << update_counter_loc << "'"
+                << " WHERE ReportDescID = " << desc_simdb_id_
+                << " AND ParentReportID = 0";
+
+            db_mgr_->EXECUTE(cmd.str());
+        }
+    #endif
+
         for (auto & r : reports_) {
             auto & header = r->getHeader();
 
@@ -1050,6 +1089,12 @@ public:
             report_tbl.addColumn("StartTick", dt::int64_t);
             report_tbl.addColumn("EndTick", dt::int64_t);
             report_tbl.addColumn("InfoString", dt::string_t);
+            report_tbl.addColumn("StartCounter", dt::string_t);
+            report_tbl.addColumn("StopCounter", dt::string_t);
+            report_tbl.addColumn("UpdateCounter", dt::string_t);
+            report_tbl.setColumnDefaultValue("StartCounter", std::string());
+            report_tbl.setColumnDefaultValue("StopCounter", std::string());
+            report_tbl.setColumnDefaultValue("UpdateCounter", std::string());
 
             auto& report_meta_tbl = schema.addTable("ReportMetadata");
             report_meta_tbl.addColumn("ReportDescID", dt::int32_t);


### PR DESCRIPTION
tl;dr - In total, 61 different tests all match exactly for the csv and csv_cumulative formats.

I used the "create_tests.py" script to create a much larger tests.yaml -- the script turns every sparta_named_test into a yaml definition that the test suite can use (basically scripts a new generation of tests.yaml instead of the hand rolled file I wrote with 18 or so tests in it). 