### PR TITLE
SimDB reports perf improvements

### DIFF
--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -89,17 +89,7 @@ class CSVReportExporter:
                 if is_compressed:
                     data = zlib.decompress(data)
 
-                # The data values are stored as:
-                #   [elem_id(u16), value(double), elem_id(u16), value(double), ...]
-                #
-                # We only care about the values, not the element IDs. Everything in these records
-                # is already in the order we want, meaning that the values line up with the stat
-                # headers we already wrote out.
-                #
-                # We could assert that the encountered element IDs correspond to the headers,
-                # although that would be a bit of a performance hit. The SimDB verification
-                # tests would be failing if this was not the case, so we will skip that for now.
-                dt = np.dtype([('id', '<u2'), ('value', '<f8')])  # u2 = uint16, f8 = float64
+                dt = np.dtype([('value', '<f8')])
                 records = np.frombuffer(data, dtype=dt)
                 double_values = records['value']
                 row_values = [FormatNumber(value) for value in double_values]

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -71,19 +71,22 @@ class CSVReportExporter:
         # Lastly, deserialize the raw values. Each record in this query corresponds to another
         # row in the CSV report (one SQL record only holds the values for the same report descriptor).
         with open(dest_file, 'a') as fout:
-            basename = os.path.basename(dest_file)
-            cmd = f'SELECT Data, IsCompressed, Notes FROM CollectionRecords WHERE Notes LIKE \'{basename}%\' ORDER BY Tick ASC'
+            # We need to ensure that we "interleave" the records from the CollectionRecords table
+            # and the CsvSkipAnnotations table before writing them to the CSV file.
+            csv_row_text_by_tick = {}
+
+            # We cannot query the CollectionRecords table directly, because it may contain multiple
+            # records for the same tick (coming from different report descriptors). We have to query
+            # the DescriptorRecords table first to find out which CollectionRecords belong to us.
+            cmd = f'SELECT DatablobID FROM DescriptorRecords WHERE ReportDescID={descriptor_id}'
             cursor.execute(cmd)
-            for data, is_compressed, notes in cursor.fetchall():
-                # If the Notes column is something like "out.csv_skipped_anno#1033", that means we
-                # should write a row of empty values for this record to denote the number of times
-                # we skipped writing to the report.
-                if notes.find('skipped_anno') != -1:
-                    hash_idx = notes.find('#')
-                    anno = notes[hash_idx:]
-                    anno += ','*(len(stat_headers) - 1)
-                    fout.write(anno)
-                    fout.write('\n')
+            datablob_ids = {row[0] for row in cursor.fetchall()}
+
+            cmd = f'SELECT Id, Tick, Data, IsCompressed FROM CollectionRecords'
+            cursor.execute(cmd)
+            for record_id, tick, data, is_compressed in cursor.fetchall():
+                # Not ours? Continue.
+                if record_id not in datablob_ids:
                     continue
 
                 if is_compressed:
@@ -93,8 +96,21 @@ class CSVReportExporter:
                 records = np.frombuffer(data, dtype=dt)
                 double_values = records['value']
                 row_values = [FormatNumber(value) for value in double_values]
+                row_text = ','.join(row_values)
+                csv_row_text_by_tick[tick] = row_text
 
-                fout.write(','.join(row_values))
+            # Now get all the skipped annotations for this report descriptor, if any.
+            cmd = f'SELECT Tick, Annotation FROM CsvSkipAnnotations WHERE ReportDescID={descriptor_id}'
+            cursor.execute(cmd)
+            for tick, anno in cursor.fetchall():
+                anno += ','*(len(stat_headers) - 1)
+                csv_row_text_by_tick[tick] = anno
+
+            # Now write all the rows in order.
+            ticks = sorted(csv_row_text_by_tick.keys())
+            for tick in ticks:
+                row_text = csv_row_text_by_tick[tick]
+                fout.write(row_text)
                 fout.write('\n')
 
     def __WriteHeader(self, fout, report_name, start_tick, end_tick, meta_kvpairs, trigger_locs):

--- a/sparta/scripts/simdb/exporters/export_text_report.py
+++ b/sparta/scripts/simdb/exporters/export_text_report.py
@@ -76,7 +76,7 @@ class TextReportExporter:
         report_name, report_start, report_end = row
 
         if report_end == -1:
