### PR TITLE
Optionally export SimDB reports using the EXACT formatting from MAP v2

### DIFF
--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -6,7 +6,7 @@ class CSVReportExporter:
     def __init__(self):
         pass
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         cursor = db_conn.cursor()
 
         # Start with the CSV header, which looks something like this:

--- a/sparta/scripts/simdb/exporters/export_gnuplot_report.py
+++ b/sparta/scripts/simdb/exporters/export_gnuplot_report.py
@@ -2,7 +2,7 @@ class GnuplotReportExporter:
     def __init__(self):
         pass
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         # For now, just "touch" each report file. The comparison script will naturally
         # fail which is okay for now.
         with open(dest_file, "w") as fout:

--- a/sparta/scripts/simdb/exporters/export_html_report.py
+++ b/sparta/scripts/simdb/exporters/export_html_report.py
@@ -2,7 +2,7 @@ class HTMLReportExporter:
     def __init__(self):
         pass
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         # For now, just "touch" each report file. The comparison script will naturally
         # fail which is okay for now.
         with open(dest_file, "w") as fout:

--- a/sparta/scripts/simdb/exporters/export_js_report.py
+++ b/sparta/scripts/simdb/exporters/export_js_report.py
@@ -1,6 +1,7 @@
 from .sim_utils import *
 from .stat_utils import *
 from .json_utils import *
+from collections import OrderedDict
 import json
 
 class JSReportExporter:
@@ -11,7 +12,7 @@ class JSReportExporter:
         self.leaf_nodes = set()
         self.parents_of_leaf_nodes = set()
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         self.db_conn = db_conn
         self.cursor = db_conn.cursor()
 
@@ -36,12 +37,15 @@ class JSReportExporter:
         report_id = row[0]
 
         # decimal_places_ = strtoul(report_->getStyle("decimal_places", "2").c_str(), nullptr, 0);
-        decimal_places = int(GetReportStyle(cursor, report_id, descriptor_id, "decimal_places", "2"))
+        if cmdline_args.v2:
+            decimal_places = -1
+        else:
+            decimal_places = int(GetReportStyle(cursor, report_id, descriptor_id, "decimal_places", "2"))
         self.stat_values_getter = GetStatsValuesGetter(self.cursor, dest_file, True, True, decimal_places)
 
         # out << "{\n";
         # out << "  \"units\" : {\n";
-        out = {"units": {}}
+        out = OrderedDict([("units", OrderedDict())])
 
         # std::vector<std::string> all_key_names;
         # writeReport_(out, *report_, all_key_names);
@@ -126,7 +130,7 @@ class JSReportExporter:
             # std::vector<std::string> all_stat_names;
             # writeStats_(out, report, "", all_stat_names);
             unit_name = GetReportName(self.cursor, report_id)
-            out["units"][unit_name] = {}
+            out["units"][unit_name] = OrderedDict()
             all_unit_names.append(unit_name)
 
             all_stat_names = []

--- a/sparta/scripts/simdb/exporters/export_json_report.py
+++ b/sparta/scripts/simdb/exporters/export_json_report.py
@@ -50,6 +50,23 @@ class JSONReducedReportExporter:
         with open(dest_file, "w") as fout:
             json.dump(json_out, fout, indent=4)
 
+        cmd = f"SELECT MetaName, MetaValue FROM ReportMetadata WHERE ReportDescID = {descriptor_id}"
+        cmd += " AND MetaName = 'PrettyPrint'"
+        cursor.execute(cmd)
+
+        pretty_print = True
+        row = cursor.fetchone()
+        if row:
+            pretty_print = row[1].lower() == 'true'
+
+        if not pretty_print:
+            # If not pretty printing, we need to remove all leading/trailing whitespace
+            with open(dest_file, 'r') as fin:
+                reformatted_lines = [line.strip() for line in fin.readlines()]
+
+            with open(dest_file, 'w') as fout:
+                fout.write('\n'.join(reformatted_lines))
+
 class JSONDetailReportExporter:
     def __init__(self):
         pass

