### PR TITLE
Install SimDB export/comparator scripts for MAP v2.1 release

### DIFF
--- a/sparta/CMakeLists.txt
+++ b/sparta/CMakeLists.txt
@@ -242,3 +242,9 @@ install(DIRECTORY sparta/ DESTINATION include/sparta)
 install(DIRECTORY cache/ DESTINATION include/cache)
 install(FILES ${SPARTA_STATIC_LIBS} DESTINATION lib)
 install(DIRECTORY cmake/ DESTINATION lib/cmake/sparta)
+install(DIRECTORY scripts/simdb/exporters/ DESTINATION bin/exporters)
+install(PROGRAMS scripts/simdb/simdb_compare DESTINATION bin)
+install(PROGRAMS scripts/simdb/simdb_export DESTINATION bin)
+install(FILES scripts/simdb/simdb_export.py
+              scripts/simdb/simdb_compare.py
+              scripts/simdb/compare_utils.py DESTINATION bin)

--- a/sparta/example/CoreModel/src/main.cpp
+++ b/sparta/example/CoreModel/src/main.cpp
@@ -77,6 +77,9 @@ int main(int argc, char **argv)
             show_factories = true;
         }
 
+        const std::string cores_info = "Num cores: " + std::to_string(num_cores);
+        sparta::SimulationInfo::getInstance().addOtherInfo(cores_info);
+
         // Create the simulator
         sparta::Scheduler scheduler;
         ExampleSimulator sim("core_topology_1",

--- a/sparta/scripts/simdb/compare_utils.py
+++ b/sparta/scripts/simdb/compare_utils.py
@@ -1,0 +1,119 @@
+import os, json, re
+
+def GetComparator(dest_file):
+    extension = os.path.splitext(dest_file)[1]
+    if extension in ('.txt', '.text'):
+        return TextReportComparator()
+    if extension in ('.json'):
+        return JSONReportComparator()
+    if extension in ('.csv'):
+        return CSVReportComparator()
+    if extension in ('.html', '.htm'):
+        return HTMLReportComparator()
+
+    return None
+
+class Comparator:
+    def __init__(self):
+        pass
+
+    def NormalizeText(self, text):
+        # Remove leading/trailing whitespace and replace all internal whitespace with a single space
+        return re.sub(r'\s+', ' ', text.strip())
+
+class TextReportComparator(Comparator):
+    def __init__(self):
+        Comparator.__init__(self)
+
+    def Compare(self, baseline_report, simdb_report):
+        with open(baseline_report, "r") as bf, open(simdb_report, "r") as ef:
+            baseline_text = self.NormalizeText(bf.read())
+            export_text = self.NormalizeText(ef.read())
+
+        return baseline_text == export_text
+
+class JSONReportComparator(Comparator):
+    def __init__(self):
+        Comparator.__init__(self)
+
+    def Compare(self, baseline_report, simdb_report):
+        with open(baseline_report, "r", encoding="utf-8") as bf, open(simdb_report, "r", encoding="utf-8") as ef:
+            try:
+                baseline_data = json.load(bf)
+            except json.JSONDecodeError as e:
+                return False
+
+            try:
+                export_data = json.load(ef)
+            except json.JSONDecodeError as e:
+                return False
+
+        return baseline_data == export_data
+
+class CSVReportComparator(Comparator):
+    def __init__(self):
+        Comparator.__init__(self)
+
+    def Compare(self, baseline_report, simdb_report):
+        with open(baseline_report, "r") as bf, open(simdb_report, "r") as ef:
+            bf_lines = bf.readlines()
+            ef_lines = ef.readlines()
+
+            if len(bf_lines) != len(ef_lines):
+                return False
+
+            for i in range(len(bf_lines)):
+                bf_line = self.NormalizeText(bf_lines[i])
+                ef_line = self.NormalizeText(ef_lines[i])
+
+                if bf_line != ef_line:
+                    return False
+
+        return True
+
+class HTMLReportComparator(TextReportComparator):
+    pass
+
+def RunComparison(legacy_reports_dir, simdb_reports_dir, baseline_reports, logger):
+    def WriteToLogger(logger, msg):
+        msg = msg.rstrip() + "\n"
+        logger.write(msg)
+
+    # Compare the baseline reports to the SimDB reports.
+    passing_reports = []
+    failing_reports = []
+    unsupported_reports = []
+
+    WriteToLogger(logger, "Comparing baseline reports to SimDB reports.")
+    for report in baseline_reports:
+        baseline_report = os.path.join(legacy_reports_dir, report)
+        simdb_report = os.path.join(simdb_reports_dir, report)
+
+        if not os.path.exists(simdb_report):
+            WriteToLogger(logger, f"SimDB report '{report}' not found.")
+            failing_reports.append(report)
+            continue
+        
+        # Compare the two reports.
+        comparator = GetComparator(report)
+        if comparator is None:
+            WriteToLogger(logger, f"Report {report} is not supported for comparison.")
+            unsupported_reports.append(report)
+            continue
+
+        if not comparator.Compare(baseline_report, simdb_report):
+            WriteToLogger(logger, f"Baseline report {report} does not match SimDB report. Test will fail.")
+            failing_reports.append(report)
+        else:
+            WriteToLogger(logger, f"Baseline report {report} matches SimDB report.")
+            passing_reports.append(report)
+        
+    num_passed = len(passing_reports)
+    total_comparisons = num_passed + len(failing_reports) + len(unsupported_reports)
+    WriteToLogger(logger, f"Report comparison complete: {num_passed} of {total_comparisons} reports passed.")
+
+    return {
+        "passing": passing_reports,
+        "failing": failing_reports,
+        "unsupported": unsupported_reports
+    }

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -1,5 +1,6 @@
 import os, zlib, struct
 from .utils import FormatNumber
+import numpy as np
 
 class CSVReportExporter:
     def __init__(self):
@@ -98,13 +99,10 @@ class CSVReportExporter:
                 # We could assert that the encountered element IDs correspond to the headers,
                 # although that would be a bit of a performance hit. The SimDB verification
                 # tests would be failing if this was not the case, so we will skip that for now.
-                elem_id_size = 2
-                value_size = 8
-
-                row_values = []
-                for i in range(elem_id_size, len(data), elem_id_size + value_size):
-                    value = struct.unpack('d', data[i:i + value_size])[0]
-                    row_values.append(FormatNumber(value))
+                dt = np.dtype([('id', '<u2'), ('value', '<f8')])  # u2 = uint16, f8 = float64
+                records = np.frombuffer(data, dtype=dt)
+                double_values = records['value']
+                row_values = [FormatNumber(value) for value in double_values]
 
                 fout.write(','.join(row_values))
                 fout.write('\n')

--- a/sparta/scripts/simdb/exporters/export_gnuplot_report.py
+++ b/sparta/scripts/simdb/exporters/export_gnuplot_report.py
@@ -6,5 +6,4 @@ class GnuplotReportExporter:
         # For now, just "touch" each report file. The comparison script will naturally
         # fail which is okay for now.
         with open(dest_file, "w") as fout:
-            print (f"Exporting {dest_file}...")
             fout.write("# This is a placeholder file. The SimDB exporter is not implemented yet.\n")

--- a/sparta/scripts/simdb/exporters/export_html_report.py
+++ b/sparta/scripts/simdb/exporters/export_html_report.py
@@ -6,5 +6,4 @@ class HTMLReportExporter:
         # For now, just "touch" each report file. The comparison script will naturally
         # fail which is okay for now.
         with open(dest_file, "w") as fout:
-            print (f"Exporting {dest_file}...")
             fout.write("# This is a placeholder file. The SimDB exporter is not implemented yet.\n")

--- a/sparta/scripts/simdb/exporters/export_py_report.py
+++ b/sparta/scripts/simdb/exporters/export_py_report.py
@@ -6,5 +6,4 @@ class PyReportExporter:
         # For now, just "touch" each report file. The comparison script will naturally
         # fail which is okay for now.
         with open(dest_file, "w") as fout:
-            print (f"Exporting {dest_file}...")
             fout.write("# This is a placeholder file. The SimDB exporter is not implemented yet.\n")

--- a/sparta/scripts/simdb/exporters/sim_utils.py
+++ b/sparta/scripts/simdb/exporters/sim_utils.py
@@ -4,7 +4,7 @@ class SimulationInfo:
     @classmethod
     def GetHeaderPairs(cls, db_conn):
         cursor = db_conn.cursor()
-        cmd = "SELECT HeaderName, HeaderValue FROM SimulationInfoHeaderPairs"
+        cmd = "SELECT HeaderName, HeaderValue FROM SimulationInfoHeaderPairs WHERE HeaderName != 'Other'"
         cursor.execute(cmd)
 
         header_pairs = []
@@ -25,6 +25,19 @@ class SimulationInfo:
 
             # out << p.second << line_end;
             out.write(f"{p[1]}{line_end}")
+
+        # if(other.size() > 0){
+        #     o << line_start << "Other:" << line_end;
+        #     for(const std::string& oi : other){
+        #         o << line_start << "  " << oi << line_end;
+        #     }
+        # }
+        cmd = "SELECT HeaderValue FROM SimulationInfoHeaderPairs WHERE HeaderName == 'Other'"
+        cursor = db_conn.cursor()
+        cursor.execute(cmd)
+
+        for row in cursor.fetchall():
+            out.write(f"{line_start}Other:  {row[0]}{line_end}")
 
 def GetSimInfo(cursor):
     cmd = "SELECT SimName, SimVersion, SpartaVersion, ReproInfo FROM SimulationInfo"

--- a/sparta/scripts/simdb/simdb_compare
+++ b/sparta/scripts/simdb/simdb_compare
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Path to the Python script
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+PYTHON_SCRIPT="$SCRIPT_DIR/simdb_compare.py"
+
+# Check if the Python script exists
+if [[ ! -f "$PYTHON_SCRIPT" ]]; then
+    echo "Error: simdb_compare.py not found in $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+# Run the Python script with all the arguments passed to this wrapper
+exec python3 "$PYTHON_SCRIPT" "$@" "--quiet"

--- a/sparta/scripts/simdb/simdb_compare.py
+++ b/sparta/scripts/simdb/simdb_compare.py
@@ -1,0 +1,98 @@
+import os, sys
+import argparse
+import shutil
+import sqlite3
+import io
+from compare_utils import *
+
+parser = argparse.ArgumentParser(description="Compare SimDB reports with legacy reports.")
+parser.add_argument("--legacy-reports-dir", default=".", help="Directory containing legacy reports.")
+parser.add_argument("--results-dir", default="simdb-comparison-results", help="Directory to save comparison results.")
+parser.add_argument("--force", action="store_true", help="Force overwrite results directory.")
+parser.add_argument("--quiet", action="store_true", help="Suppress output.")
+parser.add_argument("database", type=str, help="Path to the SimDB database file.")
+args = parser.parse_args()
+
+if not os.path.exists(args.database):
+    print(f"Error: The specified database file '{args.database}' does not exist.")
+    sys.exit(1)
+
+legacy_reports_dir_out = os.path.join(args.results_dir, "legacy_reports")
+legacy_reports_dir_in = args.legacy_reports_dir
+if not os.path.exists(legacy_reports_dir_in):
+    print(f"Error: The specified legacy reports directory '{legacy_reports_dir_in}' does not exist.")
+    sys.exit(1)
+
+if os.path.exists(args.results_dir):
+    if args.force:
+        shutil.rmtree(args.results_dir)
+    else:
+        print(f"Error: The results directory '{args.results_dir}' already exists. Use --force to overwrite.")
+        sys.exit(1)
+
+# Copy all the legacy reports to <results_dir>/legacy_reports
+os.makedirs(legacy_reports_dir_out)
+
+# Copy the database file to the results directory
+db_file_name = os.path.basename(args.database)
+db_file_out = os.path.join(args.results_dir, db_file_name)
+shutil.copy2(args.database, db_file_out)
+
+conn = sqlite3.connect(args.database)
+cursor = conn.cursor()
+
+cmd = "SELECT DestFile FROM ReportDescriptors"
+cursor.execute(cmd)
+baseline_reports = []
+for row in cursor.fetchall():
+    dest_file = row[0]
+    baseline_reports.append(dest_file)
+    src_path = os.path.join(legacy_reports_dir_in, dest_file)
+    dst_path = os.path.join(legacy_reports_dir_out, dest_file)
+    assert os.path.exists(src_path)
+    shutil.copy2(src_path, dst_path)
+
+# Export all SimDB reports to <results_dir>/simdb_reports
+simdb_reports_dir_out = os.path.join(args.results_dir, "simdb_reports")
+scripts_dir = os.path.dirname(os.path.abspath(__file__))
+export_py = os.path.join(scripts_dir, "simdb_export.py")
+export_cmd = f"python3 {export_py} --export-dir {simdb_reports_dir_out} --force {args.database}"
+if args.quiet:
+    export_cmd += " > /dev/null 2>&1"
+os.system(export_cmd)
+
+# Run the comparisons and generate the final comparison report.
+logger = io.StringIO()
+results = RunComparison(legacy_reports_dir_out, simdb_reports_dir_out, baseline_reports, logger)
+
+passing_reports = results["passing"]
+failing_reports = results["failing"]
+unsupported_reports = results["unsupported"]
+
+logger.write("\nSummary of Comparison Results...\n")
+
+if passing_reports:
+    logger.write("PASSING:\n")
+    for report in passing_reports:
+        logger.write(f"  {report}\n")
+
+if failing_reports:
+    logger.write("FAILING:\n")
+    for report in failing_reports:
+        logger.write(f"  {report}\n")
+
+if unsupported_reports:
+    logger.write("UNSUPPORTED:\n")
+    for report in unsupported_reports:
+        logger.write(f"  {report}\n")
+
+logfile = os.path.join(args.results_dir, "comparison_results.txt")
+with open(logfile, "w") as fout:
+    fout.write(logger.getvalue())
+
+if unsupported_reports:
+    print(f"{len(passing_reports)} passed, {len(failing_reports)} failed, {len(unsupported_reports)} unsupported.")
+else:
+    print(f"{len(passing_reports)} passed, {len(failing_reports)} failed.")
+
+print(f"Comparison results saved to {logfile}")

--- a/sparta/scripts/simdb/simdb_export
+++ b/sparta/scripts/simdb/simdb_export
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Path to the Python script
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+PYTHON_SCRIPT="$SCRIPT_DIR/simdb_export.py"
+
+# Check if the Python script exists
+if [[ ! -f "$PYTHON_SCRIPT" ]]; then
+    echo "Error: simdb_export.py not found in $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+# Run the Python script with all the arguments passed to this wrapper
+exec python3 "$PYTHON_SCRIPT" "$@"

--- a/sparta/scripts/simdb/simdb_export.py
+++ b/sparta/scripts/simdb/simdb_export.py
@@ -82,7 +82,7 @@ for _, dest_file, _ in rows:
             os.remove(dest_file)
 
 if existing_files:
-    print(f"Error: The following destination files already exist. Use --force to overwrite:")
+    print (f"Error: The following destination files already exist. Use --force to overwrite:")
     for file in existing_files:
         print(f"  {file}")
     sys.exit(1)

--- a/sparta/scripts/simdb/simdb_export.py
+++ b/sparta/scripts/simdb/simdb_export.py
@@ -15,25 +15,28 @@ from exporters.export_gnuplot_report import GnuplotReportExporter
 from exporters.export_stats_mapping_report import StatsMappingReportExporter
 
 parser = argparse.ArgumentParser(description="Export SimDB records to formatted report files.")
-parser.add_argument("--db-file", type=str, required=True, help="Path to the SimDB database file.")
 parser.add_argument("--dest-file", type=str, help="Export only this one destination file (out.csv etc. from the defn yaml).")
-parser.add_argument("--export-dir", type=str, default="simdb_reports", help="Directory to save the exported report files.")
-parser.add_argument("--force", action="store_true", help="Force overwrite export directory.")
+parser.add_argument("--export-dir", type=str, default=".", help="Directory to save the exported report files.")
+parser.add_argument("--force", action="store_true", help="Force overwrite export directory/reports.")
+parser.add_argument("database", type=str, help="Path to the SimDB database file.")
 args = parser.parse_args()
 
-if not os.path.exists(args.db_file):
-    print(f"Error: The specified database file '{args.db_file}' does not exist.")
+if not os.path.exists(args.database):
+    print(f"Error: The specified database file '{args.database}' does not exist.")
     sys.exit(1)
 
-if os.path.exists(args.export_dir):
+export_dir_is_cwd = os.path.abspath(args.export_dir) == os.getcwd()
+if os.path.exists(args.export_dir) and not export_dir_is_cwd:
     if args.force:
         shutil.rmtree(args.export_dir)
     else:
         print(f"Error: The export directory '{args.export_dir}' already exists. Use --force to overwrite.")
         sys.exit(1)
 
-os.makedirs(args.export_dir)
-conn = sqlite3.connect(args.db_file)
+if not export_dir_is_cwd:
+    os.makedirs(args.export_dir)
+
+conn = sqlite3.connect(args.database)
 cursor = conn.cursor()
 
 # Get the appropriate exporter for the given report format.
@@ -68,7 +71,24 @@ if args.dest_file:
     cmd += f" WHERE DestFile = '{args.dest_file}'"
 cursor.execute(cmd)
 
-for id, dest_file, format in cursor.fetchall():
+rows = cursor.fetchall()
+existing_files = []
+for _, dest_file, _ in rows:
+    dest_file = os.path.join(args.export_dir, dest_file)
+    if os.path.exists(dest_file):
+        if not args.force:
+            existing_files.append(dest_file)
+        else:
+            os.remove(dest_file)
+
+if existing_files:
+    print(f"Error: The following destination files already exist. Use --force to overwrite:")
+    for file in existing_files:
+        print(f"  {file}")
+    sys.exit(1)
+
+for id, dest_file, format in rows:
     dest_file = os.path.join(args.export_dir, dest_file)
     exporter = GetExporter(format)
     exporter.Export(dest_file, id, conn)
+    print (f"Exported: {dest_file}")

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -199,6 +199,17 @@ namespace sparta {
             simdb::DatabaseManager* db_mgr_ = nullptr;
 
             /*!
+             * \brief Set to true only when the simulation was run with
+             * --disable-legacy-reports --enable-simdb-reports.
+             * Note that the intended use for writing both legacy and
+             * SimDB reports is to allow for a transition period
+             * where users can migrate to the new SimDB reports,
+             * using a provided comparison script to verify backwards
+             * compatibility.
+             */
+            bool legacy_reports_disabled_ = false;
+
+            /*!
              * \brief Cache the Scheduler so we know the current tick for every
              * call to simdb::CollectionMgr::sweep().
              */
@@ -487,6 +498,24 @@ namespace sparta {
                     all.insert(cur.first);
                 }
                 return std::vector<Report*>(all.begin(), all.end());
+            }
+
+            /*!
+             * \brief In MAP v2.1, we provide report systems for both legacy reports
+             * and SimDB-exported reports. We allow using both at the same time in
+             * order to validate the SimDB reports for backwards compatibility.
+             *
+             * This function is called when these two command line options are used:
+             *   --enable-simdb-reports --disable-legacy-reports
+             *
+             * Using "--disable-legacy-reports" in MAP v2.1 is akin to saying "I have
+             * verified that the SimDB reports are the same and I only want to use
+             * SimDB now".
+             *
+             * This method will be removed in a future release.
+             */
+            void disableLegacyReports() {
+                legacy_reports_disabled_ = true;
             }
 
             /*!

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -199,7 +199,7 @@ namespace sparta {
             simdb::DatabaseManager* db_mgr_ = nullptr;
 
             /*!
-             * \brief Set to true only when the simulation was run with
+             * \brief Set to false only when the simulation was run with
              * --disable-legacy-reports --enable-simdb-reports.
              * Note that the intended use for writing both legacy and
              * SimDB reports is to allow for a transition period
@@ -207,7 +207,7 @@ namespace sparta {
              * using a provided comparison script to verify backwards
              * compatibility.
              */
-            bool legacy_reports_disabled_ = false;
+            bool legacy_reports_enabled_ = true;
 
             /*!
              * \brief Cache the Scheduler so we know the current tick for every
@@ -515,7 +515,7 @@ namespace sparta {
              * This method will be removed in a future release.
              */
             void disableLegacyReports() {
-                legacy_reports_disabled_ = true;
+                legacy_reports_enabled_ = false;
             }
 
             /*!

--- a/sparta/sparta/app/SimulationConfiguration.hpp
+++ b/sparta/sparta/app/SimulationConfiguration.hpp
@@ -502,8 +502,9 @@ public:
             return simdb_file_;
         }
 
-        void enableSimDBReports() {
+        void enableSimDBReports(const bool disable_legacy_reports = false) {
             reports_enabled_ = true;
+            disable_legacy_reports_ = disable_legacy_reports;
             if (simdb_file_.empty()) {
                 simdb_file_ = "sparta.db";
             }
@@ -513,9 +514,14 @@ public:
             return reports_enabled_;
         }
 
+        bool legacyReportsEnabled() const {
+            return !disable_legacy_reports_;
+        }
+
     private:
         std::string simdb_file_;
         bool reports_enabled_ = false;
+        bool disable_legacy_reports_ = false;
     } simdb_config;
 
     /*!

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -624,7 +624,10 @@ CommandLineSimulator::CommandLineSimulator(const std::string& usage,
          "Specify a simulation database file to hold reports and other sim artifacts. Use together with "
          "--enable-simdb-* options to selectively add artifacts to the database.")
         ("enable-simdb-reports",
-         "Enable the simulation database to hold reports.");
+         "Enable the simulation database to hold reports.")
+        ("disable-legacy-reports",
+         "Do not produce legacy formatted reports on the filesystem. Only write the SimDB file. "
+         "This is to be used with --enable-simdb-reports.");
     #endif
 
     // Feature Options
@@ -1801,7 +1804,13 @@ bool CommandLineSimulator::parse(int argc,
     // The various --enable-simdb-* options will implicitly set the database file to sparta.db
     // unless otherwise specified with --simdb-file (which has already been parsed above).
     if (vm_.count("enable-simdb-reports") > 0) {
-        sim_config_.simdb_config.enableSimDBReports();
+        const bool disable_legacy_reports = vm_.count("disable-legacy-reports") > 0;
+        sim_config_.simdb_config.enableSimDBReports(disable_legacy_reports);
+    } else if (vm_.count("disable-legacy-reports") > 0) {
+        std::cerr << "Error: --disable-legacy-reports requires --enable-simdb-reports" << std::endl;
+        printUsageHelp_();
+        err_code = 1;
+        return false;
     }
 
     //pevents

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -468,7 +468,7 @@ ReportDescriptor::~ReportDescriptor()
             this->writeOutput(nullptr);
         }
 
-        if (legacy_reports_disabled_) {
+        if (!legacy_reports_enabled_) {
             std::filesystem::remove(dest_file);
         }
     } catch (...) {
@@ -503,7 +503,7 @@ uint32_t ReportDescriptor::writeOutput(std::ostream* out)
         const bool report_active = this->updateReportActiveState_(inst.first);
         if (report_active && false == inst.second->supportsUpdate()) {
             //TODO: Deprecate "during simulation" formatters
-            if (!legacy_reports_disabled_) {
+            if (legacy_reports_enabled_) {
                 inst.second->write();
             }
             if (db_mgr_) {
@@ -557,7 +557,7 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
             if (skipped_annotator_ != nullptr) {
                 if (skipped_annotator_->currentSkipCount() > 0) {
                     //TODO: Deprecate "during simulation" formatters
-                    if (!legacy_reports_disabled_) {
+                    if (legacy_reports_enabled_) {
                         inst.second->skip(skipped_annotator_.get());
                     }
                     inst.first->start();
@@ -570,7 +570,7 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
             }
             if (capture_update_values) {
                 //TODO: Deprecate "during simulation" formatters
-                if (!legacy_reports_disabled_) {
+                if (legacy_reports_enabled_) {
                     inst.second->update();
                 }
                 if (db_mgr_) {

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -467,6 +467,10 @@ ReportDescriptor::~ReportDescriptor()
             this->updateOutput(nullptr);
             this->writeOutput(nullptr);
         }
+
+        if (legacy_reports_disabled_) {
+            std::filesystem::remove(dest_file);
+        }
     } catch (...) {
         //destructors should never throw
     }
@@ -499,7 +503,9 @@ uint32_t ReportDescriptor::writeOutput(std::ostream* out)
         const bool report_active = this->updateReportActiveState_(inst.first);
         if (report_active && false == inst.second->supportsUpdate()) {
             //TODO: Deprecate "during simulation" formatters
-            inst.second->write();
+            if (!legacy_reports_disabled_) {
+                inst.second->write();
+            }
             if (db_mgr_) {
                 sweepSimDbStats_();
             }
@@ -551,7 +557,9 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
             if (skipped_annotator_ != nullptr) {
                 if (skipped_annotator_->currentSkipCount() > 0) {
                     //TODO: Deprecate "during simulation" formatters
-                    inst.second->skip(skipped_annotator_.get());
+                    if (!legacy_reports_disabled_) {
+                        inst.second->skip(skipped_annotator_.get());
+                    }
                     inst.first->start();
                     capture_update_values = false;
                     if (db_mgr_) {
@@ -562,7 +570,9 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
             }
             if (capture_update_values) {
                 //TODO: Deprecate "during simulation" formatters
-                inst.second->update();
+                if (!legacy_reports_disabled_) {
+                    inst.second->update();
+                }
                 if (db_mgr_) {
                     sweepSimDbStats_();
                 }

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -182,8 +182,10 @@ public:
         num_written += desc_.writeOutput();
 
         bool print = true;
-        if (auto sim_cfg = sim_->getSimulationConfiguration()) {
-            print = sim_cfg->simdb_config.legacyReportsEnabled();
+        if (sim_) {
+            if (auto sim_cfg = sim_->getSimulationConfiguration()) {
+                print = sim_cfg->simdb_config.legacyReportsEnabled();
+            }
         }
 
         if (print) {

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1009,32 +1009,6 @@ public:
     {
     }
 
-    ~Impl()
-    {
-        // If we're not in the middle of an exception, we can save
-        // reports, unless report_on_error is defined
-        bool save_reports = true;
-        if(nullptr != sim_)
-        {
-            save_reports = sim_->simulationSuccessful();
-            if(false == save_reports)
-            {
-                // Check simulation configuration to see if we still need to report on error
-                save_reports = (sim_->getSimulationConfiguration() &&
-                                sim_->getSimulationConfiguration()->report_on_error);
-            }
-        }
-
-        if(save_reports)
-        {
-            try {
-                this->saveReports();
-            } catch (...) {
-                std::cerr << "WARNING: Error saving reports to file" << std::endl;
-            }
-        }
-    }
-
     ReportRepository::DirectoryHandle createDirectory(
         const app::ReportDescriptor & desc)
     {
@@ -1380,6 +1354,13 @@ public:
                         SQL_TABLE("SimulationInfoHeaderPairs"),
                         SQL_COLUMNS("HeaderName", "HeaderValue"),
                         SQL_VALUES(kvp.first, kvp.second));
+                }
+
+                for (const auto& other : SimulationInfo::getInstance().other) {
+                    db_mgr_->INSERT(
+                        SQL_TABLE("SimulationInfoHeaderPairs"),
+                        SQL_COLUMNS("HeaderName", "HeaderValue"),
+                        SQL_VALUES("Other", other));
                 }
 
                 std::ostringstream oss;

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -356,8 +356,6 @@ Simulation::~Simulation()
 
     // Deregister
     root_.getNodeAttachedNotification().DEREGISTER_FOR_THIS(rootDescendantAdded_);
-
-    report_repository_.reset();
 }
 
 void Simulation::configure(const int argc,
@@ -954,6 +952,8 @@ void Simulation::saveReports()
         }
         std::cout << summary_fmt << std::endl;;
     }
+
+    report_repository_->saveReports();
 
 #ifdef SPARTA_TCMALLOC_SUPPORT
     if (memory_profiler_) {


### PR DESCRIPTION
This PR gets everything ready for map_v2.1 where we will want an easy way for users to try out SimDB reports and check for backwards compatibility. The main idea here is that we need simdb_export / simdb_compare to be in Conda on the search path for the easiest verification workflow:

```
# v2 workflow still supported
./sim -i 10k --report stats.yaml 

# Try out SimDB (omitting --simdb-file just defaults to using "sparta.db")
./sim -i 10k --report stats.yaml --enable-simdb-reports
simdb_compare sparta.db

### Prints out something like:
###   7 passed, 0 failed.
###   Comparison results saved to simdb-comparison-results/comparison_results.txt
###
### Note the simdb-comparison-results directory contains the legacy reports, SimDB reports, sparta.db, and a log file.
### Users will decide how to report any discrepancies (data might be sensitive).

# If the comparison script says everything is the same, the new workflow in v2.1+ would be:
./sim -i 10k --report stats.yaml --enable-simdb-reports --disable-legacy-reports
simdb_export sparta.db

### Prints out something like:
###   Exported: ./autopop_update_count.csv
###   Exported: ./global_cumulative_stats.csv
###   Exported: ./global_stats.csv

# Starting in map_v3, SimDB will be the default (assume --simdb-file now used)
./sim -i 10k --report stats.yaml --simdb-file stats.db
simdb_export stats.db
```

It is an open question whether we provide a fallback to re-enable legacy reports in v3, something like:

`./sim -i 10k --report stats.yaml --simdb-file stats.db --enable-legacy-reports`

We probably do want that option, but eventually in map_v3 we will actually delete all the old report formatter code forever!