-            cmd = "SELECT SimEndTick FROM SimulationInfo WHERE Id = 1"
+            cmd = "SELECT SimEndTick FROM SimulationInfo LIMIT 1"
             cursor.execute(cmd)
             report_end = cursor.fetchone()[0]
 

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -199,6 +199,11 @@ namespace sparta {
             simdb::DatabaseManager* db_mgr_ = nullptr;
 
             /*!
+             * \brief SimDB primary key in the ReportDescriptors table.
+             */
+            int simdb_descriptor_id_ = 0;
+
+            /*!
              * \brief Set to false only when the simulation was run with
              * --disable-legacy-reports --enable-simdb-reports.
              * Note that the intended use for writing both legacy and
@@ -249,6 +254,21 @@ namespace sparta {
              * that the report was not active.
              */
             void skipSimDbStats_();
+
+            /*!
+             * \brief This method gets called for each CollectionRecords entry that is
+             * written to the database.
+             */
+            static void postProcessRecord_(const int datablob_db_id, const uint64_t tick, void* user_data)
+            {
+                static_cast<ReportDescriptor*>(user_data)->postProcessRecordImpl_(datablob_db_id, tick);
+            }
+
+            /*!
+             * \brief This method gets called for each CollectionRecords entry that is
+             * written to the database.
+             */
+            void postProcessRecordImpl_(const int datablob_db_id, const uint64_t tick);
 
             friend class ReportDescriptorCollection;
 

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -290,6 +290,13 @@ void ReportDescriptor::configSimDbReport_(
         std::shared_ptr<simdb::CollectionPoint> collectable =
             collection_mgr->createCollectable<double>(si_loc, "root");
 
+        // To save disk space, we do not need to serialize the element IDs with every
+        // collected data point. Other formats may still need this information, and
+        // we are less concerned with disk space for final-value-only reports like JSON.
+        if (format == "csv" || format == "csv_cumulative") {
+            collectable->doNotWriteElemId();
+        }
+
         collected_stat_t collected_stat(si.second.get(), collectable);
         simdb_stats_.push_back(collected_stat);
     }

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -344,7 +344,7 @@ void ReportDescriptor::sweepSimDbStats_()
     }
 
     const auto tick = scheduler_->getCurrentTick();
-    db_mgr_->getCollectionMgr()->sweep("root", tick, dest_file);
+    db_mgr_->getCollectionMgr()->sweep("root", tick);
 #endif
 }
 
@@ -355,9 +355,9 @@ void ReportDescriptor::skipSimDbStats_()
         return;
     }
 
-    const std::string annotation = dest_file + "_skipped_anno_" + skipped_annotator_->currentAnnotation();
+    //const std::string annotation = dest_file + "_skipped_anno_" + skipped_annotator_->currentAnnotation();
     const auto tick = scheduler_->getCurrentTick();
-    db_mgr_->getCollectionMgr()->sweep("root", tick, annotation, true);
+    db_mgr_->getCollectionMgr()->sweep("root", tick, true);
 #endif
 }
 

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -206,7 +206,7 @@ int ReportDescriptor::configSimDbReports(simdb::DatabaseManager* db_mgr, RootTre
         SQL_COLUMNS("LocPattern", "DefFile", "DestFile", "Format"),
         SQL_VALUES(loc_pattern, def_file, dest_file, format));
 
-    const auto report_desc_id = rd_record->getId();
+    simdb_descriptor_id_ = rd_record->getId();
 
     for (const auto& kvp : header_metadata_) {
         const auto& meta_name = kvp.first;
@@ -214,15 +214,15 @@ int ReportDescriptor::configSimDbReports(simdb::DatabaseManager* db_mgr, RootTre
         db_mgr_->INSERT(
             SQL_TABLE("ReportDescriptorMeta"),
             SQL_COLUMNS("ReportDescID", "MetaName", "MetaValue"),
-            SQL_VALUES(report_desc_id, meta_name, meta_value));
+            SQL_VALUES(simdb_descriptor_id_, meta_name, meta_value));
     }
 
     std::unordered_set<std::string> visited_stats;
     for (const auto r : reports) {
-        configSimDbReport_(r, visited_stats, report_desc_id);
+        configSimDbReport_(r, visited_stats, simdb_descriptor_id_);
     }
 
-    return report_desc_id;
+    return simdb_descriptor_id_;
 #else
     (void) db_mgr;
     (void) root;
@@ -344,7 +344,8 @@ void ReportDescriptor::sweepSimDbStats_()
     }
 
     const auto tick = scheduler_->getCurrentTick();
-    db_mgr_->getCollectionMgr()->sweep("root", tick);
+    simdb::DatabaseEntryCallback post_process_cb = ReportDescriptor::postProcessRecord_;
+    db_mgr_->getCollectionMgr()->sweep("root", tick, post_process_cb, this);
 #endif
 }
 
@@ -355,10 +356,36 @@ void ReportDescriptor::skipSimDbStats_()
         return;
     }
 
-    //const std::string annotation = dest_file + "_skipped_anno_" + skipped_annotator_->currentAnnotation();
+    const std::string annotation = skipped_annotator_->currentAnnotation();
     const auto tick = scheduler_->getCurrentTick();
