### PR TITLE
Implement js_json SimDB report exporter

### DIFF
--- a/sparta/example/CoreModel/CMakeLists.txt
+++ b/sparta/example/CoreModel/CMakeLists.txt
@@ -126,6 +126,7 @@ sparta_named_test(sparta_core_example_default_param_config_override sparta_core_
 sparta_named_test(sparta_core_example_report_yaml_replacements sparta_core_example -i 10k --report placeholders.yaml --report-yaml-replacements TRACENAME my_stats_report CORE0_WARMUP 1200)
 sparta_named_test(sparta_core_example_report_specific_yaml_replacements sparta_core_example -i 10k --report foo_descriptor.yaml foo.yaml --report bar_descriptor.yaml bar.yaml)
 sparta_named_test(sparta_core_example_omit_stats_with_value_zero sparta_core_example -i 10k --report all_json_formats.yaml --omit-zero-value-stats-from-json_reduced)
+sparta_named_test(sparta_core_example_js_json_reports sparta_core_example -i 10k --report js_json_reports.yaml)
 sparta_named_test(sparta_core_example_context_counter_update_triggers1 sparta_core_example -i 495 --report context_counter_update_triggers1.yaml --config-file context_weights.yaml -p top.cpu.core0.params.foo 680)
 sparta_named_test(sparta_core_example_context_counter_update_triggers2 sparta_core_example -i 550 --report context_counter_update_triggers2.yaml --config-file context_weights.yaml -p top.cpu.core0.params.foo 680)
 sparta_named_test(sparta_core_example_context_counter_update_triggers3 sparta_core_example -i 860 --report context_counter_update_triggers3.yaml --config-file context_weights.yaml -p top.cpu.core0.params.foo 680)

--- a/sparta/example/CoreModel/js_json_reports.yaml
+++ b/sparta/example/CoreModel/js_json_reports.yaml
@@ -1,0 +1,6 @@
+content:
+  report:
+    pattern:   _global
+    def_file:  simple_stats.yaml
+    dest_file: untriggered.json
+    format:    js_json

--- a/sparta/scripts/simdb/exporters/export_js_report.py
+++ b/sparta/scripts/simdb/exporters/export_js_report.py
@@ -1,10 +1,279 @@
+from .sim_utils import *
+from .stat_utils import *
+from .json_utils import *
+import json
+
 class JSReportExporter:
     def __init__(self):
-        pass
+        self.db_conn = None
+        self.cursor = None
+        self.stat_values_getter = None
+        self.leaf_nodes = set()
+        self.parents_of_leaf_nodes = set()
 
     def Export(self, dest_file, descriptor_id, db_conn):
-        # For now, just "touch" each report file. The comparison script will naturally
-        # fail which is okay for now.
+        self.db_conn = db_conn
+        self.cursor = db_conn.cursor()
+
+        # Get the root report ID
+        cmd = f"SELECT Id FROM Reports WHERE ReportDescID = {descriptor_id} AND ParentReportID = 0"
+        cursor = db_conn.cursor()
+        cursor.execute(cmd)
+        row = cursor.fetchone()
+        if row is None:
+            raise ValueError(f"Report descriptor {descriptor_id} does not have a root report")
+
+        report_id = row[0]
+
+        # decimal_places_ = strtoul(report_->getStyle("decimal_places", "2").c_str(), nullptr, 0);
+        decimal_places = int(GetReportStyle(cursor, report_id, descriptor_id, "decimal_places", "2"))
+        self.stat_values_getter = GetStatsValuesGetter(self.cursor, dest_file, True, True, decimal_places)
+
+        # out << "{\n";
+        # out << "  \"units\" : {\n";
+        out = {"units": {}}
+
+        # std::vector<std::string> all_key_names;
+        # writeReport_(out, *report_, all_key_names);
+        all_key_names = []
+        self.__WriteReport(out, report_id, descriptor_id, all_key_names)
+
+        # out << "    \"ordered_keys\" : [    \n";
+        # for (uint32_t idx = 0; idx < all_key_names.size(); idx++) {
+        #     out << "      \"" << all_key_names[idx] << "\"";
+        #     if (idx != (all_key_names.size() - 1)) {
+        #         out << ", ";
+        #     }
+        #     out << "\n";
+        # }
+        # out << "    ]\n";
+        # out << "  },\n";
+        out["units"]["ordered_keys"] = all_key_names
+
+        # out << "  \"vis\" : {\n";
+        # out << "    \"hidden\"  : " << sparta::InstrumentationNode::VIS_HIDDEN << ",\n";
+        # out << "    \"support\" : "  << sparta::InstrumentationNode::VIS_SUPPORT << ",\n";
+        # out << "    \"detail\"  : "  << sparta::InstrumentationNode::VIS_DETAIL << ",\n";
+        # out << "    \"normal\"  : "  << sparta::InstrumentationNode::VIS_NORMAL << ",\n";
+        # out << "    \"summary\" : "  << sparta::InstrumentationNode::VIS_SUMMARY << "\n";
+        # out << "  },\n";
+        out["vis"] = GetVisibilities(cursor)
+        if "critical" in out["vis"]:
+            del out["vis"]["critical"]
+
+        # out << "  \"siminfo\" : {\n";
+        # out << "    \"name\" : \"" << SimulationInfo::getInstance().sim_name << "\",\n";
+        # out << "    \"sim_version\" : \"" << SimulationInfo::getInstance().simulator_version << "\",\n";
+        # out << "    \"sparta_version\" : \"" << SimulationInfo::getInstance().getSpartaVersion() << "\",\n";
+        # out << "    \"reproduction\" : \"" << SimulationInfo::getInstance().reproduction_info << "\"\n";
+        # out << "  },\n";
+        out["siminfo"] = GetSimInfo(cursor)
+        if "json_report_version" in out["siminfo"]:
+            del out["siminfo"]["json_report_version"]
+
+        # out << "  \"report_metadata\": ";
+        # if (metadata_kv_pairs_.empty()) {
+        #     out << "{}\n";
+        # } else {
+        #     out << "{\n";
+        #     const size_t num_metadata = metadata_kv_pairs_.size();
+        #     size_t num_written_metadata = 0;
+        #     for (const auto & md : metadata_kv_pairs_) {
+        #         out << std::string(4, ' ') << "\"" << md.first << "\": \"" << md.second << "\"";
+        #         ++num_written_metadata;
+        #         if (num_written_metadata <= num_metadata - 1) {
+        #             out << ",\n";
+        #         }
+        #     }
+        #     out << "  }\n";
+        # }
+        #
+        # out << "}\n";
+        # out << std::endl;
+        out["report_metadata"] = GetJsonReportMetadata(cursor, descriptor_id, "js_json")
+
         with open(dest_file, "w") as fout:
-            print (f"Exporting {dest_file}...")
-            fout.write("# This is a placeholder file. The SimDB exporter is not implemented yet.\n")
+            json.dump(out, fout, indent=2)
+
+    def __WriteReport(self, out, report_id, descriptor_id, all_unit_names):
+        # // Early out - no stats in this report or any sub-reports
+        # if (report.getRecursiveNumStatistics() == 0) {
+        #     return;
+        # }
+        if not HasStatistics(self.cursor, descriptor_id, report_id, recursive=True):
+            return
+
+        # bool merge_subreports = isLeafNode_(report);
+        merge_subreports = self.__IsLeafNode(report_id)
+
+        # // If we need to start a new report
+        # if (merge_subreports || report.getNumStatistics() > 0) {
+        if merge_subreports or HasStatistics(self.cursor, descriptor_id, report_id):
+            # std::string unit_name = getReportName_(report);
+            # out << "    \"" << unit_name << "\": {\n";
+            # all_unit_names.push_back(unit_name);
+            #
+            # std::vector<std::string> all_stat_names;
+            # writeStats_(out, report, "", all_stat_names);
+            unit_name = GetReportName(self.cursor, report_id)
+            out["units"][unit_name] = {}
+            all_unit_names.append(unit_name)
+
+            all_stat_names = []
+            self.__WriteStats(out["units"][unit_name], report_id, descriptor_id, "", all_stat_names)
+
+            # if (merge_subreports) {
+            #     mergeReportList_(out, report.getSubreports(), getReportName_(report), all_stat_names);
+            # }
+            if merge_subreports:
+                subrep_ids = GetSubreportIDs(self.cursor, report_id)
+                self.__MergeReportList(out["units"][unit_name], subrep_ids, unit_name, all_stat_names)
+
+            # out << "      \"ordered_keys\": [\n";
+            # for (uint32_t idx = 0; idx < all_stat_names.size(); idx++) {
+            #     out << "        \"" << all_stat_names[idx] << "\"";
+            #     if (idx != (all_stat_names.size() - 1)) {
+            #         out << ", ";
+            #     }
+            #     out << "\n";
+            # }
+            # out << "      ]\n";
+            # out << "    },\n";
+            out["units"][unit_name]["ordered_keys"] = all_stat_names
+
+        # if (!merge_subreports) {
+        #     writeReportList_(out, report.getSubreports(), all_unit_names);
+        # }
+        if not merge_subreports:
+            subrep_ids = GetSubreportIDs(self.cursor, descriptor_id, report_id)
+            self.__WriteReportList(out, subrep_ids, descriptor_id, all_unit_names)
+
+    def __WriteReportList(self, out, subrep_ids, descriptor_id, all_unit_names):
+        # for (const auto & r : reports) {
+        #     writeReport_(out, r, all_unit_names);
+        # }
+        for report_id in subrep_ids:
+            self.__WriteReport(out, report_id, descriptor_id, all_unit_names)
+
+    def __MergeReport(self, out, report_id, descriptor_id, merge_top_name, all_stat_names):
+        # const std::string & report_name = getReportName_(report);
+        report_name = GetReportName(self.cursor, report_id)
+
+        # sparta_assert_context(report_name.length() > merge_top_name.length(),
+        #     "Expected the current report name (" << report_name << ") " <<
+        #     " to be long than the top-level report name (" << merge_top_name << ")");
+        if len(report_name) <= len(merge_top_name):
+            raise ValueError(f"Expected the current report name ({report_name}) to be longer " \
+                              "than the top-level report name ({merge_top_name})")
+
+        # uint32_t substr_idx = 0;
+        # for (substr_idx = 0; substr_idx < merge_top_name.length(); substr_idx++) {
+        #     if (merge_top_name[substr_idx] != report_name[substr_idx]) {
+        #         break;
+        #     }
+        # }
+        substr_idx = 0
+        for substr_idx in range(len(merge_top_name)):
+            if merge_top_name[substr_idx] != report_name[substr_idx]:
+                break
+
+        # substr_idx++;  // skip over the '.'
+        # sparta_assert(substr_idx < report_name.length());
+        substr_idx += 1
+        if substr_idx >= len(report_name):
+            raise ValueError(f"Substring index {substr_idx} is out of range for report name {report_name}")
+
+        # std::string stat_prefix = report_name.substr(substr_idx);
+        # writeStats_(out, report, stat_prefix, all_stat_names);
+        stat_prefix = report_name[substr_idx:]
+        self.__WriteStats(out, report_id, descriptor_id, stat_prefix, all_stat_names)
+
+        # if (report.getNumSubreports() > 0) {
+        #     mergeReportList_(out, report.getSubreports(), merge_top_name, all_stat_names);
+        # }
+        subrep_ids = GetSubreportIDs(self.cursor, report_id)
+        if len(subrep_ids) > 0:
+            self.__MergeReportList(out, subrep_ids, descriptor_id, merge_top_name, all_stat_names)
+
+    def __MergeReportList(self, out, subrep_ids, descriptor_id, merge_top_name, all_stat_names):
+        # for (const auto & r : reports) {
+        #     mergeReport_(out, r, merge_top_name, all_stat_names);
+        # }
+        for report_id in subrep_ids:
+            self.__MergeReport(out, report_id, descriptor_id, merge_top_name, all_stat_names)
+
+    def __WriteStats(self, out, report_id, descriptor_id, stat_prefix, all_stat_names):
+        # const statistics::StatisticPairs& stats = report.getStatistics();
+        report_stats = GetReportStatInsts(self.cursor, report_id, self.stat_values_getter)
+
+        # for (uint32_t idx = 0; idx < stats.size(); idx++) {
+        for idx in range(len(report_stats)):
+            # const statistics::stat_pair_t & si = stats[idx];
+            si = report_stats[idx]
+
+            # std::string sname = stat_prefix;
+            # if (si.first == "") {
+            #     // Use location as stat name since report creator did not give it an
+            #     // explicit name. Since ths full path is used, do not append the
+            #     // stat_prefix because it would make the resulting stat name very
+            #     // confusing.
+            #     sname = si.second->getLocation();
+            # } else {
+            #     if (sname.length() > 0) {
+            #         sname += ".";
+            #     }
+            #     sname += si.first;
+            # }
+            sname = stat_prefix
+            if not si.GetName():
+                sname = si.GetLocation()
+            else:
+                if len(sname) > 0:
+                    sname += "."
+                sname += si.GetName()
+
+            # all_stat_names.push_back(sname);
+            # out << "      \"" << sname << "\": { ";
+            # double val = si.second->getValue();
+            # out << "\"val\" : ";
+            # if (isnan(val)){
+            #     out << "\"nan\"";
+            # } else if (isinf(val)) {
+            #     out << "\"inf\"";
+            # } else{
+            #     out << Report::formatNumber(val, false, decimal_places_);
+            # }
+            all_stat_names.append(sname)
+            out[sname] = OrderedDict([("val", si.GetValue())])
+
+            # out << ", \"vis\" : " << si.second->getVisibility();
+            # out << ", \"desc\" : \"" << desc << "\"},";
+            # out << "\n";
+            out[sname]["vis"] = si.GetVis()
+            out[sname]["desc"] = si.GetDesc()
+
+    def __IsLeafNode(self, report_id):
+        # std::string report_name = getReportName_(report);
+        report_name = GetReportName(self.cursor, report_id)
+
+        # for (const std::string & cmp_name : leaf_nodes_) {
+        #     if (report_name == cmp_name) {
+        #         return true;
+        #     }
+        # }
+        if report_name in self.leaf_nodes:
+            return True
+
+        # report_name += ".";
+        # for (const std::string & cmp_name : parents_of_leaf_nodes_) {
+        #     if (boost::starts_with(report_name, cmp_name) && (report_name != cmp_name)) {
+        #         return true;
+        #     }
+        # }
+        # return false;
+        report_name += "."
+        for cmp_name in self.parents_of_leaf_nodes:
+            if report_name.startswith(cmp_name) and report_name != cmp_name:
+                return True
+
+        return False

--- a/sparta/scripts/simdb/exporters/export_js_report.py
+++ b/sparta/scripts/simdb/exporters/export_js_report.py
@@ -15,6 +15,16 @@ class JSReportExporter:
         self.db_conn = db_conn
         self.cursor = db_conn.cursor()
 
+        cmd = "SELECT ReportName, IsParentOfLeafNodes FROM JsJsonLeafNodes"
+        cursor = db_conn.cursor()
+        cursor.execute(cmd)
+        for report_name, is_parent in cursor.fetchall():
+            assert is_parent in (0,1)
+            if is_parent == 1:
+                self.parents_of_leaf_nodes.add(report_name)
+            else:
+                self.leaf_nodes.add(report_name)
+
         # Get the root report ID
         cmd = f"SELECT Id FROM Reports WHERE ReportDescID = {descriptor_id} AND ParentReportID = 0"
         cursor = db_conn.cursor()

--- a/sparta/scripts/simdb/exporters/export_text_report.py
+++ b/sparta/scripts/simdb/exporters/export_text_report.py
@@ -92,7 +92,7 @@ class TextReportExporter:
         additional_stat_indent = "  "
 
         # if(write_contentless_reports_ || hasStatistics_(r)){
-        if self.GetWriteContentlessReports() or HasStatistics(db_conn.cursor(), report_id):
+        if self.GetWriteContentlessReports() or HasStatistics(db_conn.cursor(), descriptor_id, report_id):
             # std::stringstream indent;
             # if(indent_subreports_){
             #     for(uint32_t d=0; d<depth; ++d){

--- a/sparta/scripts/simdb/exporters/stat_utils.py
+++ b/sparta/scripts/simdb/exporters/stat_utils.py
@@ -3,10 +3,11 @@ import os, zlib, struct, math
 from .utils import FormatNumber
 
 class StatisticInstance:
-    def __init__(self, name, location, desc, stat_value_getter):
+    def __init__(self, name, location, desc, vis, stat_value_getter):
         self.name = name
         self.location = location
         self.desc = desc
+        self.vis = vis
         self.stat_value_getter = stat_value_getter
 
     def GetName(self):
@@ -19,12 +20,16 @@ class StatisticInstance:
         assert unused == False
         return self.desc
 
+    def GetVis(self):
+        return self.vis
+
     def GetValue(self):
-        return self.stat_value_getter.GetNext()
+        return self.stat_value_getter.GetValueByLocation(self.location)
 
 class StatValueGetter:
-    def __init__(self, stats_values):
+    def __init__(self, stats_values, stat_values_by_loc):
         self.stats_values = stats_values
+        self.stat_values_by_loc = stat_values_by_loc
         self.index = 0
 
     def GetNext(self):
@@ -34,7 +39,12 @@ class StatValueGetter:
         self.index += 1
         return value
 
-def GetStatsValuesGetter(cursor, dest_file, replace_nan_with_nanstring=False):
+    def GetValueByLocation(self, loc):
+        if loc not in self.stat_values_by_loc:
+            raise KeyError(f"Location {loc} not found in stats blob")
+        return self.stat_values_by_loc[loc]
+
+def GetStatsValuesGetter(cursor, dest_file, replace_nan_with_nanstring=False, replace_inf_with_infstring=False, decimal_places=-1):
     dest_file_name = os.path.basename(dest_file)
     cmd = f"SELECT Data, IsCompressed FROM CollectionRecords WHERE Notes='{dest_file_name}'"
     cursor.execute(cmd)
@@ -45,20 +55,46 @@ def GetStatsValuesGetter(cursor, dest_file, replace_nan_with_nanstring=False):
     # Turn the stats blob (byte vector) into a vector of doubles.
     assert len(stats_blob) % (2+8) == 0, "Invalid stats blob length"
     stats_values = []
+    coll_ids = []
     for i in range(0, len(stats_blob), 2+8):
-        # The first value is the collectable ID, the second is the value.
-        # We don't need the collectable ID here.
         val = struct.unpack("d", stats_blob[i+2:i+10])[0]
         if replace_nan_with_nanstring and math.isnan(val):
             val = "nan"
+        elif replace_inf_with_infstring and math.isinf(val):
+            val = "inf"
         else:
-            val = FormatNumber(val, as_string=False)
+            val = FormatNumber(val, as_string=False, decimal_places=decimal_places)
+
         stats_values.append(val)
+        cid = struct.unpack("H", stats_blob[i:i+2])[0]
+        coll_ids.append(cid)
 
-    return StatValueGetter(stats_values)
+    # The above stats_values (linear list) is to be used when the entire stat
+    # collection is to be read one stat at a time using the GetNext() method.
+    # Some uses need to access stat values by location.
+    #
+    # We can use the collectable ID to get the location of the stat since
+    # the location/collectable ID pair is stored in the CollectableTreeNodes
+    # table.
+    stat_locs_by_coll_id = {}
+    cmd = "SELECT ElementTreeNodeID, Location FROM CollectableTreeNodes"
+    cursor.execute(cmd)
+    for coll_id, loc in cursor.fetchall():
+        stat_locs_by_coll_id[coll_id] = loc
 
-def HasStatistics(cursor, report_id, recursive=False):
-    def Impl(cursor, report_id, recursive):
+    stat_values_by_coll_id = {}
+    for cid, val in zip(coll_ids, stats_values):
+        stat_values_by_coll_id[cid] = val
+
+    stat_values_by_loc = {}
+    for cid, val in stat_values_by_coll_id.items():
+        loc = stat_locs_by_coll_id[cid]
+        stat_values_by_loc[loc] = val
+
+    return StatValueGetter(stats_values, stat_values_by_loc)
+
+def HasStatistics(cursor, descriptor_id, report_id, recursive=False):
+    def Impl(cursor, descriptor_id, report_id, recursive):
         cmd = f"SELECT COUNT(*) FROM StatisticInsts WHERE ReportID = {report_id}"
         cursor.execute(cmd)
         count = cursor.fetchone()[0]
@@ -67,15 +103,15 @@ def HasStatistics(cursor, report_id, recursive=False):
         if not recursive:
             return False
 
-        for subrep_id in GetSubreportIDs(cursor, report_id, report_id):
-            if Impl(cursor, subrep_id, recursive):
+        for subrep_id in GetSubreportIDs(cursor, descriptor_id, report_id):
+            if Impl(cursor, descriptor_id, subrep_id, recursive):
                 return True
 
         return False
 
-    return Impl(cursor, report_id, recursive)
+    return Impl(cursor, descriptor_id, report_id, recursive)
 
-def GetReportStatsDict(cursor, report_id):
+def GetReportStatDicts(cursor, report_id):
     cmd = f"SELECT StatisticName, StatisticLoc, StatisticDesc, StatisticVis FROM StatisticInsts WHERE ReportID = {report_id}"
     cursor.execute(cmd)
 
@@ -94,14 +130,25 @@ def GetReportStatsDict(cursor, report_id):
     return stats
 
 def GetReportStatInsts(cursor, report_id, stat_value_getter=None):
-    cmd = f"SELECT StatisticName, StatisticLoc, StatisticDesc FROM StatisticInsts WHERE ReportID = {report_id}"
+    cmd = f"SELECT StatisticName, StatisticLoc, StatisticDesc, StatisticVis FROM StatisticInsts WHERE ReportID = {report_id}"
     cursor.execute(cmd)
 
     statistics = []
-    for name, loc, desc in cursor.fetchall():
-        statistics.append(StatisticInstance(name, loc, desc, stat_value_getter))
+    for name, loc, desc, vis in cursor.fetchall():
+        statistics.append(StatisticInstance(name, loc, desc, vis, stat_value_getter))
 
     return statistics
+
+def GetReportName(cursor, report_id):
+    cmd = f"SELECT Name FROM Reports WHERE Id = {report_id}"
+    cursor.execute(cmd)
+    row = cursor.fetchone()
+
+    if not row:
+        return None
+
+    report_name = row[0]
+    return report_name
 
 def GetSubreportIDs(cursor, descriptor_id, parent_report_id):
     cmd = f"SELECT Id FROM Reports WHERE ReportDescID = {descriptor_id} AND ParentReportID = {parent_report_id}"
@@ -132,7 +179,7 @@ def GetStatsNestedDict(cursor, descriptor_id, parent_report_id, stat_value_gette
             flattened_name = name.split(".")[-1]
             ordered_dict[flattened_name] = OrderedDict()
 
-            report_stats = GetReportStatsDict(cursor, report_id)
+            report_stats = GetReportStatDicts(cursor, report_id)
             ordered_keys = []
             for stat in report_stats:
                 stat_name = stat["name"]

--- a/sparta/scripts/simdb/exporters/utils.py
+++ b/sparta/scripts/simdb/exporters/utils.py
@@ -1,6 +1,6 @@
 import math
 
-def FormatNumber(val, float_scinot_allowed=True, decimal_places=-1, as_string=True):
+def FormatNumber(val, decimal_places=-1, as_string=True):
     if math.isnan(val):
         return "nan" if as_string else float('nan')
     elif math.isinf(val):
@@ -11,8 +11,7 @@ def FormatNumber(val, float_scinot_allowed=True, decimal_places=-1, as_string=Tr
             return str(int(val)) if as_string else int(val)  # Convert to int to avoid ".0" in output
         else:
             if decimal_places >= 0:
-                format_spec = f".{decimal_places}f" if not float_scinot_allowed else f".{decimal_places}g"
-                val = format(val, format_spec)
+                val = round(val, decimal_places)
             else:
                 # Format to 6 significant digits
                 val = format(val, ".6g")

--- a/sparta/scripts/simdb/run_report_verif_suite.py
+++ b/sparta/scripts/simdb/run_report_verif_suite.py
@@ -570,16 +570,17 @@ formats.sort()
 # json     5        0        0
 # html     0        0        6
 # ...
-max_format_len = max([len(format) for format in formats])
-max_format_len = max(max_format_len, len("Format"))
-print(f"{'Format':<{max_format_len}} {'Passed':<8} {'Failed':<8} {'NoCompare':<8}")
-print("-----------------------------------------")
+if formats:
+    max_format_len = max([len(format) for format in formats])
+    max_format_len = max(max_format_len, len("Format"))
+    print(f"{'Format':<{max_format_len}} {'Passed':<8} {'Failed':<8} {'NoCompare':<8}")
+    print("-----------------------------------------")
 
-for format in formats:
-    num_passing = num_passing_by_format.get(format, 0)
-    num_failing = num_failing_by_format.get(format, 0)
-    num_unsupported = num_unsupported_by_format.get(format, 0)
-    print(f"{format:<{max_format_len}} {num_passing:<8} {num_failing:<8} {num_unsupported:<8}")
+    for format in formats:
+        num_passing = num_passing_by_format.get(format, 0)
+        num_failing = num_failing_by_format.get(format, 0)
+        num_unsupported = num_unsupported_by_format.get(format, 0)
+        print(f"{format:<{max_format_len}} {num_passing:<8} {num_failing:<8} {num_unsupported:<8}")
 
 print("")
 if incomplete_tests:

--- a/sparta/scripts/simdb/run_report_verif_suite.py
+++ b/sparta/scripts/simdb/run_report_verif_suite.py
@@ -499,6 +499,8 @@ else:
     # Run all the tests serially.
     print(f"Running {len(sparta_tests)} tests serially...")
     for i, test in enumerate(sparta_tests):
+        # Clear the bottom line of the terminal
+        sys.stdout.write('\033[2K\r')
         print(f"--- Test {i+1} of {len(sparta_tests)}:\t{test.test_name}", end="\r")
         try:
             test.RunTest()

--- a/sparta/sparta/report/format/JavascriptObject.hpp
+++ b/sparta/sparta/report/format/JavascriptObject.hpp
@@ -22,6 +22,11 @@
 #include "boost/algorithm/string.hpp"
 #include "sparta/report/Report.hpp"
 
+namespace simdb
+{
+    class DatabaseManager;
+}
+
 namespace sparta
 {
     namespace report
@@ -97,6 +102,8 @@ public:
         parents_of_leaf_nodes_.insert(node_name + ".");
     }
 
+    // Write the leaf node info to the database.
+    static void writeLeafNodeInfoToDB(simdb::DatabaseManager * db_mgr);
 
 protected:
 

--- a/sparta/src/JavascriptObject.cpp
+++ b/sparta/src/JavascriptObject.cpp
@@ -17,6 +17,9 @@
 #include "sparta/utils/SpartaException.hpp"
 #include "sparta/statistics/StatisticInstance.hpp"
 
+#if SIMDB_ENABLED
+#include "simdb/sqlite/DatabaseManager.hpp"
+#endif
 
 void sparta::report::format::JavascriptObject::writeContentToStream_(std::ostream& out) const
 {
@@ -246,4 +249,23 @@ void sparta::report::format::JavascriptObject::writeReportList_(std::ostream& ou
     for (const auto & r : reports) {
         writeReport_(out, r, all_unit_names);
     }
+}
+
+void sparta::report::format::JavascriptObject::writeLeafNodeInfoToDB(simdb::DatabaseManager * db_mgr)
+{
+#if SIMDB_ENABLED
+    for (const auto & report_name : leaf_nodes_) {
+        db_mgr->INSERT(SQL_TABLE("JsJsonLeafNodes"),
+                       SQL_COLUMNS("ReportName", "IsParentOfLeafNodes"),
+                       SQL_VALUES(report_name, 0));
+    }
+
+    for (const auto & report_name : parents_of_leaf_nodes_) {
+        db_mgr->INSERT(SQL_TABLE("JsJsonLeafNodes"),
+                       SQL_COLUMNS("ReportName", "IsParentOfLeafNodes"),
+                       SQL_VALUES(report_name, 1));
+    }
+#else
+    (void)db_mgr;
+#endif
 }

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -23,6 +23,7 @@
 #include "sparta/trigger/SingleTrigger.hpp"
 #include "sparta/trigger/ExpiringExpressionTrigger.hpp"
 #include "sparta/report/format/ReportHeader.hpp"
+#include "sparta/report/format/JavascriptObject.hpp"
 #include "sparta/statistics/dispatch/archives/ReportStatisticsArchive.hpp"
 #include "sparta/statistics/dispatch/archives/StatisticsArchives.hpp"
 #include "sparta/statistics/dispatch/streams/StatisticsStreams.hpp"
@@ -1170,6 +1171,11 @@ public:
             vis_tbl.addColumn("Summary", dt::int32_t);
             vis_tbl.addColumn("Critical", dt::int32_t);
 
+            auto& js_json_leaf_nodes = schema.addTable("JsJsonLeafNodes");
+            js_json_leaf_nodes.addColumn("ReportName", dt::string_t);
+            js_json_leaf_nodes.addColumn("IsParentOfLeafNodes", dt::int32_t);
+            js_json_leaf_nodes.setColumnDefaultValue("IsParentOfLeafNodes", -1);
+
             const auto& simdb_file = simdb_config.getSimDBFile();
             db_mgr_ = std::make_unique<simdb::DatabaseManager>(simdb_file, true);
             db_mgr_->createDatabaseFromSchema(schema);
@@ -1214,6 +1220,8 @@ public:
                                static_cast<int>(sparta::InstrumentationNode::VIS_NORMAL),
                                static_cast<int>(sparta::InstrumentationNode::VIS_SUMMARY),
                                static_cast<int>(sparta::InstrumentationNode::VIS_CRITICAL)));
+
+                report::format::JavascriptObject::writeLeafNodeInfoToDB(db_mgr_.get());
 
                 for (auto& kvp : directories_) {
                     kvp.second->configSimDbReports(db_mgr_.get(), sim_->getRoot());


### PR DESCRIPTION
This is the final PR for MAP v2.1 SimDB report exporters -- everything that we want to get extra bake time in v2.1 is passing:

```
Format        Passed   Failed   NoCompare
-----------------------------------------
csv           86       0        0       
html          0        0        6       
js_json       3        0        0       
json          9        0        0       
json_detail   5        0        0       
json_reduced  8        0        0       
stats_mapping 1        0        0       
txt           23       0        0
```