### PR TITLE
Perf improvements and test script fixes

### DIFF
--- a/sparta/scripts/simdb/exporters/export_json_report.py
+++ b/sparta/scripts/simdb/exporters/export_json_report.py
@@ -168,7 +168,7 @@ class JSONReducedReportExporter:
 
     def Export(self, dest_file, descriptor_id, db_conn):
         cursor = db_conn.cursor()
-        report_metadata = GetJsonReportMetadata(cursor, descriptor_id, "json")
+        report_metadata = GetJsonReportMetadata(cursor, descriptor_id, "json_reduced")
         siminfo = GetSimInfo(cursor)
         vis = GetVisibilities(cursor)
 

--- a/sparta/scripts/simdb/exporters/export_json_report.py
+++ b/sparta/scripts/simdb/exporters/export_json_report.py
@@ -1,7 +1,7 @@
 # Note the use of OrderedDict is to ensure we can match the rapidjson C++
 # legacy formatters exactly.
 from collections import OrderedDict
-import os, json, zlib, struct
+import os, json, zlib, struct, math
 from .utils import FormatNumber
 
 class StatValueGetter:
@@ -31,7 +31,10 @@ def GetStatsValuesGetter(cursor, dest_file):
         # The first value is the collectable ID, the second is the value.
         # We don't need the collectable ID here.
         val = struct.unpack("d", stats_blob[i+2:i+10])[0]
-        val = FormatNumber(val, as_string=False)
+        if math.isnan(val):
+            val = "nan"
+        else:
+            val = FormatNumber(val, as_string=False)
         stats_values.append(val)
 
     return StatValueGetter(stats_values)

--- a/sparta/scripts/simdb/run_report_verif_suite.py
+++ b/sparta/scripts/simdb/run_report_verif_suite.py
@@ -46,9 +46,9 @@ def SymlinkTree(src, dst):
         for d in dirs:
             os.makedirs(os.path.join(dst_root, d), exist_ok=True)
         for f in files:
-            src_file = os.path.join(root, f)
-            dst_link = os.path.join(dst_root, f)
-            os.symlink(src_file, dst_link)
+            src = os.path.join(root, f)
+            dst = os.path.join(dst_root, f)
+            os.symlink(src, dst)
 
 class SpartaTest:
     @classmethod


### PR DESCRIPTION
These changes were meant to go in with the previous SimDB verif PR to get all json_reduced tests passing.

The use of io.StringIO and symlinks in the verif script boost test suite performance by 90%

```
Format       Passed   Failed   NoCompare
-----------------------------------------
csv          86       0        0       
html         0        0        6       
js_json      0        2        0       
json         7        0        0       
json_detail  5        0        0       
json_reduced 8        0        0       
txt          0        19       0
```