-    db_mgr_->getCollectionMgr()->sweep("root", tick, true);
+
+    // This method is called on the main thread, and we do not want to do
+    // any database writes which will severely impact performance. SimDB
+    // provides the queueWork() method to invoke arbitrary code on the
+    // database thread to get around this.
+    //
+    // Doing the work on the database thread is much faster primarily
+    // due to the fact that SimDB will perform batch processing on all
+    // pending work in a single BEGIN/COMMIT transaction. This occurs
+    // periodically on a 100ms timer in the background.
+    auto work = [=](simdb::DatabaseManager* db_mgr) {
+        db_mgr->INSERT(
+            SQL_TABLE("CsvSkipAnnotations"),
+            SQL_COLUMNS("ReportDescID", "Tick", "Annotation"),
+            SQL_VALUES(simdb_descriptor_id_, tick, annotation));
+    };
+
+    db_mgr_->getCollectionMgr()->queueWork(work);
+
 #endif
+}
+
+void ReportDescriptor::postProcessRecordImpl_(const int datablob_db_id, const uint64_t tick)
+{
+    db_mgr_->INSERT(
+        SQL_TABLE("DescriptorRecords"),
+        SQL_COLUMNS("ReportDescID", "DatablobID", "Tick"),
+        SQL_VALUES(simdb_descriptor_id_, datablob_db_id, tick));
 }
 
 report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1220,8 +1220,8 @@ public:
 
             // For timeseries reports that use toggle triggers, we need to
             // annotate the .csv files with a special annotation which tells
-            // the user how many ticks/cycles were skipped while the toggle
-            // trigger was "off".
+            // the user how many ticks/cycles/picoseconds were skipped while
+            // the report/trigger was inactive.
             auto& csv_skip_annotations_tbl = schema.addTable("CsvSkipAnnotations");
             csv_skip_annotations_tbl.addColumn("ReportDescID", dt::int32_t);
             csv_skip_annotations_tbl.addColumn("Tick", dt::int64_t);

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1208,6 +1208,16 @@ public:
             js_json_leaf_nodes.setColumnDefaultValue("IsParentOfLeafNodes", -1);
             js_json_leaf_nodes.disableAutoIncPrimaryKey();
 
+            // In the case of multiple reports, we will end up with more than
+            // one CollectionRecords rows with the same Tick value. We use this
+            // table in the python exporter to determine which records belong
+            // to which report.
+            auto& desc_records_tbl = schema.addTable("DescriptorRecords");
+            desc_records_tbl.addColumn("ReportDescID", dt::int32_t);
+            desc_records_tbl.addColumn("DatablobID", dt::int32_t);
+            desc_records_tbl.addColumn("Tick", dt::int64_t);
+            desc_records_tbl.createCompoundIndexOn(SQL_COLUMNS("ReportDescID", "Tick"));
+
             const auto& simdb_file = simdb_config.getSimDBFile();
             db_mgr_ = std::make_unique<simdb::DatabaseManager>(simdb_file, true);
             db_mgr_->createDatabaseFromSchema(schema);

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1153,6 +1153,7 @@ public:
             report_meta_tbl.addColumn("ReportID", dt::int32_t);
             report_meta_tbl.addColumn("MetaName", dt::string_t);
             report_meta_tbl.addColumn("MetaValue", dt::string_t);
+            report_meta_tbl.disableAutoIncPrimaryKey();
 
             auto& report_styles_tbl = schema.addTable("ReportStyles");
             report_styles_tbl.addColumn("ReportDescID", dt::int32_t);
@@ -1160,6 +1161,7 @@ public:
             report_styles_tbl.addColumn("StyleName", dt::string_t);
             report_styles_tbl.addColumn("StyleValue", dt::string_t);
             report_styles_tbl.createCompoundIndexOn(SQL_COLUMNS("ReportDescID", "ReportID", "StyleName"));
+            report_styles_tbl.disableAutoIncPrimaryKey();
 
             auto& stat_insts_tbl = schema.addTable("StatisticInsts");
             stat_insts_tbl.addColumn("ReportID", dt::int32_t);
@@ -1175,6 +1177,7 @@ public:
             stat_defn_meta_tbl.addColumn("MetaName", dt::string_t);
             stat_defn_meta_tbl.addColumn("MetaValue", dt::string_t);
             stat_defn_meta_tbl.createIndexOn("StatisticInstID");
+            stat_defn_meta_tbl.disableAutoIncPrimaryKey();
 
             auto& siminfo_tbl = schema.addTable("SimulationInfo");
             siminfo_tbl.addColumn("SimName", dt::string_t);
