### PR TITLE
Fix for using yaml-cpp 0.7.0

### DIFF
--- a/sparta/cmake/sparta-config.cmake
+++ b/sparta/cmake/sparta-config.cmake
@@ -49,6 +49,7 @@ find_package (yaml-cpp 0.7 REQUIRED)
 if (yaml-cpp_FOUND)
   if (yaml-cpp_VERSION_MINOR EQUAL 7)
     get_property(YAML_CPP_INCLUDE_DIR TARGET yaml-cpp PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
   else ()
     # To be used with yaml-cpp 0.8 or (assumed) higer
     get_property(YAML_CPP_INCLUDE_DIR TARGET yaml-cpp::yaml-cpp PROPERTY INTERFACE_INCLUDE_DIRECTORIES)

--- a/sparta/example/DynamicModelPipeline/CMakeLists.txt
+++ b/sparta/example/DynamicModelPipeline/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(DYNAMIC_MODEL_PIPELINE)
 
 include(../ExamplesMacros.cmake)
-include(${SPARTA_BASE}/cmake/sparta-config.cmake)
 
 add_executable(dynamic_model_pipeline
     src/main.cpp


### PR DESCRIPTION
When using yaml-cpp 0.7.0, the target yaml-cpp::yaml-cpp is not set, causing errors while including $sparta_LIBS. 

Also, DynamicModelPipeline CMakeLists.txt does not need to include sparta-config.cmake as it already included in top-level cmake. 

Added an alias for yaml-cpp when version is 0.7.0 and removed include(sparta-config) in DynamicModelPipeline CMakeLists.txt