### PR TITLE
[map_v2] More Sparta build improvements

### DIFF
--- a/sparta/cmake/FindSparta.cmake
+++ b/sparta/cmake/FindSparta.cmake
@@ -74,11 +74,18 @@ if(NOT SPARTA_FOUND)
           get_target_property(YAML_CPP_INCLUDE_DIR yaml-cpp::yaml-cpp INTERFACE_INCLUDE_DIRECTORIES)
         endif ()
         set_property(TARGET SPARTA::sparta
-          PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SPARTA_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${SQLite3_INCLUDE_DIRS} ${HDF5_CXX_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIR} ${RapidJSON_INCLUDE_DIR} ${YAML_CPP_INCLUDE_DIR})
+          PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${SPARTA_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${SQLite3_INCLUDE_DIRS} ${HDF5_CXX_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIRS} ${RapidJSON_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIR})
         set_property(TARGET SPARTA::sparta
           PROPERTY INTERFACE_LINK_LIBRARIES SPARTA::libsparta SPARTA::libsimdb HDF5::HDF5 SQLite::SQLite3
           Boost::filesystem Boost::serialization Boost::timer Boost::program_options
           ZLIB::ZLIB yaml-cpp::yaml-cpp Threads::Threads)
+
+        # If HDF5 is built with MPI support, we also need to add the MPI include dirs and link against the MPI library
+        if(HDF5_IS_PARALLEL)
+            find_package(MPI REQUIRED COMPONENTS CXX)
+            set_property(TARGET SPARTA::sparta APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${MPI_CXX_INCLUDE_DIRS})
+            set_property(TARGET SPARTA::sparta APPEND PROPERTY INTERFACE_LINK_LIBRARIES MPI::MPI_CXX)
+        endif()
 
         if(LIBRT)
           set_property(TARGET SPARTA::sparta APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${LIBRT})

--- a/sparta/cmake/sparta-config.cmake
+++ b/sparta/cmake/sparta-config.cmake
@@ -61,7 +61,7 @@ endif ()
 
 # Find RapidJSON
 find_package (RapidJSON 1.1 REQUIRED)
-include_directories (SYSTEM ${RapidJSON_INCLUDE_DIRS})
+include_directories (SYSTEM ${RAPIDJSON_INCLUDE_DIRS} ${RapidJSON_INCLUDE_DIRS})
 message (STATUS "Using RapidJSON CPP ${RapidJSON_VERSION}")
 
 # Find SQLite3
@@ -86,6 +86,14 @@ find_package(Threads REQUIRED)
 # basic Sparta linking
 set (Sparta_LIBS sparta simdb HDF5::HDF5 sqlite3 yaml-cpp::yaml-cpp ZLIB::ZLIB Threads::Threads
   Boost::date_time Boost::iostreams Boost::serialization Boost::timer Boost::program_options)
+
+# If HDF5 is built with MPI support, we also need to add the MPI include dirs and link against the MPI library
+if(HDF5_IS_PARALLEL)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    include_directories (SYSTEM ${MPI_CXX_INCLUDE_DIRS})
+    list(APPEND Sparta_LIBS MPI::MPI_CXX)
+    message (STATUS "Using MPI ${MPI_CXX_VERSION}")
+endif()
 
 # On Linux we need to link against rt as well
 if (NOT APPLE)

--- a/sparta/simdb/cmake/simdb-config.cmake
+++ b/sparta/simdb/cmake/simdb-config.cmake
@@ -11,3 +11,9 @@ enable_language(C)
 find_package(HDF5 1.10 REQUIRED)
 
 set(SimDB_LIBS simdb ${HDF5_LIBRARIES} sqlite3 z pthread)
+
+# If HDF5 is built with MPI support, we also need to add the MPI include dirs and link against the MPI library
+if(HDF5_IS_PARALLEL)
+    find_package(MPI REQUIRED)
+    list(APPEND SimDB_LIBS MPI::MPI_CXX)
+endif()

--- a/sparta/sparta/utils/SpartaExpBackoff.hpp
+++ b/sparta/sparta/utils/SpartaExpBackoff.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 
 namespace sparta {
 


### PR DESCRIPTION
Fix failure when trying to build against an HDF5 library with MPI support enabled
Maximize RapidJSON compatibility by using both possible versions of the include path CMake variable (`RapidJSON_INCLUDE_DIRS` and `RAPIDJSON_INCLUDE_DIRS`)
Fix compiler error with Clang 20+ and GCC 15+