@@ -1183,10 +1186,12 @@ public:
             siminfo_tbl.addColumn("ReproInfo", dt::string_t);
             siminfo_tbl.addColumn("SimEndTick", dt::int64_t);
             siminfo_tbl.setColumnDefaultValue("SimEndTick", -1);
+            siminfo_tbl.disableAutoIncPrimaryKey();
 
             auto& siminfo_header_pairs_tbl = schema.addTable("SimulationInfoHeaderPairs");
             siminfo_header_pairs_tbl.addColumn("HeaderName", dt::string_t);
             siminfo_header_pairs_tbl.addColumn("HeaderValue", dt::string_t);
+            siminfo_header_pairs_tbl.disableAutoIncPrimaryKey();
 
             auto& vis_tbl = schema.addTable("Visibilities");
             vis_tbl.addColumn("Hidden", dt::int32_t);
@@ -1195,11 +1200,13 @@ public:
             vis_tbl.addColumn("Normal", dt::int32_t);
             vis_tbl.addColumn("Summary", dt::int32_t);
             vis_tbl.addColumn("Critical", dt::int32_t);
+            vis_tbl.disableAutoIncPrimaryKey();
 
             auto& js_json_leaf_nodes = schema.addTable("JsJsonLeafNodes");
             js_json_leaf_nodes.addColumn("ReportName", dt::string_t);
             js_json_leaf_nodes.addColumn("IsParentOfLeafNodes", dt::int32_t);
             js_json_leaf_nodes.setColumnDefaultValue("IsParentOfLeafNodes", -1);
+            js_json_leaf_nodes.disableAutoIncPrimaryKey();
 
             const auto& simdb_file = simdb_config.getSimDBFile();
             db_mgr_ = std::make_unique<simdb::DatabaseManager>(simdb_file, true);

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1216,7 +1216,7 @@ public:
             desc_records_tbl.addColumn("ReportDescID", dt::int32_t);
             desc_records_tbl.addColumn("DatablobID", dt::int32_t);
             desc_records_tbl.addColumn("Tick", dt::int64_t);
-            desc_records_tbl.createCompoundIndexOn(SQL_COLUMNS("ReportDescID", "Tick"));
+            desc_records_tbl.createIndexOn("ReportDescID");
 
             // For timeseries reports that use toggle triggers, we need to
             // annotate the .csv files with a special annotation which tells

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -1218,6 +1218,16 @@ public:
             desc_records_tbl.addColumn("Tick", dt::int64_t);
             desc_records_tbl.createCompoundIndexOn(SQL_COLUMNS("ReportDescID", "Tick"));
 
+            // For timeseries reports that use toggle triggers, we need to
+            // annotate the .csv files with a special annotation which tells
+            // the user how many ticks/cycles were skipped while the toggle
+            // trigger was "off".
+            auto& csv_skip_annotations_tbl = schema.addTable("CsvSkipAnnotations");
+            csv_skip_annotations_tbl.addColumn("ReportDescID", dt::int32_t);
+            csv_skip_annotations_tbl.addColumn("Tick", dt::int64_t);
+            csv_skip_annotations_tbl.addColumn("Annotation", dt::string_t);
+            csv_skip_annotations_tbl.createIndexOn("ReportDescID");
+
             const auto& simdb_file = simdb_config.getSimDBFile();
             db_mgr_ = std::make_unique<simdb::DatabaseManager>(simdb_file, true);
             db_mgr_->createDatabaseFromSchema(schema);


### PR DESCRIPTION
The main goal of these changes is to get v2.1 SimDB reports to be faster and smaller than legacy reports. The biggest issue here was the `sparta.db` size when using timeseries reports, previously `33% larger than formatted reports`.

The performance benchmark used five different timeseries reports with 1M instructions (sparta_core_example).

```
                Time    Size
Legacy          6.7s    36MB
SimDB before    5.8s    48MB   (33% larger)
SimDB after     5.5s    28MB   (22% smaller)
```

So the performance we are left with (compared to legacy) is `18% faster, 22% smaller`

All tests are passing:

```
Format        Passed   Failed   NoCompare
-----------------------------------------
csv           86       0        0       
html          0        6        0       
js_json       3        0        0       
json          9        0        0       
json_detail   5        0        0       
json_reduced  8        0        0       
stats_mapping 1        0        0       
txt           23       0        0
```

Report export performance is not explicitly addressed in this PR, though the `simdb_export` script got slower by 2% due to the schema changes to make the `sparta.db` much smaller. Export perf will be improved in a later PR.

I'd recommend reviewing the C++/schema changes first, then the python code.

Here are the supporting SimDB changes (already in main):
https://github.com/colby-nyce/simdb/commit/5d6db040c0c0d1d2a60ed01ffb84d625aa5fa9db
