### PR TITLE
SimDB-exported json reports

### DIFF
--- a/sparta/example/CoreModel/CMakeLists.txt
+++ b/sparta/example/CoreModel/CMakeLists.txt
@@ -94,6 +94,7 @@ sparta_named_test(sparta_core_example_retired_inst_path sparta_core_example -i 1
 sparta_named_test(sparta_core_example_legacy_warmup_notification sparta_core_example -i 50k --report notif_all_threads_warmed_up.yaml --report report_start_on_warmup_notif.yaml --num-cores 2)
 sparta_named_test(sparta_core_example_two_reports_json_full_format sparta_core_example -i 10k --report multireports_json_full.yaml)
 sparta_named_test(sparta_core_example_two_reports_json_detail_format sparta_core_example -i 10k --report multireports_json_detail.yaml)
+sparta_named_test(sparta_core_example_json_detail_decode sparta_core_example -i 10k --report json_detail_decode.yaml)
 sparta_named_test(sparta_core_example_two_reports_json_reduced_format sparta_core_example -i 10k --report multireports_json_reduced.yaml)
 sparta_named_test(sparta_core_example_tree_node_extensions_written_to_final_config sparta_core_example -i 10k --arch-search-dir . --arch extensions_in_arch_file.yaml --config-file extensions_in_config_file.yaml --extension-file tree_node_extensions.yaml --write-final-config final_cfg_with_extensions.yaml)
 sparta_named_test(sparta_core_example_update_reports_on_demand sparta_core_example -i 10k --report update_report_on_demand.yaml)

--- a/sparta/example/CoreModel/json_detail_decode.yaml
+++ b/sparta/example/CoreModel/json_detail_decode.yaml
@@ -1,0 +1,6 @@
+content:
+  report:
+    pattern:   top.cpu.core*.decode
+    def_file:  simple_stats.yaml
+    dest_file: decode_detail.json
+    format:    json_detail

--- a/sparta/scripts/simdb/exporters/export_json_report.py
+++ b/sparta/scripts/simdb/exporters/export_json_report.py
@@ -190,8 +190,85 @@ class JSONDetailReportExporter:
         pass
 
     def Export(self, dest_file, descriptor_id, db_conn):
-        # For now, just "touch" each report file. The comparison script will naturally
-        # fail which is okay for now.
+        report_paths_by_id = {}
+        cursor = db_conn.cursor()
+        self.__RecursivelyGetReportPaths(cursor, descriptor_id, 0, report_paths_by_id, "")
+
+        stat_def_meta_by_si_id = {}
+        cmd = "SELECT StatisticInstID, MetaName, MetaValue FROM StatisticDefnMetadata"
+        cursor.execute(cmd)
+
+        for si_id, meta_name, meta_value in cursor.fetchall():
+            if si_id not in stat_def_meta_by_si_id:
+                stat_def_meta_by_si_id[si_id] = OrderedDict()
+
+            try:
+                meta_value = int(meta_value)
+            except ValueError:
+                pass
+
+            stat_def_meta_by_si_id[si_id][meta_name] = meta_value
+
+        report_ids = list(report_paths_by_id.keys())
+        detail_json_map = self.__GetStatDetails(cursor, report_ids, report_paths_by_id, stat_def_meta_by_si_id)
+
+        report_metadata = GetJsonReportMetadata(cursor, descriptor_id, "json_detail")
+        report_json = {
+            "_id": " ",
+            "report_metadata": report_metadata,
+            "stat_info": OrderedDict()
+        }
+
+        si_names = list(detail_json_map.keys())
+        si_names.sort()
+
+        for si_name in si_names:
+            report_json["stat_info"][si_name] = detail_json_map[si_name]
+
         with open(dest_file, "w") as fout:
-            print (f"Exporting {dest_file}...")
-            fout.write("# This is a placeholder file. The SimDB exporter is not implemented yet.\n")
+            json.dump(report_json, fout, indent=2)
+
+    def __RecursivelyGetReportPaths(self, cursor, descriptor_id, parent_report_id, report_paths_by_id, prefix):
+        cmd = f"SELECT Id, Name FROM Reports WHERE ReportDescID = {descriptor_id} AND ParentReportID = {parent_report_id}"
+        cursor.execute(cmd)
+
+        for report_id, name in cursor.fetchall():
+            local_name = ""
+            if prefix == "" or prefix.startswith("@ on _SPARTA_global_node_"):
+                local_name = name.split(".")[-1]
+            else:
+                local_name = prefix + "." + name.split(".")[-1]
+
+            report_paths_by_id[report_id] = local_name
+            self.__RecursivelyGetReportPaths(cursor, descriptor_id, report_id, report_paths_by_id, local_name)
+
+    def __GetStatDetails(self, cursor, report_ids, report_paths_by_id, stat_def_meta_by_si_id):
+        cmd = "SELECT Id, ReportID, StatisticName, StatisticDesc, StatisticVis, StatisticClass FROM StatisticInsts"
+        cmd += " WHERE ReportID IN (" + ",".join(map(str, report_ids)) + ")"
+        cursor.execute(cmd)
+
+        detail_json_map = {}
+        for si_id, report_id, si_name, si_desc, si_vis, si_class in cursor.fetchall():
+            if not si_name:
+                continue
+
+            if report_id not in report_ids:
+                continue
+
+            si_details = OrderedDict([
+                ("name", report_paths_by_id[report_id] + "." + si_name),
+                ("desc", si_desc),
+                ("vis", str(si_vis)),
+                ("class", str(si_class))
+            ])
+
+            if si_id in stat_def_meta_by_si_id:
+                for meta_name, meta_value in stat_def_meta_by_si_id[si_id].items():
+                    si_details[meta_name] = meta_value
+
+            if si_name not in detail_json_map:
+                detail_json_map[si_name] = []
+
+            detail_json_map[si_name].append(si_details)
+
+        return detail_json_map

--- a/sparta/scripts/simdb/run_report_verif_suite.py
+++ b/sparta/scripts/simdb/run_report_verif_suite.py
@@ -511,6 +511,8 @@ def FindNumTestsByFormat(passfail):
                     for d in dirs:
                         if d.endswith("."+format):
                             num_tests += 1
+                        elif format == "js_json" and d.endswith(".json"):
+                            num_tests += 1
 
                 num_tests_by_format[format] = num_tests
 

--- a/sparta/sparta/report/format/DetailInfoData.hpp
+++ b/sparta/sparta/report/format/DetailInfoData.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace sparta::report::format
+{
+    using StringPair = std::pair<std::string, std::string>;
+
+    struct info_data {
+        std::string name;
+        std::string desc;
+        uint64_t vis;
+        uint64_t n_class;
+        std::vector<StringPair> metadata;
+
+        bool operator==(const info_data& other) const
+        {
+            return name == other.name && desc == other.desc &&
+                   vis == other.vis && n_class == other.n_class &&
+                   metadata == other.metadata;
+        }
+    };
+} // end namespace sparta::report::format
+
+// Hash combine helper
+template <typename T>
+inline void hash_combine(std::size_t& seed, const T& val) {
+    seed ^= std::hash<T>{}(val) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+namespace std
+{
+    template <>
+    struct hash<sparta::report::format::StringPair> {
+        std::size_t operator()(const sparta::report::format::StringPair& p) const {
+            std::size_t h = 0;
+            hash_combine(h, p.first);
+            hash_combine(h, p.second);
+            return h;
+        }
+    };
+
+    template <>
+    struct hash<sparta::report::format::info_data> {
+        std::size_t operator()(const sparta::report::format::info_data& data) const {
+            std::size_t seed = 0;
+            hash_combine(seed, data.name);
+            hash_combine(seed, data.desc);
+            hash_combine(seed, data.vis);
+            hash_combine(seed, data.n_class);
+            for (const auto& pair : data.metadata) {
+                hash_combine(seed, pair);
+            }
+            return seed;
+        }
+    };
+
+} // end namespace std

--- a/sparta/sparta/report/format/JSON_detail.hpp
+++ b/sparta/sparta/report/format/JSON_detail.hpp
@@ -16,7 +16,6 @@
 
 #include "sparta/report/format/BaseOstreamFormatter.hpp"
 #include "sparta/report/format/DetailInfoData.hpp"
-#include "sparta/report/db/DatabaseContextCounter.hpp"
 #include "sparta/utils/SpartaException.hpp"
 #include "sparta/utils/SpartaAssert.hpp"
 

--- a/sparta/sparta/report/format/JSON_detail.hpp
+++ b/sparta/sparta/report/format/JSON_detail.hpp
@@ -15,27 +15,13 @@
 #include <boost/lexical_cast.hpp>
 
 #include "sparta/report/format/BaseOstreamFormatter.hpp"
+#include "sparta/report/format/DetailInfoData.hpp"
+#include "sparta/report/db/DatabaseContextCounter.hpp"
 #include "sparta/utils/SpartaException.hpp"
 #include "sparta/utils/SpartaAssert.hpp"
 
-namespace sparta
+namespace sparta::report::format
 {
-    namespace report
-    {
-        namespace format
-        {
-
-using StringPair = std::pair<std::string, std::string>;
-/*!
- * \brief Struct to contain non value stat info
- */
-struct info_data {
-    std::string name;
-    std::string desc;
-    uint64_t vis;
-    uint64_t n_class;
-    std::vector<StringPair> metadata;
-};
 
 /*!
  * \brief Map to contain the stat information obtained from each report/subreport
@@ -138,8 +124,23 @@ protected:
 
         // Dump out the data from detail_json_map
         for (std::map<std::string, std::list<info_data> >::iterator it = detail_json_map.begin(); it != detail_json_map.end();) {
+            std::unordered_set<info_data> unique_info_data_set;
+            size_t num_unique_in_list = 0;
+            for (auto& lit : it->second) {
+                // Check if the info_data is already in the set
+                if (unique_info_data_set.insert(lit).second) {
+                    ++num_unique_in_list;
+                }
+            }
+            unique_info_data_set.clear();
+
+            size_t loop_idx = 0;
             out << std::string(4, ' ') << "\"" << it->first << "\": [\n";
             for (auto& lit : it->second) {
+                if (!unique_info_data_set.insert(lit).second) {
+                    continue; // Skip duplicates
+                }
+
                 out << std::string(6, ' ') << "{ \"name\": \"" << lit.name << "\",\n";
                 out << std::string(8, ' ') << "\"desc\": \"" << lit.desc << "\",\n";
                 out << std::string(8, ' ') << "\"vis\": \"" << lit.vis << "\",\n";
@@ -164,11 +165,12 @@ protected:
                     out << "\n";
                 }
                 out << std::string(6, ' ') << "}";
-                if (&lit != &(it->second).back()) {
+                if (loop_idx < num_unique_in_list - 1) {
                     out << ",\n";
                 } else {
                     out << "\n";
                 }
+                ++loop_idx;
             }
             out << std::string(4, ' ') << "]";
             if (++it != detail_json_map.end()){
@@ -211,6 +213,52 @@ protected:
             local_name = p_name + "." + flattenReportName(r->getName());
         }
 
+        auto extract_stat = [&local_name](const statistics::stat_pair_t & si) {
+            std::string full_name = local_name + "." + si.first;
+            std::string desc = si.second->getDesc(false);
+            boost::replace_all(desc, "\"", "\\\"");
+            struct info_data tmp;
+            tmp.name = full_name;
+            tmp.desc = desc;
+            tmp.vis = si.second->getVisibility();
+            tmp.n_class = si.second->getClass();
+            const StatisticDef * stat_defn = si.second->getStatisticDef();
+            if (stat_defn != nullptr) {
+                tmp.metadata = stat_defn->getMetadata();
+            }
+            return tmp;
+        };
+
+        const Report::SubStaticticInstances & sub_stats = r->getSubStatistics();
+
+        std::set<const void*> dont_print_these;
+        for (const statistics::stat_pair_t& si : r->getStatistics()) {
+            if(si.first != ""){
+                const StatisticDef * stat_defn = si.second->getStatisticDef();
+                const CounterBase * ctr = si.second->getCounter();
+                const ParameterBase * prm = si.second->getParameter();
+                sparta_assert(static_cast<const void*>(this) != static_cast<const void*>(ctr));
+                sparta_assert(static_cast<const void*>(this) != static_cast<const void*>(prm));
+
+                auto sub_stat_iter = sub_stats.find(stat_defn);
+                const bool valid_stat_def = (stat_defn != nullptr);
+                const bool has_valid_sub_stats =
+                    (valid_stat_def && sub_stat_iter != sub_stats.end());
+
+                if (has_valid_sub_stats && stat_defn->groupedPrintingDetail(sub_stat_iter->second,
+                                                                            dont_print_these,
+                                                                            nullptr,
+                                                                            nullptr)) {
+                    detail_json_map[si.first].push_back(extract_stat(si));
+                    continue;
+                }
+                if (dont_print_these.count(ctr) > 0 || dont_print_these.count(prm) > 0) {
+                    continue;
+                }
+                detail_json_map[si.first].push_back(extract_stat(si));
+            }
+        }
+
         // Go through all subreports
         for (const Report& sr : r->getSubreports()) {
             collectDictContents_(&sr, idx+1, local_name);
@@ -247,6 +295,4 @@ inline std::ostream& operator<< (std::ostream& out, JSON_detail & f) {
     return out;
 }
 
-        } // namespace format
-    } // namespace report
-} // namespace sparta
+} // namespace sparta::report::format

--- a/sparta/src/JsonFormatter.cpp
+++ b/sparta/src/JsonFormatter.cpp
@@ -107,7 +107,6 @@ void extractStatisticsJsonFull(rapidjson::Document & doc,
 
     // Keep track of the order in which stats and subunits are written
     std::set<const void*> dont_print_these;
-    std::set<const void*> db_dont_print_these;
 
     for (const statistics::stat_pair_t & si : r->getStatistics())
     {
@@ -336,7 +335,6 @@ void extractStatisticsJsonReduced(rapidjson::Document & doc,
 
     // Keep track of the order in which stats and subunits are written
     std::set<const void*> dont_print_these;
-    std::set<const void*> db_dont_print_these;
 
     for (const statistics::stat_pair_t & si : r->getStatistics()) {
         const std::string stat_name = !si.first.empty() ? si.first : si.second->getLocation();

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1120,6 +1120,14 @@ public:
             stat_insts_tbl.addColumn("StatisticLoc", dt::string_t);
             stat_insts_tbl.addColumn("StatisticDesc", dt::string_t);
             stat_insts_tbl.addColumn("StatisticVis", dt::int32_t);
+            stat_insts_tbl.addColumn("StatisticClass", dt::int32_t);
+            stat_insts_tbl.createIndexOn("ReportID");
+
+            auto& stat_defn_meta_tbl = schema.addTable("StatisticDefnMetadata");
+            stat_defn_meta_tbl.addColumn("StatisticInstID", dt::int32_t);
+            stat_defn_meta_tbl.addColumn("MetaName", dt::string_t);
+            stat_defn_meta_tbl.addColumn("MetaValue", dt::string_t);
+            stat_defn_meta_tbl.createIndexOn("StatisticInstID");
 
             auto& siminfo_tbl = schema.addTable("SimulationInfo");
             siminfo_tbl.addColumn("SimName", dt::string_t);


### PR DESCRIPTION
These changes bring up all the JSON formats to match legacy exactly (except the js_json format, coming soon).

Here is where we stand now:

```
Format       Passed   Failed   NoCompare
-----------------------------------------
csv          86       0        0       
html         0        0        6       
js_json      0        2        0       
json         7        0        0       
json_detail  5        0        0       
json_reduced 8        0        0       
txt          0        19       0
```