--- a/sparta/scripts/simdb/exporters/export_py_report.py
+++ b/sparta/scripts/simdb/exporters/export_py_report.py
@@ -2,7 +2,7 @@ class PyReportExporter:
     def __init__(self):
         pass
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         # For now, just "touch" each report file. The comparison script will naturally
         # fail which is okay for now.
         with open(dest_file, "w") as fout:

--- a/sparta/scripts/simdb/exporters/export_stats_mapping_report.py
+++ b/sparta/scripts/simdb/exporters/export_stats_mapping_report.py
@@ -5,7 +5,7 @@ class StatsMappingReportExporter:
     def __init__(self):
         pass
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         # Get the root report ID
         cmd = f"SELECT Id FROM Reports WHERE ReportDescID = {descriptor_id} AND ParentReportID = 0"
         cursor = db_conn.cursor()

--- a/sparta/scripts/simdb/exporters/export_text_report.py
+++ b/sparta/scripts/simdb/exporters/export_text_report.py
@@ -17,7 +17,7 @@ class TextReportExporter:
         self.show_report_range = True
         self.val_col = 0
 
-    def Export(self, dest_file, descriptor_id, db_conn):
+    def Export(self, dest_file, descriptor_id, db_conn, cmdline_args):
         out = io.StringIO()
         if self.GetShowSimInfo():
             # out << sparta::SimulationInfo::getInstance().stringize("", "\n") << std::endl << std::endl;

--- a/sparta/scripts/simdb/exporters/sim_utils.py
+++ b/sparta/scripts/simdb/exporters/sim_utils.py
@@ -36,8 +36,11 @@ class SimulationInfo:
         cursor = db_conn.cursor()
         cursor.execute(cmd)
 
-        for row in cursor.fetchall():
-            out.write(f"{line_start}Other:  {row[0]}{line_end}")
+        others = cursor.fetchall()
+        if others:
+            out.write(f"{line_start}Other:{line_end}")
+            for row in others:
+                out.write(f"{line_start}  {row[0]}{line_end}")
 
 def GetSimInfo(cursor):
     cmd = "SELECT SimName, SimVersion, SpartaVersion, ReproInfo FROM SimulationInfo"

