### PR TITLE
Redesign SimDB pipeline architecture

### DIFF
--- a/sparta/CMakeLists.txt
+++ b/sparta/CMakeLists.txt
@@ -80,6 +80,10 @@ list (APPEND SourceCppFiles
             src/GenericUnit.cpp
 )
 
+if (USING_SIMDB)
+  list (APPEND SourceCppFiles src/ReportStatsCollector.cpp)
+endif ()
+
 # Add python support
 if (COMPILE_WITH_PYTHON)
   list (APPEND SourceCppFiles

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -82,7 +82,7 @@ class CSVReportExporter:
             cursor.execute(cmd)
             datablob_ids = {row[0] for row in cursor.fetchall()}
 
-            cmd = f'SELECT Id, Tick, Data, IsCompressed FROM CollectionRecords'
+            cmd = f'SELECT Id, Tick, DataBlob, IsCompressed FROM UnifiedCollectorBlobs'
             cursor.execute(cmd)
             for record_id, tick, data, is_compressed in cursor.fetchall():
                 # Not ours? Continue.

--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -75,23 +75,10 @@ class CSVReportExporter:
             # and the CsvSkipAnnotations table before writing them to the CSV file.
             csv_row_text_by_tick = {}
 
-            # We cannot query the CollectionRecords table directly, because it may contain multiple
-            # records for the same tick (coming from different report descriptors). We have to query
-            # the DescriptorRecords table first to find out which CollectionRecords belong to us.
-            cmd = f'SELECT DatablobID FROM DescriptorRecords WHERE ReportDescID={descriptor_id}'
+            cmd = f'SELECT Tick, DataBlob FROM DescriptorRecords WHERE ReportDescID={descriptor_id}'
             cursor.execute(cmd)
-            datablob_ids = {row[0] for row in cursor.fetchall()}
-
-            cmd = f'SELECT Id, Tick, DataBlob, IsCompressed FROM UnifiedCollectorBlobs'
-            cursor.execute(cmd)
-            for record_id, tick, data, is_compressed in cursor.fetchall():
-                # Not ours? Continue.
-                if record_id not in datablob_ids:
-                    continue
-
-                if is_compressed:
-                    data = zlib.decompress(data)
-
+            for tick, data in cursor.fetchall():
+                data = zlib.decompress(data)
                 dt = np.dtype([('value', '<f8')])
                 records = np.frombuffer(data, dtype=dt)
                 double_values = records['value']

--- a/sparta/scripts/simdb/exporters/stat_utils.py
+++ b/sparta/scripts/simdb/exporters/stat_utils.py
@@ -55,21 +55,11 @@ def GetStatsValuesGetter(cursor, dest_file, replace_nan_with_nanstring=False, re
     if descriptor_format in ('csv', 'csv_cumulative'):
         raise ValueError(f"Unsupported report format: {descriptor_format}")
 
-    cmd = f'SELECT COUNT(*), DatablobID FROM DescriptorRecords WHERE ReportDescID={descriptor_id}'
+
+    cmd = f'SELECT DataBlob FROM DescriptorRecords WHERE ReportDescID={descriptor_id}'
     cursor.execute(cmd)
-    row_count, datablob_id = cursor.fetchone()
-
-    if row_count == 0:
-        return None
-
-    if row_count > 1:
-        raise ValueError(f"Multiple datablob IDs found for report '{dest_file}'")
-
-    cmd = f"SELECT DataBlob, IsCompressed FROM UnifiedCollectorBlobs WHERE Id={datablob_id}"
-    cursor.execute(cmd)
-    stats_blob, is_compressed = cursor.fetchone()
-    if is_compressed:
-        stats_blob = zlib.decompress(stats_blob)
+    stats_blob = cursor.fetchone()[0]
+    stats_blob = zlib.decompress(stats_blob)
 
     # Turn the stats blob (byte vector) into a vector of doubles.
     assert len(stats_blob) % 8 == 0, "Invalid stats blob length"

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -35,16 +35,16 @@
 
 namespace sparta::app {
     class SimulationConfiguration;
+    class ReportStatsCollector;
 }  // namespace sparta::app
+
+namespace simdb {
+    class PipelineEntry;
+}
 
 namespace sparta::trigger {
     class SkippedAnnotatorBase;
 }  // namespace sparta::trigger
-
-namespace simdb {
-    class CollectionPoint;
-    class DatabaseManager;
-}  // namespace simdb
 
 namespace sparta {
 
@@ -194,14 +194,9 @@ namespace sparta {
             std::string orig_dest_file_;
 
             /*!
-             * \brief SimDB instance owned by ReportRepository.
+             * \brief Report stats collector for SimDB.
              */
-            simdb::DatabaseManager* db_mgr_ = nullptr;
-
-            /*!
-             * \brief SimDB primary key in the ReportDescriptors table.
-             */
-            int simdb_descriptor_id_ = 0;
+            ReportStatsCollector* collector_ = nullptr;
 
             /*!
              * \brief Set to false only when the simulation was run with
@@ -213,31 +208,6 @@ namespace sparta {
              * compatibility.
              */
             bool legacy_reports_enabled_ = true;
-
-            /*!
-             * \brief Cache the Scheduler so we know the current tick for every
-             * call to simdb::CollectionMgr::sweep().
-             */
-            const Scheduler* scheduler_ = nullptr;
-
-            /*!
-             * \brief Stats for each report (collected_stat_t) are stored as pairs
-             * of a StatisticInstance and a simdb::CollectionPoint. The data value
-             * is retrieved from the StatisticInstance and written to the SimDB
-             * CollectionPoint.
-             */
-            using collected_stat_t = std::pair<const StatisticInstance*, std::shared_ptr<simdb::CollectionPoint>>;
-            std::vector<collected_stat_t> simdb_stats_;
-
-            /*!
-             * \brief Write all metadata about the given report (and its subreports
-             * and statistics) to SimDB.
-             */
-            void configSimDbReport_(
-                const Report* r,
-                std::unordered_set<std::string> & visited_stats,
-                const int report_desc_id = 0,
-                const int parent_report_id = 0);
 
             /*!
              * \brief Go through the SimDB collection system and "activate" all of our
@@ -254,21 +224,6 @@ namespace sparta {
              * that the report was not active.
              */
             void skipSimDbStats_();
-
-            /*!
-             * \brief This method gets called for each CollectionRecords entry that is
-             * written to the database.
-             */
-            static void postProcessRecord_(const int datablob_db_id, const uint64_t tick, void* user_data)
-            {
-                static_cast<ReportDescriptor*>(user_data)->postProcessRecordImpl_(datablob_db_id, tick);
-            }
-
-            /*!
-             * \brief This method gets called for each CollectionRecords entry that is
-             * written to the database.
-             */
-            void postProcessRecordImpl_(const int datablob_db_id, const uint64_t tick);
 
             friend class ReportDescriptorCollection;
 
@@ -426,16 +381,9 @@ namespace sparta {
             std::shared_ptr<statistics::StreamNode> createRootStatisticsStream();
 
             /*!
-             * \brief Write all metadata about our report (and its subreports
-             * and statistics) to SimDB.
-             * 
-             * \return Returns the database ID of the report descriptor in the 
-             * ReportDescriptors table. Returns 0 if:
-             *    - SIMDB_ENABLED is false
-             *    - this descriptor is not enabled
-             *    - this descriptor has no reports
+             * \brief Get ready for SimDB report collection.
              */
-            int configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root);
+            bool configSimDbReports(app::ReportStatsCollector* collector);
 
             //! \brief Report descriptors may be triggered to stop early - ensure no
             //! further updates are written to disk

--- a/sparta/sparta/app/ReportDescriptor.hpp
+++ b/sparta/sparta/app/ReportDescriptor.hpp
@@ -529,6 +529,11 @@ namespace sparta {
             void clearDestinationFiles(const Simulation& sim);
 
             /*!
+             * \brief Called when the ReportRepository is shutting down.
+             */
+            void teardown();
+
+            /*!
              * \brief Returns the usage count (incremented by addInstantiation)
              */
             uint32_t getUsageCount() const { return instantiations_.size(); }

--- a/sparta/sparta/app/SimulationConfiguration.hpp
+++ b/sparta/sparta/app/SimulationConfiguration.hpp
@@ -494,34 +494,55 @@ public:
     class SimDBConfig
     {
     public:
-        void setSimDBFile(const std::string & filename) {
-            simdb_file_ = filename;
-        }
-
-        const std::string & getSimDBFile() const {
-            return simdb_file_;
-        }
-
-        void enableSimDBReports(const bool disable_legacy_reports = false) {
-            reports_enabled_ = true;
-            disable_legacy_reports_ = disable_legacy_reports;
-            if (simdb_file_.empty()) {
-                simdb_file_ = "sparta.db";
+        void disableLegacyReports()
+        {
+            if (!appEnabled("simdb-reports")) {
+                throw SpartaException()
+                    << "Cannot disable legacy reports when simdb-reports app is not enabled";
             }
+            legacy_reports_enabled_ = false;
         }
 
-        bool simDBReportsEnabled() const {
-            return reports_enabled_;
+        bool legacyReportsEnabled() const
+        {
+            return legacy_reports_enabled_;
         }
 
-        bool legacyReportsEnabled() const {
-            return !disable_legacy_reports_;
+        void enableApp(const std::string & app_name, const std::string & db_file)
+        {
+            enabled_apps_[db_file].insert(app_name);
+            app_db_files_[app_name] = db_file;
+        }
+
+        bool appEnabled(const std::string & app_name) const
+        {
+            return app_db_files_.count(app_name) > 0;
+        }
+
+        std::vector<std::string> getEnabledApps() const 
+        {
+            std::vector<std::string> apps;
+            for (const auto & kvp : app_db_files_) {
+                apps.push_back(kvp.first);
+            }
+            return apps;
+        }
+
+        std::string getAppDatabase(const std::string & app_name) const
+        {
+            auto it = app_db_files_.find(app_name);
+            if (it != app_db_files_.end()) {
+                return it->second;
+            } else {
+                return "";
+            }
         }
 
     private:
         std::string simdb_file_;
-        bool reports_enabled_ = false;
-        bool disable_legacy_reports_ = false;
+        std::map<std::string, std::set<std::string>> enabled_apps_;
+        std::map<std::string, std::string> app_db_files_;
+        bool legacy_reports_enabled_ = true;
     } simdb_config;
 
     /*!

--- a/sparta/sparta/app/simdb/ReportStatsCollector.hpp
+++ b/sparta/sparta/app/simdb/ReportStatsCollector.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "simdb/apps/UniformSerializer.hpp"
+#include "sparta/app/ReportDescriptor.hpp"
+
+namespace sparta {
+    class Scheduler;
+    class StatisticInstance;
+}
+
+namespace sparta::report::format {
+    class ReportHeader;
+}
+
+namespace sparta::app {
+
+/// This is a SimDB application that serializes all metadata about the
+/// report configuration(s), and collects data for report generation later
+/// on. A key feature of this app is that it allows for the simulation to
+/// run once, and then have multiple python classes handle the data in
+/// different ways (HDF5 converter, CSV exporter, display in a web page,
+/// etc).
+
+class ReportStatsCollector : public simdb::UniformSerializer
+{
+public:
+    static constexpr auto NAME = "simdb-reports";
+
+    ReportStatsCollector() = default;
+
+    void configPipeline(simdb::PipelineConfig& config) override;
+
+    void setScheduler(const Scheduler* scheduler);
+
+    void addDescriptor(const ReportDescriptor* desc);
+
+    int getDescriptorID(const ReportDescriptor* desc,
+                        bool must_exist = true) const;
+
+    void setHeader(const ReportDescriptor* desc,
+                   const report::format::ReportHeader& header);
+
+    void updateReportMetadata(const ReportDescriptor* desc,
+                              const std::string& key,
+                              const std::string& value);
+
+    void updateReportStartTime(const ReportDescriptor* desc);
+
+    void updateReportEndTime(const ReportDescriptor* desc);
+
+    void collect(const ReportDescriptor* desc);
+
+    void writeSkipAnnotation(const ReportDescriptor* desc,
+                             const std::string& annotation);
+
+private:
+    void extendSchema_(simdb::Schema&) override;
+
+    void postInit_(int argc, char** argv) override;
+
+    void postSim_() override;
+
+    void onPreTeardown_() override;
+
+    void onPostTeardown_() override;
+
+    std::string getByteLayoutYAML_() const override;
+
+    void writeReportInfo_(const ReportDescriptor* desc);
+
+    void writeReportInfo_(const ReportDescriptor* desc,
+                          const Report* r,
+                          std::unordered_set<std::string>& visited_stats,
+                          int parent_report_id);
+
+    class StageObserver : public simdb::PipelineStageObserver
+    {
+    public:
+        StageObserver(ReportStatsCollector* collector) : collector_(collector) {}
+        void onEnterStage(const simdb::PipelineEntry& entry, size_t stage_idx) override;
+        void onLeaveStage(const simdb::PipelineEntry& entry, size_t stage_idx) override;
+    private:
+        ReportStatsCollector* collector_;
+    };
+
+    void postCommit_(const simdb::PipelineEntry& entry);
+    friend class StageObserver;
+
+    using Descriptor = std::tuple<std::string, std::string, std::string, std::string>;
+    std::vector<std::pair<const ReportDescriptor*, Descriptor>> descriptors_;
+    std::unordered_map<const ReportDescriptor*, int> descriptor_ids_;
+    std::unordered_map<const ReportDescriptor*, const report::format::ReportHeader*> descriptor_headers_;
+    std::unordered_map<const ReportDescriptor*, std::vector<int>> descriptor_report_ids_;
+    std::unordered_map<const ReportDescriptor*, std::vector<int>> descriptor_report_style_ids_;
+    std::unordered_map<const ReportDescriptor*, std::vector<int>> descriptor_report_meta_ids_;
+    std::unordered_map<const ReportDescriptor*, std::vector<const StatisticInstance*>> simdb_stats_;
+    std::unordered_map<const ReportDescriptor*, uint64_t> report_start_times_;
+    std::unordered_map<const ReportDescriptor*, uint64_t> report_end_times_;
+    std::unordered_map<const ReportDescriptor*, std::map<std::string, std::string>> report_metadata_;
+    std::unordered_map<const ReportDescriptor*, std::vector<std::pair<uint64_t, std::string>>> report_skip_annotations_;
+    StageObserver stage_observer_{this};
+    const Scheduler* scheduler_ = nullptr;
+};
+
+} // namespace sparta::app

--- a/sparta/sparta/report/ReportRepository.hpp
+++ b/sparta/sparta/report/ReportRepository.hpp
@@ -46,6 +46,7 @@
 
 namespace sparta::app {
     class ReportDescriptor;
+    class ReportStatsCollector;
 } /* namespace sparta */
 
 namespace sparta::app {
@@ -83,7 +84,8 @@ public:
      * \return Handle to the newly created directory.
      */
     DirectoryHandle createDirectory(
-        const app::ReportDescriptor & desc);
+        const app::ReportDescriptor & desc,
+        app::ReportStatsCollector* collector = nullptr);
 
     /*!
      * \brief Add a report to the given directory.
@@ -108,8 +110,12 @@ public:
     void postBuildTree();
 
     /*!
-     * \brief Called on Simulation::finalizeFramework() after the reports
-     * have all been setup.
+     * \brief Called when the Simulation is setting up reports.
+     */
+    void configSimDbReports();
+
+    /*!
+     * \brief Called when the framework is finalized.
      */
     void postFinalizeFramework();
 

--- a/sparta/sparta/report/format/BaseFormatter.hpp
+++ b/sparta/sparta/report/format/BaseFormatter.hpp
@@ -273,12 +273,6 @@ public:
         return zero_si_values_omitted_;
     }
 
-    //! Write SimDB report metadata to the database.
-    void configSimDbReport(
-        simdb::DatabaseManager* db_mgr,
-        const int report_desc_id,
-        const int report_id);
-
     /*!
      * \brief Append the content of this report to some output. Has ios::app
      * semantics. Effectively equivalent to writeHeader() then update()
@@ -559,12 +553,6 @@ protected:
     bool zero_si_values_omitted_ = false;
 
 private:
-    //! Allow subclasses to add any formatter-specific metadata
-    //! to the SimDB report
-    virtual std::map<std::string, std::string> getExtraSimDbMetadata_() const {
-        return {};
-    }
-
     //! \brief Header variables that were written out, in the order
     //! they were written out
     mutable std::vector<std::string> written_header_lines_;

--- a/sparta/sparta/statistics/InstrumentationNode.hpp
+++ b/sparta/sparta/statistics/InstrumentationNode.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "sparta/simulation/TreeNode.hpp"
 #include "sparta/utils/SpartaException.hpp"
 #include "sparta/utils/SpartaAssert.hpp"
 #include "sparta/utils/Utils.hpp"

--- a/sparta/src/BaseFormatter.cpp
+++ b/sparta/src/BaseFormatter.cpp
@@ -30,10 +30,6 @@
 #include "sparta/report/format/StatsMapping.hpp"
 #include "sparta/report/format/BaseOstreamFormatter.hpp"
 
-#if SIMDB_ENABLED
-#include "simdb/sqlite/DatabaseManager.hpp"
-#endif
-
 namespace sparta {
     namespace report {
         namespace format {
@@ -185,43 +181,6 @@ bool BaseFormatter::isValidFormatName(const std::string& format)
         }
     }
     return false;
-}
-
-void BaseFormatter::configSimDbReport(
-    simdb::DatabaseManager* db_mgr,
-    const int report_desc_id,
-    const int report_id)
-{
-#if SIMDB_ENABLED
-    // Note that in order to keep the schema data types uniform,
-    // we write every bit of metadata as a string. The python
-    // export module will convert the data types to the correct
-    // types when it writes formatted reports after simulation.
-    auto meta_kv_pairs = metadata_kv_pairs_;
-
-    const std::string pretty_print = pretty_print_enabled_ ? "true" : "false";
-    meta_kv_pairs["PrettyPrint"] = pretty_print;
-
-    const std::string omit_zero = zero_si_values_omitted_ ? "true" : "false";
-    meta_kv_pairs["OmitZeros"] = omit_zero;
-
-    // Add any formatter-specific metadata
-    auto extra_meta_kv_pairs = getExtraSimDbMetadata_();
-    for (const auto& pair : extra_meta_kv_pairs) {
-        meta_kv_pairs[pair.first] = pair.second;
-    }
-
-    for (const auto& pair : meta_kv_pairs) {
-        db_mgr->INSERT(
-            SQL_TABLE("ReportMetadata"),
-            SQL_COLUMNS("ReportDescID", "ReportID", "MetaName", "MetaValue"),
-            SQL_VALUES(report_desc_id, report_id, pair.first, pair.second));
-    }
-#else
-    (void) db_mgr;
-    (void) report_desc_id;
-    (void) report_id;
-#endif
 }
 
 } // namespace format

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -133,7 +133,7 @@ void showSimDBHelp()
 #if SIMDB_ENABLED
     std::cout << "TODO: SimDB Help" << std::endl;
 #else
-    std::cout << "SimDB is not enabled in this build (-DUSING_SIMDB=ON)" << std::endl;
+     std::cout << "SimDB is not enabled in this build (-DUSING_SIMDB=ON)" << std::endl;
 #endif
 }
 
@@ -619,15 +619,19 @@ CommandLineSimulator::CommandLineSimulator(const std::string& usage,
     // Simulation Database Options
     #if SIMDB_ENABLED
     simdb_opts_.add_options()
-        ("simdb-file",
-         named_value<std::vector<std::string>>("FILENAME", 1, 1),
-         "Specify a simulation database file to hold reports and other sim artifacts. Use together with "
-         "--enable-simdb-* options to selectively add artifacts to the database.")
+        ("simdb-apps",
+         named_value<std::vector<std::string>>("filename.db app1 app2 ...", 2, -1)->multitoken(),
+         "Instantiate and run the provided SimDB applications and associate them with the "
+         "simulation database file SIMDB_FILE. You can use this option multiple times to "
+         "create apps going to different databases.")
         ("enable-simdb-reports",
-         "Enable the simulation database to hold reports.")
+         named_value<std::vector<std::string>>("[DATABASE_FILE]", 0, 1),
+         "Enable the simulation database to hold reports. If no database file is specified, "
+         "it will default to sparta.db")
         ("disable-legacy-reports",
          "Do not produce legacy formatted reports on the filesystem. Only write the SimDB file. "
-         "This is to be used with --enable-simdb-reports.");
+         "This is to be used with --enable-simdb-reports.")
+        ;
     #endif
 
     // Feature Options
@@ -1126,11 +1130,19 @@ bool CommandLineSimulator::parse(int argc,
             }else if (o.string_key == "report-update-icount") {
                 throw_report_deprecated = true;
                 ++i;
-            }else if (o.string_key == "simdb-file") {
-                const auto& simdb_file = o.value[0];
-                sim_config_.simdb_config.setSimDBFile(simdb_file);
+            }else if (o.string_key == "simdb-apps") {
+                const auto simdb_file = o.value.at(0);
+                for (size_t idx = 1; idx < o.value.size(); ++idx) {
+                    sim_config_.simdb_config.enableApp(o.value.at(idx), simdb_file);
+                }
                 opts.options.erase(opts.options.begin() + i);
-
+            }else if (o.string_key == "enable-simdb-reports") {
+                std::string simdb_file = "sparta.db";
+                if (o.value.size() > 0) {
+                    simdb_file = o.value.at(0);
+                }
+                sim_config_.simdb_config.enableApp("simdb-reports", simdb_file);
+                opts.options.erase(opts.options.begin() + i);
             }else if (o.string_key == "pipeline-collection") {
                 //Enforce that we cannot set pipeline-collection options twice.
                 if(collection_parsed)
@@ -1540,8 +1552,12 @@ bool CommandLineSimulator::parse(int argc,
             std::cout << report_opts_.getOptionsLevelUpTo(0) << std::endl;
             showReportsHelp();
         }else if(help_topic_ == "simdb"){
-            std::cout << simdb_opts_.getOptionsLevelUpTo(0) << std::endl;
-            showSimDBHelp();
+            #if SIMDB_ENABLED
+                std::cout << simdb_opts_.getOptionsLevelUpTo(0) << std::endl;
+                showSimDBHelp();
+            #else
+                std::cout << "SimDB is not enabled in this build of SPARTA (-DUSING_SIMDB=ON)." << std::endl;
+            #endif
         }else if(help_topic_ == "pipeout"){
             std::cout << pipeout_opts_.getOptionsLevelUpTo(0) << std::endl;
         }else{
@@ -1801,16 +1817,8 @@ bool CommandLineSimulator::parse(int argc,
     sim_config_.report_on_error         = vm_.count("report-on-error") > 0;
     sim_config_.reports                 = reports;
 
-    // The various --enable-simdb-* options will implicitly set the database file to sparta.db
-    // unless otherwise specified with --simdb-file (which has already been parsed above).
-    if (vm_.count("enable-simdb-reports") > 0) {
-        const bool disable_legacy_reports = vm_.count("disable-legacy-reports") > 0;
-        sim_config_.simdb_config.enableSimDBReports(disable_legacy_reports);
-    } else if (vm_.count("disable-legacy-reports") > 0) {
-        std::cerr << "Error: --disable-legacy-reports requires --enable-simdb-reports" << std::endl;
-        printUsageHelp_();
-        err_code = 1;
-        return false;
+    if (vm_.count("disable-legacy-reports") > 0) {
+        sim_config_.simdb_config.disableLegacyReports();
     }
 
     //pevents

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -329,28 +329,6 @@ report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,
 
 ReportDescriptor::~ReportDescriptor()
 {
-    try {
-        if (!idle_reports_.empty()) {
-            std::vector<inst_t> to_flush;
-            for (auto & inst : instantiations_) {
-                if (idle_reports_.find(inst.first) != idle_reports_.end()) {
-                    to_flush.push_back(inst);
-                }
-            }
-
-            instantiations_.swap(to_flush);
-            triggered_reports_.clear();
-
-            this->updateOutput(nullptr);
-            this->writeOutput(nullptr);
-        }
-
-        if (!legacy_reports_enabled_) {
-            std::filesystem::remove(dest_file);
-        }
-    } catch (...) {
-        //destructors should never throw
-    }
 }
 
 bool ReportDescriptor::updateReportActiveState_(const Report * r)
@@ -527,6 +505,28 @@ void ReportDescriptor::clearDestinationFiles(const Simulation& sim)
             }
         }
         ++idx;
+    }
+}
+
+void ReportDescriptor::teardown()
+{
+    if (!idle_reports_.empty()) {
+        std::vector<inst_t> to_flush;
+        for (auto & inst : instantiations_) {
+            if (idle_reports_.find(inst.first) != idle_reports_.end()) {
+                to_flush.push_back(inst);
+            }
+        }
+
+        instantiations_.swap(to_flush);
+        triggered_reports_.clear();
+
+        this->updateOutput(nullptr);
+        this->writeOutput(nullptr);
+    }
+
+    if (!legacy_reports_enabled_) {
+        std::filesystem::remove(dest_file);
     }
 }
 

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -40,9 +40,10 @@
 #include "sparta/app/SimulationConfiguration.hpp"
 #include "sparta/report/format/BaseFormatter.hpp"
 #include "sparta/trigger/ExpressionTrigger.hpp"
+#include "simdb/sqlite/DatabaseManager.hpp"
 
 #if SIMDB_ENABLED
-#include "simdb/sqlite/DatabaseManager.hpp"
+#include "sparta/app/simdb/ReportStatsCollector.hpp"
 #endif
 
 namespace YAML {
@@ -186,206 +187,48 @@ std::shared_ptr<statistics::StreamNode> ReportDescriptor::createRootStatisticsSt
     return nullptr;
 }
 
-int ReportDescriptor::configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root)
+bool ReportDescriptor::configSimDbReports(app::ReportStatsCollector* collector)
 {
 #if SIMDB_ENABLED
     if (!isEnabled()) {
-        return 0;
+        return false;
     }
 
     const std::vector<Report*> reports = getAllInstantiations();
     if (reports.empty()) {
-        return 0;
+        return false;
     }
 
-    db_mgr_ = db_mgr;
-    scheduler_ = root->getClock()->getScheduler();
-
-    const auto rd_record = db_mgr_->INSERT(
-        SQL_TABLE("ReportDescriptors"),
-        SQL_COLUMNS("LocPattern", "DefFile", "DestFile", "Format"),
-        SQL_VALUES(loc_pattern, def_file, dest_file, format));
-
-    simdb_descriptor_id_ = rd_record->getId();
-
-    for (const auto& kvp : header_metadata_) {
-        const auto& meta_name = kvp.first;
-        const auto& meta_value = kvp.second;
-        db_mgr_->INSERT(
-            SQL_TABLE("ReportDescriptorMeta"),
-            SQL_COLUMNS("ReportDescID", "MetaName", "MetaValue"),
-            SQL_VALUES(simdb_descriptor_id_, meta_name, meta_value));
+    if (!collector) {
+        return false;
     }
 
-    std::unordered_set<std::string> visited_stats;
-    for (const auto r : reports) {
-        configSimDbReport_(r, visited_stats, simdb_descriptor_id_);
-    }
-
-    return simdb_descriptor_id_;
+    collector_ = collector;
+    collector_->addDescriptor(this);
+    return true;
 #else
-    (void) db_mgr;
-    (void) root;
-    return 0;
-#endif
-}
-
-void ReportDescriptor::configSimDbReport_(
-    const Report* r,
-    std::unordered_set<std::string> & visited_stats,
-    const int report_desc_id,
-    const int parent_report_id)
-{
-#if SIMDB_ENABLED
-    const auto report_name = r->getName();
-    const auto report_start_tick = r->getStart();
-    const auto report_end_tick = r->getEnd();
-    const auto report_info = r->getInfoString();
-
-    const auto report_record = db_mgr_->INSERT(
-        SQL_TABLE("Reports"),
-        SQL_COLUMNS("ReportDescID", "ParentReportID", "Name", "StartTick", "EndTick", "InfoString"),
-        SQL_VALUES(report_desc_id, parent_report_id, report_name, report_start_tick, report_end_tick, report_info));
-
-    const auto report_id = report_record->getId();
-
-    for (const auto& kvp : r->getAllStyles()) {
-        db_mgr_->INSERT(
-            SQL_TABLE("ReportStyles"),
-            SQL_COLUMNS("ReportDescID", "ReportID", "StyleName", "StyleValue"),
-            SQL_VALUES(report_desc_id, report_id, kvp.first, kvp.second));
-    }
-
-    auto collection_mgr = db_mgr_->getCollectionMgr();
-    const auto& stats = r->getStatistics();
-    for (const auto& si : stats) {
-        const auto& si_name = si.first;
-        const auto si_loc = si.second->getLocation();
-        const auto si_desc = si.second->getDesc(false);
-        const auto si_vis = static_cast<int>(si.second->getVisibility());
-        const auto si_class = static_cast<int>(si.second->getClass());
-
-        if (!visited_stats.insert(si_loc).second) {
-            continue;
-        }
-
-        auto si_record = db_mgr_->INSERT(
-            SQL_TABLE("StatisticInsts"),
-            SQL_COLUMNS("ReportID", "StatisticName", "StatisticLoc", "StatisticDesc", "StatisticVis", "StatisticClass"),
-            SQL_VALUES(report_id, si_name, si_loc, si_desc, si_vis, si_class));
-
-        if (auto stat_def = si.second->getStatisticDef()) {
-            const auto si_id = si_record->getId();
-            for (const auto& pair : stat_def->getMetadata()) {
-                const auto& meta_name = pair.first;
-                const auto& meta_value = pair.second;
-
-                db_mgr_->INSERT(
-                    SQL_TABLE("StatisticDefnMetadata"),
-                    SQL_COLUMNS("StatisticInstID", "MetaName", "MetaValue"),
-                    SQL_VALUES(si_id, meta_name, meta_value));
-            }
-        }
-
-        std::shared_ptr<simdb::CollectionPoint> collectable =
-            collection_mgr->createCollectable<double>(si_loc, "root");
-
-        // To save disk space, we do not need to serialize the element IDs with every
-        // collected data point. Other formats may still need this information, and
-        // we are less concerned with disk space for final-value-only reports like JSON.
-        if (format == "csv" || format == "csv_cumulative") {
-            collectable->doNotWriteElemId();
-        }
-
-        collected_stat_t collected_stat(si.second.get(), collectable);
-        simdb_stats_.push_back(collected_stat);
-    }
-
-    for (const auto& pair : instantiations_) {
-        if (pair.first == r) {
-            const auto formatter = pair.second;
-            formatter->configSimDbReport(
-                db_mgr_,
-                report_desc_id,
-                report_id);
-
-            break;
-        }
-    }
-
-    for (const auto& sr : r->getSubreports()) {
-        configSimDbReport_(&sr, visited_stats, report_desc_id, report_id);
-    }
-#else
-    (void) r;
-    (void) visited_stats;
-    (void) report_desc_id;
-    (void) parent_report_id;
+    (void)collector;
+    return false;
 #endif
 }
 
 void ReportDescriptor::sweepSimDbStats_()
 {
 #if SIMDB_ENABLED
-    if (db_mgr_ == nullptr) {
-        return;
-    }
-
-    for (const auto& collected_stat : simdb_stats_) {
-        const auto si = collected_stat.first;
-        const auto& collectable = collected_stat.second;
-
-        // Note that the "once" flag is set to true so that when we
-        // tell the collector to "sweep" all these values, they are
-        // automatically removed from the collector's "black box".
-        const double value = si->getValue();
-        constexpr bool once = true;
-        collectable->activate(value, once);
-    }
-
-    const auto tick = scheduler_->getCurrentTick();
-    simdb::DatabaseEntryCallback post_process_cb = ReportDescriptor::postProcessRecord_;
-    db_mgr_->getCollectionMgr()->sweep("root", tick, post_process_cb, this);
+    collector_->collect(this);
 #endif
 }
 
 void ReportDescriptor::skipSimDbStats_()
 {
 #if SIMDB_ENABLED
-    if (db_mgr_ == nullptr || skipped_annotator_ == nullptr) {
+    if (collector_ == nullptr || skipped_annotator_ == nullptr) {
         return;
     }
 
     const std::string annotation = skipped_annotator_->currentAnnotation();
-    const auto tick = scheduler_->getCurrentTick();
-
-    // This method is called on the main thread, and we do not want to do
-    // any database writes which will severely impact performance. SimDB
-    // provides the queueWork() method to invoke arbitrary code on the
-    // database thread to get around this.
-    //
-    // Doing the work on the database thread is much faster primarily
-    // due to the fact that SimDB will perform batch processing on all
-    // pending work in a single BEGIN/COMMIT transaction. This occurs
-    // periodically on a 100ms timer in the background.
-    auto work = [=](simdb::DatabaseManager* db_mgr) {
-        db_mgr->INSERT(
-            SQL_TABLE("CsvSkipAnnotations"),
-            SQL_COLUMNS("ReportDescID", "Tick", "Annotation"),
-            SQL_VALUES(simdb_descriptor_id_, tick, annotation));
-    };
-
-    db_mgr_->getCollectionMgr()->queueWork(work);
-
+    collector_->writeSkipAnnotation(this, annotation);
 #endif
-}
-
-void ReportDescriptor::postProcessRecordImpl_(const int datablob_db_id, const uint64_t tick)
-{
-    db_mgr_->INSERT(
-        SQL_TABLE("DescriptorRecords"),
-        SQL_COLUMNS("ReportDescID", "DatablobID", "Tick"),
-        SQL_VALUES(simdb_descriptor_id_, datablob_db_id, tick));
 }
 
 report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,
@@ -479,6 +322,7 @@ report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,
     if(formatter->supportsUpdate()){
         //TODO: Deprecate "during simulation" formatters
         formatter->writeHeader();
+        //TODO cnyce: need to capture the report range right now and "fix" it in the collector
     }
 
     return formatter;
@@ -540,7 +384,7 @@ uint32_t ReportDescriptor::writeOutput(std::ostream* out)
             if (legacy_reports_enabled_) {
                 inst.second->write();
             }
-            if (db_mgr_) {
+            if (collector_) {
                 sweepSimDbStats_();
             }
             num_saved++;
@@ -596,7 +440,7 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
                     }
                     inst.first->start();
                     capture_update_values = false;
-                    if (db_mgr_) {
+                    if (collector_) {
                         skipSimDbStats_();
                     }
                 }
@@ -607,7 +451,7 @@ uint32_t ReportDescriptor::updateOutput(std::ostream* out)
                 if (legacy_reports_enabled_) {
                     inst.second->update();
                 }
-                if (db_mgr_) {
+                if (collector_) {
                     sweepSimDbStats_();
                 }
             }

--- a/sparta/src/ReportDescriptor.cpp
+++ b/sparta/src/ReportDescriptor.cpp
@@ -322,7 +322,6 @@ report::format::BaseFormatter* ReportDescriptor::addInstantiation(Report* r,
     if(formatter->supportsUpdate()){
         //TODO: Deprecate "during simulation" formatters
         formatter->writeHeader();
-        //TODO cnyce: need to capture the report range right now and "fix" it in the collector
     }
 
     return formatter;

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -165,6 +165,7 @@ public:
 
         num_written += desc_.updateOutput();
         num_written += desc_.writeOutput();
+        desc_.teardown();
 
     #if SIMDB_ENABLED
         if (collector_ && desc_.format != "csv" && desc_.format != "csv_cumulative") {

--- a/sparta/src/ReportRepository.cpp
+++ b/sparta/src/ReportRepository.cpp
@@ -45,7 +45,8 @@
 #include "sparta/utils/ValidValue.hpp"
 
 #if SIMDB_ENABLED
-#include "simdb/sqlite/DatabaseManager.hpp"
+#include "sparta/app/simdb/ReportStatsCollector.hpp"
+#include "simdb/apps/AppManager.hpp"
 #endif
 
 namespace sparta::report::format {
@@ -68,8 +69,9 @@ namespace sparta {
 class Directory
 {
 public:
-    Directory(const app::ReportDescriptor & desc) :
-        desc_(desc)
+    Directory(const app::ReportDescriptor & desc, app::ReportStatsCollector* collector)
+        : desc_(desc)
+        , collector_(collector)
     {
         sparta_assert(desc_.getUsageCount() == 0);
         sparta_assert(!desc_.def_file.empty());
@@ -116,33 +118,15 @@ public:
      * \brief Write all metadata about our report (and its subreports
      * and statistics) to SimDB.
      */
-    void configSimDbReports(simdb::DatabaseManager* db_mgr, RootTreeNode* root)
+    void configSimDbReports()
     {
     #if SIMDB_ENABLED
-        db_mgr_ = db_mgr;
-        desc_simdb_id_ = desc_.configSimDbReports(db_mgr, root);
-
-        if (desc_simdb_id_ == 0) {
+        if (!desc_.configSimDbReports(collector_)) {
             return;
         }
 
         const auto& header = reports_[0]->getHeader();
-        const auto start_counter_loc = header.getStringified("start_counter");
-        const auto stop_counter_loc = header.getStringified("stop_counter");
-        const auto update_counter_loc = header.getStringified("update_counter");
-
-        std::ostringstream cmd;
-        cmd << "UPDATE Reports SET "
-            << "StartCounter = '" << start_counter_loc << "', "
-            << "StopCounter = '" << stop_counter_loc << "', "
-            << "UpdateCounter = '" << update_counter_loc << "'"
-            << " WHERE ReportDescID = " << desc_simdb_id_
-            << " AND ParentReportID = 0";
-
-        db_mgr_->EXECUTE(cmd.str());
-    #else
-        (void) db_mgr;
-        (void) root;
+        collector_->setHeader(&desc_, header);
     #endif
     }
 
@@ -155,6 +139,7 @@ public:
     {
         sim_ = sim;
         this->consumeDescriptorExtensions_(context);
+        this->configSimDbReports();
         return true;
     }
 
@@ -180,6 +165,12 @@ public:
 
         num_written += desc_.updateOutput();
         num_written += desc_.writeOutput();
+
+    #if SIMDB_ENABLED
+        if (collector_ && desc_.format != "csv" && desc_.format != "csv_cumulative") {
+            collector_->updateReportEndTime(&desc_);
+        }
+    #endif
 
         bool print = true;
         if (sim_) {
@@ -553,19 +544,13 @@ private:
             }
         }
 
-    #if SIMDB_ENABLED
-        if (first && db_mgr_ != nullptr && desc_simdb_id_ != 0) {
-            // Note that all of our reports (and their subreports) have
-            // the same start tick.
-            std::ostringstream cmd;
-            cmd << "UPDATE Reports SET StartTick = "
-                << reports_[0]->getStart()
-                << " WHERE ReportDescID = " << desc_simdb_id_
-                << " AND ParentReportID = 0";
-
-            db_mgr_->EXECUTE(cmd.str());
-        }
-    #endif
+        #if SIMDB_ENABLED
+            if (first && collector_) {
+                collector_->updateReportStartTime(&desc_);
+            }
+        #else
+            (void)first;
+        #endif
     }
 
     void stopReports_()
@@ -590,16 +575,8 @@ private:
         desc_.ignoreFurtherUpdates();
 
         #if SIMDB_ENABLED
-            if (db_mgr_ != nullptr && desc_simdb_id_ != 0) {
-                if (reports_[0]->getEnd() != Scheduler::INDEFINITE) {
-                    std::ostringstream cmd;
-                    cmd << "UPDATE Reports SET EndTick = "
-                        << reports_[0]->getEnd()
-                        << " WHERE ReportDescID = " << desc_simdb_id_
-                        << " AND ParentReportID = 0";
-
-                    db_mgr_->EXECUTE(cmd.str());
-                }
+            if (collector_ && desc_.format != "csv" && desc_.format != "csv_cumulative") {
+                collector_->updateReportEndTime(&desc_);
             }
         #endif
     }
@@ -813,19 +790,12 @@ private:
     void updateSimDbReportMeta_(const std::string & key,
                                 const std::string & value)
     {
-    #if SIMDB_ENABLED
-        if (key.empty() || value.empty()) {
+        if (key.empty() || value.empty() || !collector_) {
             return;
         }
 
-        if (db_mgr_ != nullptr && desc_simdb_id_ != 0) {
-            std::ostringstream cmd;
-            cmd << "UPDATE Reports SET " << key << " = '" << value
-                << "' WHERE ReportDescID = " << desc_simdb_id_
-                << " AND ParentReportID = 0";
-
-            db_mgr_->EXECUTE(cmd.str());
-        }
+    #if SIMDB_ENABLED
+        collector_->updateReportMetadata(&desc_, key, value);
     #endif
     }
 
@@ -986,9 +956,7 @@ private:
     TreeNode * device_tree_location_ = nullptr;
     app::Simulation * sim_ = nullptr;
     std::shared_ptr<SubContainer> sub_container_;
-
-    simdb::DatabaseManager * db_mgr_ = nullptr;
-    int desc_simdb_id_ = 0;
+    app::ReportStatsCollector* collector_ = nullptr;
 };
 
 std::map<std::string, Directory*> Directory::referenced_directories_;
@@ -1010,9 +978,10 @@ public:
     }
 
     ReportRepository::DirectoryHandle createDirectory(
-        const app::ReportDescriptor & desc)
+        const app::ReportDescriptor & desc,
+        app::ReportStatsCollector* collector)
     {
-        std::unique_ptr<Directory> direc(new Directory(desc));
+        std::unique_ptr<Directory> direc(new Directory(desc, collector));
 
         direc->setReportSubContainer(sub_container_);
         ReportRepository::DirectoryHandle handle = direc.get();
@@ -1063,7 +1032,6 @@ public:
 
     void postFinalizeFramework()
     {
-    #if SIMDB_ENABLED
         bool any_enabled = false;
         for (auto& kvp : directories_) {
             auto& report_desc = kvp.second->getDescriptor();
@@ -1078,11 +1046,12 @@ public:
         }
 
         const auto& simdb_config = sim_->getSimulationConfiguration()->simdb_config;
-        if (simdb_config.simDBReportsEnabled()) {
+        const auto apps = simdb_config.getEnabledApps();
+        const bool simdb_enabled = std::find(apps.begin(), apps.end(), "simdb-reports") != apps.end();
+        if (simdb_enabled) {
             // Not all report formats are supported by SimDB exporters. Until
-            // all are supported, we should not allow --enable-simdb-reports
-            // if we will not be able to export all of this simulation's
-            // reports.
+            // all are supported, we should not allow this app to run if we
+            // will not be able to export all of this simulation's reports.
             std::set<std::string> unsupported_dest_files;
             for (auto& kvp : directories_) {
                 auto& report_desc = kvp.second->getDescriptor();
@@ -1119,170 +1088,7 @@ public:
                     }
                 }
             }
-
-            simdb::Schema schema;
-            using dt = simdb::SqlDataType;
-
-            auto& report_desc_tbl = schema.addTable("ReportDescriptors");
-            report_desc_tbl.addColumn("LocPattern", dt::string_t);
-            report_desc_tbl.addColumn("DefFile", dt::string_t);
-            report_desc_tbl.addColumn("DestFile", dt::string_t);
-            report_desc_tbl.addColumn("Format", dt::string_t);
-
-            auto& run_meta_tbl = schema.addTable("ReportDescriptorMeta");
-            run_meta_tbl.addColumn("ReportDescID", dt::int32_t);
-            run_meta_tbl.addColumn("MetaName", dt::string_t);
-            run_meta_tbl.addColumn("MetaValue", dt::string_t);
-
-            auto& report_tbl = schema.addTable("Reports");
-            report_tbl.addColumn("ReportDescID", dt::int32_t);
-            report_tbl.addColumn("ParentReportID", dt::int32_t);
-            report_tbl.addColumn("Name", dt::string_t);
-            report_tbl.addColumn("StartTick", dt::int64_t);
-            report_tbl.addColumn("EndTick", dt::int64_t);
-            report_tbl.addColumn("InfoString", dt::string_t);
-            report_tbl.addColumn("StartCounter", dt::string_t);
-            report_tbl.addColumn("StopCounter", dt::string_t);
-            report_tbl.addColumn("UpdateCounter", dt::string_t);
-            report_tbl.setColumnDefaultValue("StartCounter", std::string());
-            report_tbl.setColumnDefaultValue("StopCounter", std::string());
-            report_tbl.setColumnDefaultValue("UpdateCounter", std::string());
-
-            auto& report_meta_tbl = schema.addTable("ReportMetadata");
-            report_meta_tbl.addColumn("ReportDescID", dt::int32_t);
-            report_meta_tbl.addColumn("ReportID", dt::int32_t);
-            report_meta_tbl.addColumn("MetaName", dt::string_t);
-            report_meta_tbl.addColumn("MetaValue", dt::string_t);
-            report_meta_tbl.disableAutoIncPrimaryKey();
-
-            auto& report_styles_tbl = schema.addTable("ReportStyles");
-            report_styles_tbl.addColumn("ReportDescID", dt::int32_t);
-            report_styles_tbl.addColumn("ReportID", dt::int32_t);
-            report_styles_tbl.addColumn("StyleName", dt::string_t);
-            report_styles_tbl.addColumn("StyleValue", dt::string_t);
-            report_styles_tbl.createCompoundIndexOn(SQL_COLUMNS("ReportDescID", "ReportID", "StyleName"));
-            report_styles_tbl.disableAutoIncPrimaryKey();
-
-            auto& stat_insts_tbl = schema.addTable("StatisticInsts");
-            stat_insts_tbl.addColumn("ReportID", dt::int32_t);
-            stat_insts_tbl.addColumn("StatisticName", dt::string_t);
-            stat_insts_tbl.addColumn("StatisticLoc", dt::string_t);
-            stat_insts_tbl.addColumn("StatisticDesc", dt::string_t);
-            stat_insts_tbl.addColumn("StatisticVis", dt::int32_t);
-            stat_insts_tbl.addColumn("StatisticClass", dt::int32_t);
-            stat_insts_tbl.createIndexOn("ReportID");
-
-            auto& stat_defn_meta_tbl = schema.addTable("StatisticDefnMetadata");
-            stat_defn_meta_tbl.addColumn("StatisticInstID", dt::int32_t);
-            stat_defn_meta_tbl.addColumn("MetaName", dt::string_t);
-            stat_defn_meta_tbl.addColumn("MetaValue", dt::string_t);
-            stat_defn_meta_tbl.createIndexOn("StatisticInstID");
-            stat_defn_meta_tbl.disableAutoIncPrimaryKey();
-
-            auto& siminfo_tbl = schema.addTable("SimulationInfo");
-            siminfo_tbl.addColumn("SimName", dt::string_t);
-            siminfo_tbl.addColumn("SimVersion", dt::string_t);
-            siminfo_tbl.addColumn("SpartaVersion", dt::string_t);
-            siminfo_tbl.addColumn("ReproInfo", dt::string_t);
-            siminfo_tbl.addColumn("SimEndTick", dt::int64_t);
-            siminfo_tbl.setColumnDefaultValue("SimEndTick", -1);
-            siminfo_tbl.disableAutoIncPrimaryKey();
-
-            auto& siminfo_header_pairs_tbl = schema.addTable("SimulationInfoHeaderPairs");
-            siminfo_header_pairs_tbl.addColumn("HeaderName", dt::string_t);
-            siminfo_header_pairs_tbl.addColumn("HeaderValue", dt::string_t);
-            siminfo_header_pairs_tbl.disableAutoIncPrimaryKey();
-
-            auto& vis_tbl = schema.addTable("Visibilities");
-            vis_tbl.addColumn("Hidden", dt::int32_t);
-            vis_tbl.addColumn("Support", dt::int32_t);
-            vis_tbl.addColumn("Detail", dt::int32_t);
-            vis_tbl.addColumn("Normal", dt::int32_t);
-            vis_tbl.addColumn("Summary", dt::int32_t);
-            vis_tbl.addColumn("Critical", dt::int32_t);
-            vis_tbl.disableAutoIncPrimaryKey();
-
-            auto& js_json_leaf_nodes = schema.addTable("JsJsonLeafNodes");
-            js_json_leaf_nodes.addColumn("ReportName", dt::string_t);
-            js_json_leaf_nodes.addColumn("IsParentOfLeafNodes", dt::int32_t);
-            js_json_leaf_nodes.setColumnDefaultValue("IsParentOfLeafNodes", -1);
-            js_json_leaf_nodes.disableAutoIncPrimaryKey();
-
-            // In the case of multiple reports, we will end up with more than
-            // one CollectionRecords rows with the same Tick value. We use this
-            // table in the python exporter to determine which records belong
-            // to which report.
-            auto& desc_records_tbl = schema.addTable("DescriptorRecords");
-            desc_records_tbl.addColumn("ReportDescID", dt::int32_t);
-            desc_records_tbl.addColumn("DatablobID", dt::int32_t);
-            desc_records_tbl.addColumn("Tick", dt::int64_t);
-            desc_records_tbl.createIndexOn("ReportDescID");
-
-            // For timeseries reports that use toggle triggers, we need to
-            // annotate the .csv files with a special annotation which tells
-            // the user how many ticks/cycles/picoseconds were skipped while
-            // the report/trigger was inactive.
-            auto& csv_skip_annotations_tbl = schema.addTable("CsvSkipAnnotations");
-            csv_skip_annotations_tbl.addColumn("ReportDescID", dt::int32_t);
-            csv_skip_annotations_tbl.addColumn("Tick", dt::int64_t);
-            csv_skip_annotations_tbl.addColumn("Annotation", dt::string_t);
-            csv_skip_annotations_tbl.createIndexOn("ReportDescID");
-
-            const auto& simdb_file = simdb_config.getSimDBFile();
-            db_mgr_ = std::make_unique<simdb::DatabaseManager>(simdb_file, true);
-            db_mgr_->createDatabaseFromSchema(schema);
-
-            // Use a heartbeat of 1 so that SimDB does not try to optimize the
-            // database size by using a pseudo-RLE algo to compress the stats. This
-            // makes the python exporter faster and simpler.
-            //
-            // Note that the database records are still compressed, so the .db
-            // size should not be an issue (still a lot smaller than the legacy
-            // formatted reports).
-            constexpr auto heartbeat = 1;
-            db_mgr_->enableCollection(heartbeat);
-            auto collection_mgr = db_mgr_->getCollectionMgr();
-
-            // Since a single report can have StatisticInstance's from different
-            // clock domains, we will just tell the collector that all stats are
-            // on the "root" clock.
-            //
-            // Note that this doesn't have any real effect on the reports, and
-            // differentiating between clocks is more of a concern for Argos.
-            // We just happen to be reusing the SimDB collection system for
-            // StatisticInstance reports.
-            constexpr auto assumed_root_period = 1;
-            collection_mgr->addClock("root", assumed_root_period);
-
-            db_mgr_->safeTransaction([&]() {
-                db_mgr_->INSERT(
-                    SQL_TABLE("SimulationInfo"),
-                    SQL_COLUMNS("SimName", "SimVersion", "SpartaVersion", "ReproInfo"),
-                    SQL_VALUES(SimulationInfo::getInstance().sim_name,
-                               SimulationInfo::getInstance().simulator_version,
-                               SimulationInfo::getInstance().getSpartaVersion(),
-                               SimulationInfo::getInstance().reproduction_info));
-
-                db_mgr_->INSERT(
-                    SQL_TABLE("Visibilities"),
-                    SQL_COLUMNS("Hidden", "Support", "Detail", "Normal", "Summary", "Critical"),
-                    SQL_VALUES(static_cast<int>(sparta::InstrumentationNode::VIS_HIDDEN),
-                               static_cast<int>(sparta::InstrumentationNode::VIS_SUPPORT),
-                               static_cast<int>(sparta::InstrumentationNode::VIS_DETAIL),
-                               static_cast<int>(sparta::InstrumentationNode::VIS_NORMAL),
-                               static_cast<int>(sparta::InstrumentationNode::VIS_SUMMARY),
-                               static_cast<int>(sparta::InstrumentationNode::VIS_CRITICAL)));
-
-                report::format::JavascriptObject::writeLeafNodeInfoToDB(db_mgr_.get());
-
-                for (auto& kvp : directories_) {
-                    kvp.second->configSimDbReports(db_mgr_.get(), sim_->getRoot());
-                }
-                db_mgr_->finalizeCollections();
-                return true;
-            });
         }
-    #endif // SIMDB_ENABLED
     }
 
     statistics::StatisticsArchives * getStatsArchives()
@@ -1373,39 +1179,6 @@ public:
                       << std::endl << std::endl;
         }
 
-    #if SIMDB_ENABLED
-        if (db_mgr_) {
-            db_mgr_->safeTransaction([&](){
-                for (const auto& kvp : SimulationInfo::getInstance().getHeaderPairs()) {
-                    db_mgr_->INSERT(
-                        SQL_TABLE("SimulationInfoHeaderPairs"),
-                        SQL_COLUMNS("HeaderName", "HeaderValue"),
-                        SQL_VALUES(kvp.first, kvp.second));
-                }
-
-                for (const auto& other : SimulationInfo::getInstance().other) {
-                    db_mgr_->INSERT(
-                        SQL_TABLE("SimulationInfoHeaderPairs"),
-                        SQL_COLUMNS("HeaderName", "HeaderValue"),
-                        SQL_VALUES("Other", other));
-                }
-
-                std::ostringstream oss;
-                oss << "UPDATE SimulationInfo SET SimEndTick = "
-                    << sim_->getScheduler()->getCurrentTick();
-
-                db_mgr_->EXECUTE(oss.str());
-                return true;
-            });
-
-            db_mgr_->postSim();
-            db_mgr_->closeDatabase();
-            db_mgr_.reset();
-        }
-    #endif // SIMDB_ENABLED
-
-        directories_.clear();
-
         // %%% ... if(sim_) { ... %%%
         //   This same method can get called again from our own
         //   destructor, *after* the Simulation has already been
@@ -1437,10 +1210,6 @@ private:
     std::shared_ptr<sparta::NotificationSource<std::string>> on_triggered_notifier_;
     std::unique_ptr<statistics::StatisticsArchives> stats_archives_;
     std::unique_ptr<statistics::StatisticsStreams> stats_streams_;
-
-    #if SIMDB_ENABLED
-    std::unique_ptr<simdb::DatabaseManager> db_mgr_;
-    #endif
 };
 
 ReportRepository::ReportRepository(app::Simulation * sim) :
@@ -1454,9 +1223,10 @@ ReportRepository::ReportRepository(TreeNode * context) :
 }
 
 ReportRepository::DirectoryHandle ReportRepository::createDirectory(
-    const app::ReportDescriptor & desc)
+    const app::ReportDescriptor & desc,
+    app::ReportStatsCollector* collector)
 {
-    return impl_->createDirectory(desc);
+    return impl_->createDirectory(desc, collector);
 }
 
 void ReportRepository::addReport(

--- a/sparta/src/ReportStatsCollector.cpp
+++ b/sparta/src/ReportStatsCollector.cpp
@@ -1,0 +1,513 @@
+#include "sparta/app/simdb/ReportStatsCollector.hpp"
+#include "simdb/apps/AppRegistration.hpp"
+#include "sparta/app/SimulationInfo.hpp"
+#include "sparta/statistics/InstrumentationNode.hpp"
+#include "sparta/statistics/StatisticInstance.hpp"
+#include "sparta/report/format/JavascriptObject.hpp"
+#include "sparta/report/format/ReportHeader.hpp"
+
+namespace sparta::app {
+
+REGISTER_SIMDB_APPLICATION(ReportStatsCollector);
+
+void ReportStatsCollector::configPipeline(simdb::PipelineConfig& config)
+{
+    config.asyncStage(1) >> CompressEntry;
+    config.asyncStage(2) >> CommitEntry;
+    config.asyncStage(2).observe(&stage_observer_);
+}
+
+void ReportStatsCollector::setScheduler(const Scheduler* scheduler)
+{
+    scheduler_ = scheduler;
+}
+
+void ReportStatsCollector::addDescriptor(const ReportDescriptor* desc)
+{
+    const auto& pattern = desc->loc_pattern;
+    const auto& def_file = desc->def_file;
+    const auto& dest_file = desc->dest_file;
+    const auto& format = desc->format;
+    descriptors_.emplace_back(desc, std::make_tuple(pattern, def_file, dest_file, format));
+
+    writeReportInfo_(desc);
+}
+
+int ReportStatsCollector::getDescriptorID(const ReportDescriptor* desc, bool must_exist) const
+{
+    auto it = descriptor_ids_.find(desc);
+    if (it != descriptor_ids_.end()) {
+        return it->second;
+    }
+
+    if (must_exist) {
+        throw SpartaException("ReportDescriptor not found");
+    }
+
+    return 0; // Invalid database ID
+}
+
+void ReportStatsCollector::setHeader(const ReportDescriptor* desc,
+                                     const report::format::ReportHeader& header)
+{
+    descriptor_headers_[desc] = &header;
+
+}
+
+void ReportStatsCollector::updateReportMetadata(
+    const ReportDescriptor* desc,
+    const std::string& key,
+    const std::string& value)
+{
+    report_metadata_[desc][key] = value;
+}
+
+void ReportStatsCollector::updateReportStartTime(const ReportDescriptor* desc)
+{
+    auto start_tick = desc->getAllInstantiations()[0]->getStart();
+    report_start_times_[desc] = start_tick;
+}
+
+void ReportStatsCollector::updateReportEndTime(const ReportDescriptor* desc)
+{
+    auto end_tick = desc->getAllInstantiations()[0]->getEnd();
+    if (end_tick == Scheduler::INDEFINITE) {
+        end_tick = scheduler_->getCurrentTick();
+    }
+    report_end_times_[desc] = end_tick;
+}
+
+void ReportStatsCollector::collect(const ReportDescriptor* desc)
+{
+    auto serializer = createVectorSerializer<double>();
+    for (const auto stat : simdb_stats_.at(desc)) {
+        serializer.push_back(stat->getValue());
+    }
+
+    simdb::PipelineEntry entry = prepareEntry(scheduler_->getCurrentTick(), std::move(serializer));
+    entry.setUserData(desc);
+    processEntry(std::move(entry));
+}
+
+void ReportStatsCollector::writeSkipAnnotation(
+    const ReportDescriptor* desc,
+    const std::string& annotation)
+{
+    auto tick = scheduler_->getCurrentTick();
+    report_skip_annotations_[desc].emplace_back(tick, annotation);
+}
+
+void ReportStatsCollector::extendSchema_(simdb::Schema& schema)
+{
+    using dt = simdb::SqlDataType;
+
+    auto& report_desc_tbl = schema.addTable("ReportDescriptors");
+    report_desc_tbl.addColumn("LocPattern", dt::string_t);
+    report_desc_tbl.addColumn("DefFile", dt::string_t);
+    report_desc_tbl.addColumn("DestFile", dt::string_t);
+    report_desc_tbl.addColumn("Format", dt::string_t);
+
+    auto& run_meta_tbl = schema.addTable("ReportDescriptorMeta");
+    run_meta_tbl.addColumn("ReportDescID", dt::int32_t);
+    run_meta_tbl.addColumn("MetaName", dt::string_t);
+    run_meta_tbl.addColumn("MetaValue", dt::string_t);
+
+    auto& report_tbl = schema.addTable("Reports");
+    report_tbl.addColumn("ReportDescID", dt::int32_t);
+    report_tbl.addColumn("ParentReportID", dt::int32_t);
+    report_tbl.addColumn("Name", dt::string_t);
+    report_tbl.addColumn("StartTick", dt::int64_t);
+    report_tbl.addColumn("EndTick", dt::int64_t);
+    report_tbl.addColumn("InfoString", dt::string_t);
+    report_tbl.addColumn("StartCounter", dt::string_t);
+    report_tbl.addColumn("StopCounter", dt::string_t);
+    report_tbl.addColumn("UpdateCounter", dt::string_t);
+    report_tbl.setColumnDefaultValue("StartCounter", std::string());
+    report_tbl.setColumnDefaultValue("StopCounter", std::string());
+    report_tbl.setColumnDefaultValue("UpdateCounter", std::string());
+
+    auto& report_meta_tbl = schema.addTable("ReportMetadata");
+    report_meta_tbl.addColumn("ReportDescID", dt::int32_t);
+    report_meta_tbl.addColumn("ReportID", dt::int32_t);
+    report_meta_tbl.addColumn("MetaName", dt::string_t);
+    report_meta_tbl.addColumn("MetaValue", dt::string_t);
+
+    auto& report_styles_tbl = schema.addTable("ReportStyles");
+    report_styles_tbl.addColumn("ReportDescID", dt::int32_t);
+    report_styles_tbl.addColumn("ReportID", dt::int32_t);
+    report_styles_tbl.addColumn("StyleName", dt::string_t);
+    report_styles_tbl.addColumn("StyleValue", dt::string_t);
+    report_styles_tbl.createCompoundIndexOn({"ReportDescID", "ReportID", "StyleName"});
+
+    auto& stat_insts_tbl = schema.addTable("StatisticInsts");
+    stat_insts_tbl.addColumn("ReportID", dt::int32_t);
+    stat_insts_tbl.addColumn("StatisticName", dt::string_t);
+    stat_insts_tbl.addColumn("StatisticLoc", dt::string_t);
+    stat_insts_tbl.addColumn("StatisticDesc", dt::string_t);
+    stat_insts_tbl.addColumn("StatisticVis", dt::int32_t);
+    stat_insts_tbl.addColumn("StatisticClass", dt::int32_t);
+    stat_insts_tbl.createIndexOn("ReportID");
+
+    auto& stat_defn_meta_tbl = schema.addTable("StatisticDefnMetadata");
+    stat_defn_meta_tbl.addColumn("StatisticInstID", dt::int32_t);
+    stat_defn_meta_tbl.addColumn("MetaName", dt::string_t);
+    stat_defn_meta_tbl.addColumn("MetaValue", dt::string_t);
+    stat_defn_meta_tbl.createIndexOn("StatisticInstID");
+    stat_defn_meta_tbl.disableAutoIncPrimaryKey();
+
+    auto& siminfo_tbl = schema.addTable("SimulationInfo");
+    siminfo_tbl.addColumn("SimName", dt::string_t);
+    siminfo_tbl.addColumn("SimVersion", dt::string_t);
+    siminfo_tbl.addColumn("SpartaVersion", dt::string_t);
+    siminfo_tbl.addColumn("ReproInfo", dt::string_t);
+    siminfo_tbl.addColumn("SimEndTick", dt::int64_t);
+    siminfo_tbl.setColumnDefaultValue("SimEndTick", -1);
+    siminfo_tbl.disableAutoIncPrimaryKey();
+
+    auto& siminfo_header_pairs_tbl = schema.addTable("SimulationInfoHeaderPairs");
+    siminfo_header_pairs_tbl.addColumn("HeaderName", dt::string_t);
+    siminfo_header_pairs_tbl.addColumn("HeaderValue", dt::string_t);
+    siminfo_header_pairs_tbl.disableAutoIncPrimaryKey();
+
+    auto& vis_tbl = schema.addTable("Visibilities");
+    vis_tbl.addColumn("Hidden", dt::int32_t);
+    vis_tbl.addColumn("Support", dt::int32_t);
+    vis_tbl.addColumn("Detail", dt::int32_t);
+    vis_tbl.addColumn("Normal", dt::int32_t);
+    vis_tbl.addColumn("Summary", dt::int32_t);
+    vis_tbl.addColumn("Critical", dt::int32_t);
+    vis_tbl.disableAutoIncPrimaryKey();
+
+    auto& js_json_leaf_nodes_tbl = schema.addTable("JsJsonLeafNodes");
+    js_json_leaf_nodes_tbl.addColumn("ReportName", dt::string_t);
+    js_json_leaf_nodes_tbl.addColumn("IsParentOfLeafNodes", dt::int32_t);
+    js_json_leaf_nodes_tbl.setColumnDefaultValue("IsParentOfLeafNodes", -1);
+    js_json_leaf_nodes_tbl.disableAutoIncPrimaryKey();
+
+    auto& elem_tree_nodes_tbl = schema.addTable("ElementTreeNodes");
+    elem_tree_nodes_tbl.addColumn("Name", dt::string_t);
+    elem_tree_nodes_tbl.addColumn("ParentID", dt::int32_t);
+
+    auto& collectable_tree_nodes_tbl = schema.addTable("CollectableTreeNodes");
+    collectable_tree_nodes_tbl.addColumn("ElementTreeNodeID", dt::int32_t);
+    collectable_tree_nodes_tbl.addColumn("ClockID", dt::int32_t);
+    collectable_tree_nodes_tbl.addColumn("DataType", dt::string_t);
+    collectable_tree_nodes_tbl.addColumn("Location", dt::string_t);
+    collectable_tree_nodes_tbl.addColumn("AutoCollected", dt::int32_t);
+    collectable_tree_nodes_tbl.setColumnDefaultValue("AutoCollected", 0);
+    collectable_tree_nodes_tbl.disableAutoIncPrimaryKey();
+
+    // In the case of multiple reports, we will end up with more than
+    // one CollectionRecords rows with the same Tick value. We use this
+    // table in the python exporter to determine which records belong
+    // to which report.
+    auto& desc_records_tbl = schema.addTable("DescriptorRecords");
+    desc_records_tbl.addColumn("ReportDescID", dt::int32_t);
+    desc_records_tbl.addColumn("DatablobID", dt::int32_t);
+    desc_records_tbl.addColumn("Tick", dt::int64_t);
+    desc_records_tbl.createIndexOn("ReportDescID");
+
+    // For timeseries reports that use toggle triggers, we need to
+    // annotate the .csv files with a special annotation which tells
+    // the user how many ticks/cycles/picoseconds were skipped while
+    // the report/trigger was inactive.
+    auto& csv_skip_annotations_tbl = schema.addTable("CsvSkipAnnotations");
+    csv_skip_annotations_tbl.addColumn("ReportDescID", dt::int32_t);
+    csv_skip_annotations_tbl.addColumn("Tick", dt::int64_t);
+    csv_skip_annotations_tbl.addColumn("Annotation", dt::string_t);
+    csv_skip_annotations_tbl.createIndexOn("ReportDescID");
+}
+
+void ReportStatsCollector::postInit_(int argc, char** argv)
+{
+    auto db_mgr = getDatabaseManager();
+
+    db_mgr->INSERT(
+        SQL_TABLE("SimulationInfo"),
+        SQL_COLUMNS("SimName", "SimVersion", "SpartaVersion", "ReproInfo"),
+        SQL_VALUES(SimulationInfo::getInstance().sim_name,
+                    SimulationInfo::getInstance().simulator_version,
+                    SimulationInfo::getInstance().getSpartaVersion(),
+                    SimulationInfo::getInstance().reproduction_info));
+
+    db_mgr->INSERT(
+        SQL_TABLE("Visibilities"),
+        SQL_COLUMNS("Hidden", "Support", "Detail", "Normal", "Summary", "Critical"),
+        SQL_VALUES(static_cast<int>(sparta::InstrumentationNode::VIS_HIDDEN),
+                    static_cast<int>(sparta::InstrumentationNode::VIS_SUPPORT),
+                    static_cast<int>(sparta::InstrumentationNode::VIS_DETAIL),
+                    static_cast<int>(sparta::InstrumentationNode::VIS_NORMAL),
+                    static_cast<int>(sparta::InstrumentationNode::VIS_SUMMARY),
+                    static_cast<int>(sparta::InstrumentationNode::VIS_CRITICAL)));
+
+    report::format::JavascriptObject::writeLeafNodeInfoToDB(db_mgr);
+
+    for (const auto& [desc, descriptor] : descriptors_) {
+        const auto& [pattern, def_file, dest_file, format] = descriptor;
+
+        auto record = db_mgr->INSERT(
+            SQL_TABLE("ReportDescriptors"),
+            SQL_COLUMNS("LocPattern", "DefFile", "DestFile", "Format"),
+            SQL_VALUES(pattern, def_file, dest_file, format));
+
+        const int report_desc_id = record->getId();
+        descriptor_ids_[desc] = report_desc_id;
+    }
+
+    for (const auto& [desc, header] : descriptor_headers_) {
+        const auto descriptor_id = getDescriptorID(desc);
+        const auto start_counter_loc = header->getStringified("start_counter");
+        const auto stop_counter_loc = header->getStringified("stop_counter");
+        const auto update_counter_loc = header->getStringified("update_counter");
+
+        std::ostringstream cmd;
+        cmd << "UPDATE Reports SET "
+            << "StartCounter = '" << start_counter_loc << "', "
+            << "StopCounter = '" << stop_counter_loc << "', "
+            << "UpdateCounter = '" << update_counter_loc << "'"
+            << " WHERE ReportDescID = " << descriptor_id
+            << " AND ParentReportID = 0";
+
+        getDatabaseManager()->EXECUTE(cmd.str());
+    }
+}
+
+void ReportStatsCollector::postSim_()
+{
+    auto db_mgr = getDatabaseManager();
+
+    for (const auto& [name, value] : SimulationInfo::getInstance().getHeaderPairs()) {
+        db_mgr->INSERT(
+            SQL_TABLE("SimulationInfoHeaderPairs"),
+            SQL_COLUMNS("HeaderName", "HeaderValue"),
+            SQL_VALUES(name, value));
+    }
+
+    for (const auto& other : SimulationInfo::getInstance().other) {
+        db_mgr->INSERT(
+            SQL_TABLE("SimulationInfoHeaderPairs"),
+            SQL_COLUMNS("HeaderName", "HeaderValue"),
+            SQL_VALUES("Other", other));
+    }
+
+    std::ostringstream oss;
+    oss << "UPDATE SimulationInfo SET SimEndTick = "
+        << scheduler_->getCurrentTick();
+
+    db_mgr->EXECUTE(oss.str());
+}
+
+void ReportStatsCollector::onPreTeardown_()
+{
+}
+
+void ReportStatsCollector::onPostTeardown_()
+{
+    // Now that simulation is over, we need to update a few tables with the actual
+    // report descriptor IDs that were not available at the start of simulation.
+
+    auto db_mgr = getDatabaseManager();
+
+    for (const auto& [desc, db_ids] : descriptor_report_ids_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        for (const auto& report_id : db_ids) {
+            std::ostringstream cmd;
+            cmd << "UPDATE Reports SET ReportDescID = " << report_desc_id
+                << " WHERE Id = " << report_id;
+            db_mgr->EXECUTE(cmd.str());
+        }
+    }
+
+    for (const auto& [desc, db_ids] : descriptor_report_style_ids_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        for (const auto& style_id : db_ids) {
+            std::ostringstream cmd;
+            cmd << "UPDATE ReportStyles SET ReportDescID = " << report_desc_id
+                << " WHERE Id = " << style_id;
+            db_mgr->EXECUTE(cmd.str());
+        }
+    }
+
+    for (const auto& [desc, db_ids] : descriptor_report_meta_ids_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        for (const auto& meta_id : db_ids) {
+            std::ostringstream cmd;
+            cmd << "UPDATE ReportMetadata SET ReportDescID = " << report_desc_id
+                << " WHERE Id = " << meta_id;
+            db_mgr->EXECUTE(cmd.str());
+        }
+    }
+
+    for (const auto& [desc, meta] : report_metadata_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        for (const auto& [meta_name, meta_value] : meta) {
+            std::ostringstream cmd;
+            cmd << "UPDATE Reports SET " << meta_name << " = '" << meta_value
+                << "' WHERE ReportDescID = " << report_desc_id
+                << " AND ParentReportID = 0";
+            db_mgr->EXECUTE(cmd.str());
+        }
+    }
+
+    for (const auto& [desc, start_time] : report_start_times_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        std::ostringstream cmd;
+        cmd << "UPDATE Reports SET StartTick = " << start_time
+            << " WHERE ReportDescID = " << report_desc_id
+            << " AND ParentReportID = 0";
+        db_mgr->EXECUTE(cmd.str());
+    }
+
+    for (const auto& [desc, end_time] : report_end_times_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        std::ostringstream cmd;
+        cmd << "UPDATE Reports SET EndTick = " << end_time
+            << " WHERE ReportDescID = " << report_desc_id
+            << " AND ParentReportID = 0";
+        db_mgr->EXECUTE(cmd.str());
+    }
+
+    for (const auto& [desc, annotation_pairs] : report_skip_annotations_) {
+        const auto report_desc_id = getDescriptorID(desc);
+        for (const auto& [tick, annotation] : annotation_pairs) {
+            db_mgr->INSERT(
+                SQL_TABLE("CsvSkipAnnotations"),
+                SQL_COLUMNS("ReportDescID", "Tick", "Annotation"),
+                SQL_VALUES(report_desc_id, tick, annotation));
+        }
+    }
+}
+
+std::string ReportStatsCollector::getByteLayoutYAML_() const
+{
+    return "NOT YET IMPLEMENTED";
+}
+
+void ReportStatsCollector::writeReportInfo_(const ReportDescriptor* desc)
+{
+    sparta_assert(desc->isEnabled());
+    auto reports = desc->getAllInstantiations();
+    sparta_assert(!reports.empty());
+
+    std::unordered_set<std::string> visited_stats;
+    for (auto r : reports) {
+        writeReportInfo_(desc, r, visited_stats, 0);
+    }
+}
+
+void ReportStatsCollector::writeReportInfo_(
+    const ReportDescriptor* desc,
+    const Report* r,
+    std::unordered_set<std::string>& visited_stats,
+    int parent_report_id)
+{
+    auto db_mgr = getDatabaseManager();
+
+    const auto report_name = r->getName();
+    const auto report_start_tick = r->getStart();
+    const auto report_end_tick = r->getEnd();
+    const auto report_info = r->getInfoString();
+
+    const auto report_record = db_mgr->INSERT(
+        SQL_TABLE("Reports"),
+        SQL_COLUMNS("ReportDescID", "ParentReportID", "Name", "StartTick", "EndTick", "InfoString"),
+        SQL_VALUES(0, parent_report_id, report_name, report_start_tick, report_end_tick, report_info));
+
+    const auto report_id = report_record->getId();
+    descriptor_report_ids_[desc].push_back(report_id);
+
+    for (const auto& [name, value] : r->getAllStyles()) {
+        auto record = db_mgr->INSERT(
+            SQL_TABLE("ReportStyles"),
+            SQL_COLUMNS("ReportDescID", "ReportID", "StyleName", "StyleValue"),
+            SQL_VALUES(0, report_id, name, value));
+
+        descriptor_report_style_ids_[desc].push_back(record->getId());
+    }
+
+    const auto& stats = r->getStatistics();
+    for (const auto& si : stats) {
+        const auto& si_name = si.first;
+        const auto si_loc = si.second->getLocation();
+        const auto si_desc = si.second->getDesc(false);
+        const auto si_vis = static_cast<int>(si.second->getVisibility());
+        const auto si_class = static_cast<int>(si.second->getClass());
+
+        if (!visited_stats.insert(si_loc).second) {
+            continue;
+        }
+
+        auto si_record = db_mgr->INSERT(
+            SQL_TABLE("StatisticInsts"),
+            SQL_COLUMNS("ReportID", "StatisticName", "StatisticLoc", "StatisticDesc", "StatisticVis", "StatisticClass"),
+            SQL_VALUES(report_id, si_name, si_loc, si_desc, si_vis, si_class));
+
+        if (auto stat_def = si.second->getStatisticDef()) {
+            const auto si_id = si_record->getId();
+            for (const auto& pair : stat_def->getMetadata()) {
+                const auto& meta_name = pair.first;
+                const auto& meta_value = pair.second;
+
+                db_mgr->INSERT(
+                    SQL_TABLE("StatisticDefnMetadata"),
+                    SQL_COLUMNS("StatisticInstID", "MetaName", "MetaValue"),
+                    SQL_VALUES(si_id, meta_name, meta_value));
+            }
+        }
+
+        simdb_stats_[desc].push_back(si.second.get());
+    }
+
+    for (const auto& [report, formatter] : desc->getInstantiations()) {
+        if (report == r) {
+            auto meta_kv_pairs = formatter->getMetadataKVPairs();
+            meta_kv_pairs["PrettyPrint"] = formatter->prettyPrintEnabled() ? "true" : "false";
+            meta_kv_pairs["OmitZeros"] = formatter->statsWithValueZeroAreOmitted() ? "true" : "false";
+
+            for (const auto& [meta_name, meta_value] : meta_kv_pairs) {
+                auto record = db_mgr->INSERT(
+                    SQL_TABLE("ReportMetadata"),
+                    SQL_COLUMNS("ReportDescID", "ReportID", "MetaName", "MetaValue"),
+                    SQL_VALUES(0, report_id, meta_name, meta_value));
+
+                descriptor_report_meta_ids_[desc].push_back(record->getId());
+            }
+
+            break;
+        }        
+    }
+
+    for (const auto& sr : r->getSubreports()) {
+        writeReportInfo_(desc, &sr, visited_stats, report_id);
+    }
+}
+
+void ReportStatsCollector::StageObserver::onEnterStage(const simdb::PipelineEntry&, size_t)
+{
+}
+
+void ReportStatsCollector::StageObserver::onLeaveStage(const simdb::PipelineEntry& entry, size_t stage_idx)
+{
+    if (stage_idx == 1) {
+        return;
+    }
+    collector_->postCommit_(entry);
+}
+
+void ReportStatsCollector::postCommit_(const simdb::PipelineEntry& entry)
+{
+    auto record_id = entry.getCommittedDbID();
+    sparta_assert(record_id, "PipelineEntry was never committed!");
+
+    auto tick = entry.getTick();
+    auto desc = static_cast<const ReportDescriptor*>(entry.getUserData());
+    auto descriptor_id = getDescriptorID(desc);
+    auto db_mgr = getDatabaseManager();
+
+    db_mgr->INSERT(
+        SQL_TABLE("DescriptorRecords"),
+        SQL_COLUMNS("ReportDescID", "DatablobID", "Tick"),
+        SQL_VALUES(descriptor_id, record_id, tick));
+}
+
+} // namespace sparta::app

--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -778,7 +778,6 @@ void Simulation::finalizeFramework()
 
         if (collector) {
             collector->setScheduler(getScheduler());
-            collector->setDatabaseManager(db_mgr);
             db_mgr->safeTransaction([&]() { setupReports_(collector); });
             reports_setup = true;
         }
@@ -914,7 +913,11 @@ void Simulation::run(uint64_t run_time)
             app_manager_->postSim(db_mgr);
         }
 
-        app_manager_->teardown();
+        for (const auto & kvp : db_managers_) {
+            auto db_mgr = kvp.second.get();
+            app_manager_->teardown(db_mgr);
+        }
+
         app_manager_->destroy();
         app_manager_.reset();
     }