--- a/sparta/scripts/simdb/exporters/stat_utils.py
+++ b/sparta/scripts/simdb/exporters/stat_utils.py
@@ -239,3 +239,13 @@ def GetReportStyle(cursor, report_id, descriptor_id, style_name, style_default=N
 
     style_value = cursor.fetchone()
     return style_value[0] if style_value else style_default
+
+def GetReportStyleDict(cursor, report_id, descriptor_id):
+    cmd = f"SELECT StyleName, StyleValue FROM ReportStyles WHERE ReportDescID = {descriptor_id} AND ReportID = {report_id}"
+    cursor.execute(cmd)
+
+    style_dict = {}
+    for style_name, style_value in cursor.fetchall():
+        style_dict[style_name] = style_value
+
+    return style_dict

--- a/sparta/scripts/simdb/run_report_verif_suite.py
+++ b/sparta/scripts/simdb/run_report_verif_suite.py
@@ -26,6 +26,7 @@ parser.add_argument("--force", action="store_true", help="Force overwrite of the
 parser.add_argument("--serial", action="store_true", help="Run tests serially instead of in parallel.")
 parser.add_argument("--skip", nargs='+', default=[], help="Skip the specified tests.")
 parser.add_argument("--test-only", nargs='+', default=[], help="Run only the specified test(s).")
+parser.add_argument("--v2-exact", action="store_true", help="Use exact comparison against MAP v2 for report contents (e.g. 0.00082 != 8.2e-4).")
 args = parser.parse_args()
 
 # Overwrite the results directory since each test runs in its own tempdir.
@@ -268,13 +269,15 @@ class SpartaTest:
         export_cmd = "python3 " + os.path.join(script_dir, "simdb_export.py")
         export_cmd += " --export-dir simdb_reports"
         export_cmd += " --force"
+        if args.v2_exact:
+            export_cmd += " --v2"
         export_cmd += " sparta.db"
 
         self.__WriteToTestLog(f"Exporting SimDB reports with command: {export_cmd}")
         subprocess.run(export_cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         # Compare the baseline reports to the SimDB reports.
-        compare_results = RunComparison("baseline_reports", "simdb_reports", baseline_reports, self.logout)
+        compare_results = RunComparison("baseline_reports", "simdb_reports", baseline_reports, self.logout, args.v2_exact)
         passing_reports = compare_results["passing"]
         failing_reports = compare_results["failing"]
         unsupported_reports = compare_results["unsupported"]

--- a/sparta/scripts/simdb/simdb_compare.py
+++ b/sparta/scripts/simdb/simdb_compare.py
@@ -10,6 +10,7 @@ parser.add_argument("--legacy-reports-dir", default=".", help="Directory contain
 parser.add_argument("--results-dir", default="simdb-comparison-results", help="Directory to save comparison results.")
 parser.add_argument("--force", action="store_true", help="Force overwrite results directory.")
 parser.add_argument("--quiet", action="store_true", help="Suppress output.")
+parser.add_argument("--exact", action="store_true", help="Use exact comparison for report contents (e.g. 0.00082 != 8.2e-4).")
 parser.add_argument("database", type=str, help="Path to the SimDB database file.")
 args = parser.parse_args()
 
@@ -63,7 +64,7 @@ os.system(export_cmd)
 
 # Run the comparisons and generate the final comparison report.
 logger = io.StringIO()
-results = RunComparison(legacy_reports_dir_out, simdb_reports_dir_out, baseline_reports, logger)
+results = RunComparison(legacy_reports_dir_out, simdb_reports_dir_out, baseline_reports, logger, args.exact)
 
 passing_reports = results["passing"]
 failing_reports = results["failing"]

--- a/sparta/scripts/simdb/simdb_export.py
+++ b/sparta/scripts/simdb/simdb_export.py
@@ -14,10 +14,18 @@ from exporters.export_py_report import PyReportExporter
 from exporters.export_gnuplot_report import GnuplotReportExporter
 from exporters.export_stats_mapping_report import StatsMappingReportExporter
 
+from v2_reformatters.v2_json import v2JsonReformatter
+from v2_reformatters.v2_json_detail import v2JsonDetailReformatter
+from v2_reformatters.v2_json_reduced import v2JsonReducedReformatter
+from v2_reformatters.v2_js_json import v2JsJsonReformatter
+
+from exporters.stat_utils import *
+
 parser = argparse.ArgumentParser(description="Export SimDB records to formatted report files.")
 parser.add_argument("--dest-file", type=str, help="Export only this one destination file (out.csv etc. from the defn yaml).")
 parser.add_argument("--export-dir", type=str, default=".", help="Directory to save the exported report files.")
 parser.add_argument("--force", action="store_true", help="Force overwrite export directory/reports.")
+parser.add_argument("--v2", action="store_true", help="Export reports with the exact MAP v2 formatting (may be slower).")
 parser.add_argument("database", type=str, help="Path to the SimDB database file.")
 args = parser.parse_args()
 
@@ -66,6 +74,20 @@ def GetExporter(format):
     print (f"Unknown report format '{format}'")
     sys.exit(1)
 
+# Get the appropriate MAP v2 reformatter for the given report format.
+def GetV2Reformatter(format):
+    format = format.lower()
+    if format in ('json'):
+        return v2JsonReformatter()
+    if format in ('json_reduced'):
+        return v2JsonReducedReformatter()
+    if format in ('json_detail'):
+        return v2JsonDetailReformatter()
+    if format in ('js_json', 'jsjson'):
+        return v2JsJsonReformatter()
+
+    return None
+
 cmd = "SELECT Id, DestFile, Format FROM ReportDescriptors"
 if args.dest_file:
     cmd += f" WHERE DestFile = '{args.dest_file}'"
@@ -90,5 +112,20 @@ if existing_files:
 for id, dest_file, format in rows:
     dest_file = os.path.join(args.export_dir, dest_file)
     exporter = GetExporter(format)
-    exporter.Export(dest_file, id, conn)
+    exporter.Export(dest_file, id, conn, args)
+    if args.v2:
+        reformatter = GetV2Reformatter(format)
+        if reformatter:
+            cmd = f"SELECT Id FROM ReportDescriptors WHERE DestFile = '{os.path.basename(dest_file)}'"
+            cursor.execute(cmd)
+            descriptor_id = cursor.fetchone()[0]
+
+            cmd = f"SELECT Id FROM Reports WHERE ReportDescID = {descriptor_id} AND ParentReportID = 0"
+            cursor.execute(cmd)
+            row = cursor.fetchone()
+            report_id = row[0]
+
+            styles = GetReportStyleDict(cursor, report_id, descriptor_id)
+            reformatter.Reformat(dest_file, styles)
+
     print (f"Exported: {dest_file}")

--- a/sparta/scripts/simdb/v2_reformatters/v2_js_json.py
+++ b/sparta/scripts/simdb/v2_reformatters/v2_js_json.py
@@ -1,0 +1,133 @@
+import json, io
+from .v2_json_reformatter import v2JsonReformatterBase
+
+class v2JsJsonReformatter(v2JsonReformatterBase):
+    def __init__(self):
+        v2JsonReformatterBase.__init__(self)
+
+    def Reformat(self, dest_file, report_style):
+        with open(dest_file, 'r', encoding='utf-8') as fin:
+            data = json.load(fin)
+
+        out = io.StringIO()
+        out.write('{\n')
+
+        indent = 2
+        decimal_places = int(report_style.get('decimal_places', 2))
+        for key, value in data.items():
+            self.__WriteLevel(out, key, value, decimal_places, indent)
+
+        out.write('}')
+        with open(dest_file, 'w', encoding='utf-8') as fout:
+            fout.write(out.getvalue())
+
+        with open(dest_file, 'r', encoding='utf-8') as fin:
+            lines = fin.readlines()
+
+        lines = [line.rstrip() + '\n' for line in lines if line.strip()]
+
+        # Compare the indentation level for all lines. If two adjacent lines
+        # have the same indentation level, then we need to append a comma
+        # to the previous line.
+        for i in range(1, len(lines)):
+            if lines[i].strip() and lines[i-1].strip():
+                prev_indent = len(lines[i-1]) - len(lines[i-1].lstrip())
+                curr_indent = len(lines[i]) - len(lines[i].lstrip())
+                if prev_indent == curr_indent:
+                    lines[i-1] = lines[i-1].rstrip() + ',\n'
+
+        # Append a whitespace character for each list element in 'ordered_keys'
+        # (except the last element).
+        in_ordered_keys = False
+        for i in range(len(lines)):
+            if lines[i].find("ordered_keys") != -1:
+                in_ordered_keys = True
+                continue
+            elif in_ordered_keys and lines[i].rstrip().endswith(','):
+                lines[i] = lines[i].rstrip() + ' \n'
+            elif in_ordered_keys:
+                in_ordered_keys = False
+
+        # Write the final output to the file
+        with open(dest_file, 'w', encoding='utf-8') as fout:
+            fout.write(''.join(lines))
+
+    def __WriteLevel(self, out, key, value, decimal_places, indent):
+        if key in ('units', 'vis', 'siminfo'):
+            out.write(' '*indent + f'"{key}" : ')
+        else:
+            out.write(' '*indent + f'"{key}": ')
+
+        if isinstance(value, dict):
+            if set(value.keys()) == {'val', 'vis', 'desc'}:
+                val = float(value['val'])
+                vis = value['vis']
+                desc = value['desc']
+
+                def is_whole_number(x):
+                    return isinstance(x, (int, float)) and x == int(x)
+
+                # Rule 1: Whole numbers should be printed as integers
+                if is_whole_number(val):
+                    out.write('{ "val" : ' + str(int(val)) + ', ')
+
+                # Rule 2: Fractional numbers should be printed with a fixed number of decimal places
+                else:
+                    out.write('{ "val" : ' + f"{val:.{decimal_places}f}" + ', ')
+
+                out.write('"vis" : ' + str(vis) + ', ')
+                out.write('"desc" : "' + desc + '"}\n')
+            elif key == 'vis':
+                hidden = value['hidden']
+                support = value['support']
+                detail = value['detail']
+                normal = value['normal']
+                summary = value['summary']
+
+                out.write('{\n')
+                out.write(' ' * (indent + 2) + f'"hidden"  : {hidden}\n')
+                out.write(' ' * (indent + 2) + f'"support" : {support}\n')
+                out.write(' ' * (indent + 2) + f'"detail"  : {detail}\n')
+                out.write(' ' * (indent + 2) + f'"normal"  : {normal}\n')
+                out.write(' ' * (indent + 2) + f'"summary" : {summary}\n')
+                out.write(' ' * indent + '}\n')
+            elif key == 'siminfo':
+                out.write('{\n')
+                for sub_key, sub_value in value.items():
+                    out.write(' ' * (indent + 2))
+                    if isinstance(sub_value, str):
+                        out.write(f'"{sub_key}" : "{sub_value}"\n')
+                    else:
+                        out.write(f'"{sub_key}" : {sub_value}\n')
+
+                out.write(' ' * indent)
+                out.write('}\n')
+            elif key == 'report_metadata':
+                out.write('{\n')
+                longest_sub_key = max(len(sub_key) for sub_key in value.keys())
+                for sub_key, sub_value in value.items():
+                    sub_key = f'"{sub_key}"'
+                    sub_key = sub_key.ljust(longest_sub_key + 2)
+                    out.write(' ' * (indent + 2))
+                    if isinstance(sub_value, str):
+                        out.write(f'{sub_key}: "{sub_value}"\n')
+                    else:
+                        out.write(f'{sub_key}: {sub_value}\n')
+
+                out.write(' ' * indent)
+                out.write('}\n')
+            else:
+                out.write('{\n')
+                for sub_key, sub_value in value.items():
+                    self.__WriteLevel(out, sub_key, sub_value, decimal_places, indent + 2)
+
+                out.write(' ' * indent)
+                out.write('}\n')
+        elif isinstance(value, list):
+            out.write('[\n')
+            for item in value:
+                out.write(' ' * (indent + 2))
+                out.write(f'"{item}" \n')
+
+            out.write(' ' * indent)
+            out.write(']\n')

--- a/sparta/scripts/simdb/v2_reformatters/v2_json.py
+++ b/sparta/scripts/simdb/v2_reformatters/v2_json.py
@@ -1,0 +1,46 @@
+import json, re
+from .v2_json_reformatter import v2JsonReformatterBase
+
+class v2JsonReformatter(v2JsonReformatterBase):
+    def __init__(self, stat_val_pattern=None):
+        v2JsonReformatterBase.__init__(self)
+
+        # Subclasses may provide a custom regex pattern to match
+        # statistics values that need to be reformatted.
+        self.stat_val_pattern = stat_val_pattern
+
+        if not self.stat_val_pattern:
+            # The default json format displays stat values with this pattern:
+            #   "val": <value>
+            self.stat_val_pattern = re.compile(
+                r'^(?P<indent>\s*)"(?P<key>[^"]+)"\s*:\s*(?P<value>[+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)(?P<trailing_comma>\s*,?)\s*$'
+            )
+
+    def Reformat(self, dest_file, report_style):
+        if not self.stat_val_pattern:
+            return
+
+        with open(dest_file, 'r', encoding='utf-8') as fin:
+            lines = fin.readlines()
+
+        reformatted_lines = []
+        for line in lines:
+            reformatted_lines.append(self.__ReformatLine(line.rstrip()))
+
+        with open(dest_file, 'w', encoding='utf-8') as fout:
+            fout.write('\n'.join(reformatted_lines))
+
+    def __ReformatLine(self, line):
+        match = self.stat_val_pattern.match(line)
+        if match:
+            indent = match.group("indent")
+            key    = match.group("key")
+            value  = match.group("value")
+            comma  = match.group("trailing_comma")
+
+            # Reformat value according to MAP v2 standards
+            new_value = self.ReformatValue(value)
+            new_line = f'{indent}"{key}": {new_value}{comma}'
+            return new_line
+        else:
+            return line

--- a/sparta/scripts/simdb/v2_reformatters/v2_json_detail.py
+++ b/sparta/scripts/simdb/v2_reformatters/v2_json_detail.py
@@ -1,0 +1,67 @@
+import re
+from .v2_json_reformatter import v2JsonReformatterBase
+
+class v2JsonDetailReformatter(v2JsonReformatterBase):
+    def __init__(self):
+        v2JsonReformatterBase.__init__(self)
+
+    def Reformat(self, dest_file, report_style):
+        reformatted_lines = []
+
+        # JSON detail reports always start with this:
+        #
+        #     {
+        #         "_id": " ",
+        #
+        # And need to start with this:
+        #
+        #    {  "_id": " ",
+        reformatted_lines.append('{ "_id": " ",\n')
+
+        with open(dest_file, 'r', encoding='utf-8') as file:
+            lines = file.readlines()
+
+            # Start at the third line, since the first two lines are already handled.
+            for line in lines[2:]:
+                # See if the current line is of the form:
+                #   "name": "some.path.to.a.stat",
+                #
+                # Where the "name" is is exact, and the "some.path.to.a.stat" is any path.
+                match = re.match(r'^\s*"name":\s*"([^"]+)"\s*,\s*$', line)
+
+                # If it is, then we need to write the previous line + the current line.
+                # Otherwise, we just write the current line.
+                #
+                # Example before reformatting:
+                #
+                #    {
+                #        "name": "decode.AUTO.FetchQueue_utililization_UF",
+                #        "desc": "underflow bin",
+                #        "vis": "100000000",
+                #        "class": "50"
+                #    }
+                #
+                # After reformatting, it should look like this:
+                #
+                #    { "name": "decode.AUTO.FetchQueue_utililization_UF",
+                #      "desc": "underflow bin",
+                #      "vis": "100000000",
+                #      "class": "50"
+                #    }
+                if match:
+                    reformatted_line = reformatted_lines[-1]
+                    reformatted_line = reformatted_line.rstrip() + ' '
+                    reformatted_line += line.strip() + '\n'
+                    reformatted_lines[-1] = reformatted_line
+                else:
+                    # Just write the current line
+                    reformatted_lines.append(line)
+
+        # Pop the last line if it is empty, as it is not needed.
+        if reformatted_lines and reformatted_lines[-1].strip() == '':
+            reformatted_lines.pop()
+
+        # Write the reformatted lines back to the file
+        with open(dest_file, 'w', encoding='utf-8') as fout:
+            for line in reformatted_lines:
+                fout.write(line)

--- a/sparta/scripts/simdb/v2_reformatters/v2_json_reduced.py
+++ b/sparta/scripts/simdb/v2_reformatters/v2_json_reduced.py
@@ -1,0 +1,16 @@
+import re
+from .v2_json import v2JsonReformatter
+
+class v2JsonReducedReformatter(v2JsonReformatter):
+    def __init__(self):
+        # The only tweaks we need to do is to reformat some statistics values.
+        # Look for lines that match this regex:
+        #
+        #     "stat_name": float_value
+        #
+        # We will only reformat the floating point value to be the same as MAP v2.
+        pattern = re.compile(
+            r'^(?P<indent>\s*)"(?P<key>[^"]+)"\s*:\s*(?P<value>[+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)(?P<trailing_comma>\s*,?)\s*$'
+        )
+
+        v2JsonReformatter.__init__(self, stat_val_pattern=pattern)

--- a/sparta/scripts/simdb/v2_reformatters/v2_json_reformatter.py
+++ b/sparta/scripts/simdb/v2_reformatters/v2_json_reformatter.py
@@ -1,0 +1,28 @@
+import math
+
+class v2JsonReformatterBase:
+    def ReformatValue(self, val):
+        orig_val = val
+        val = float(val) if isinstance(val, str) else val
+        if val == 0:
+            return "0"
+
+        exponent = math.floor(math.log10(abs(val))) if val != 0 else 0
+        if exponent > 0 or abs(exponent) >= 6:
+            return self.__TrimExponent(str(orig_val))
+
+        num_digits = 10 + abs(exponent)
+        val = f"{val:.{num_digits}f}".rstrip('0').rstrip('.')
+        return self.__TrimExponent(val)
+
+    def __TrimExponent(self, val):
+        # Turn scientific notation like "1.23e-08" into "1.23e-8"
+        if 'e-0' in val:
+            return val.replace('e-0', 'e-')
+        if 'e+0' in val:
+            return val.replace('e+0', 'e+')
+        if 'E-0' in val:
+            return val.replace('E-0', 'E-')
+        if 'E+0' in val:
+            return val.replace('E+0', 'E+')
+        return val

--- a/sparta/src/JavascriptObject.cpp
+++ b/sparta/src/JavascriptObject.cpp
@@ -32,7 +32,7 @@ void sparta::report::format::JavascriptObject::writeContentToStream_(std::ostrea
     std::vector<std::string> all_key_names;
     writeReport_(out, *report_, all_key_names);
 
-    out << "    \"ordered_keys\" : [    \n";
+    out << "    \"ordered_keys\": [\n";
     for (uint32_t idx = 0; idx < all_key_names.size(); idx++) {
         out << "      \"" << all_key_names[idx] << "\"";
         if (idx != (all_key_names.size() - 1)) {
@@ -73,7 +73,7 @@ void sparta::report::format::JavascriptObject::writeContentToStream_(std::ostrea
                 out << ",\n";
             }
         }
-        out << "  }\n";
+        out << "\n  }\n";
     }
 
     out << "}\n";


### PR DESCRIPTION
For users that are not comfortable upgrading to MAP v2.1+ due to semantic differences between legacy reports and SimDB reports, provide a --v2 switch for the export script to get the literal exact same report. Without --v2, there can be many "differences" like this:

```
"ticks": { "val" : 39528, "vis" : 100000000, "desc" : "Current tick number"}

versus

"ticks": {
    "val": 39528,
    "vis": 100000000,
    "desc": "Current tick number"
}
```

Or like this:

```
"val": 0.00001234

versus

"val": 1.234e-5
```

Or like this:

```
"val": 1.23e-8

versus

"val": 1.23e-08
```

This discrepancy is due to the old C++ code writing to file streams directly (not necessarily with rapidjson etc.) while the default use of the python scripts just uses the json python library. There is only so much control we have to get these to match exactly.

Users who do not want to see any differences, even superficial ones, can take the performance hit of adding this extra formatting step to SimDB export.

Every test passes under both conditions:

```
python3 scripts/simdb/run_report_verif_suite.py --sim-exe-path release/example/CoreModel/sparta_core_example --v2-exact

python3 scripts/simdb/run_report_verif_suite.py --sim-exe-path release/example/CoreModel/sparta_core_example

Format        Passed   Failed   NoCompare
-----------------------------------------
csv           86       0        0       
html          0        0        6       
js_json       3        0        0       
json          8        0        0       
json_detail   4        0        0       
json_reduced  7        0        0       
stats_mapping 1        0        0       
txt           23       0        0
```