--- a/sparta/test/SimDB/SimDB_test.cpp
+++ b/sparta/test/SimDB/SimDB_test.cpp
@@ -17,7 +17,7 @@ int main()
     table.addColumn("TheString", dt::string_t);
 
     simdb::DatabaseManager db_mgr("test.db", true);
-    EXPECT_TRUE(db_mgr.createDatabaseFromSchema(schema));
+    db_mgr.appendSchema(schema);
 
     auto record = db_mgr.INSERT(
         SQL_TABLE("TheTable"),
@@ -25,8 +25,6 @@ int main()
         SQL_VALUES(112233, "HelloWorld"));
 
     EXPECT_EQUAL(record->getId(), 1);
-
-    db_mgr.closeDatabase();
 
     REPORT_ERROR;
     return ERROR_CODE;


### PR DESCRIPTION
This is an important design change for SimDB pipelines. Previously, there was only one data type you could send down the pipeline (`PipelineEntry`, a wrapper around `std::vector<char>`)

This has a number of problems:
- Overhead of copies/memcpys to get data into the char buffer
- No easy way to add pipeline stage buffers for batch processing
  - We need this for the SimDB->HDF5 profiler backend since its data type is just a handful of uint64_t's

The new design lets you build pipelines composed of stages and transforms:
- One stage == one pipeline thread
- One stage can have 1 or more transforms chained together with possibly different I/O types
- Any number of stages can be chained together with any I/O types (it is up to the user how many threads to use and how to partition the pipeline work across them)

This pipeline design really improved Sparta report performance. Collection went from being 18% faster and 22% smaller using `PipelineEntry` (as compared to legacy formatted reports), to **31% faster and 33% smaller** using templated pipeline stages and transforms.

Pertinent files from SimDB (already merged):
[Pipeline.hpp](https://github.com/colby-nyce/simdb/blob/main/include/simdb/pipeline/Pipeline.hpp)
[PipelineThread.hpp](https://github.com/colby-nyce/simdb/blob/main/include/simdb/pipeline/PipelineThread.hpp)
[Example pipeline](https://github.com/colby-nyce/simdb/blob/main/test/Pipeline/main.cpp)


