### PR TITLE
Bump SimDB to get uint64_t support

### DIFF
--- a/sparta/scripts/simdb/exporters/export_csv_report.py
+++ b/sparta/scripts/simdb/exporters/export_csv_report.py
@@ -101,8 +101,11 @@ class CSVReportExporter:
                 fout.write('\n')
 
     def __WriteHeader(self, fout, report_name, start_tick, end_tick, meta_kvpairs, trigger_locs):
-        if end_tick == -1:
+        start_tick = int(start_tick)
+        if end_tick == '18446744073709551615':
             end_tick = 'SIMULATION_END'
+        else:
+            end_tick = int(end_tick)
         fout.write(f'# report="{report_name}",start={start_tick},end={end_tick}')
 
         if not meta_kvpairs:

--- a/sparta/scripts/simdb/exporters/export_text_report.py
+++ b/sparta/scripts/simdb/exporters/export_text_report.py
@@ -136,9 +136,9 @@ class TextReportExporter:
             # out << "\n";
             if self.GetShowReportRange() and depth == 0:
                 out.write(" [")
-                out.write(str(report_start))
+                out.write(str(int(report_start)))
                 out.write(",")
-                out.write(str(report_end))
+                out.write(str(int(report_end)))
                 out.write("]")
             out.write("\n")
 

--- a/sparta/src/ReportStatsCollector.cpp
+++ b/sparta/src/ReportStatsCollector.cpp
@@ -33,8 +33,8 @@ void ReportStatsCollector::defineSchema(simdb::Schema& schema)
     report_tbl.addColumn("ReportDescID", dt::int32_t);
     report_tbl.addColumn("ParentReportID", dt::int32_t);
     report_tbl.addColumn("Name", dt::string_t);
-    report_tbl.addColumn("StartTick", dt::int64_t);
-    report_tbl.addColumn("EndTick", dt::int64_t);
+    report_tbl.addColumn("StartTick", dt::uint64_t);
+    report_tbl.addColumn("EndTick", dt::uint64_t);
     report_tbl.addColumn("InfoString", dt::string_t);
     report_tbl.addColumn("StartCounter", dt::string_t);
     report_tbl.addColumn("StopCounter", dt::string_t);
@@ -77,7 +77,7 @@ void ReportStatsCollector::defineSchema(simdb::Schema& schema)
     siminfo_tbl.addColumn("SimVersion", dt::string_t);
     siminfo_tbl.addColumn("SpartaVersion", dt::string_t);
     siminfo_tbl.addColumn("ReproInfo", dt::string_t);
-    siminfo_tbl.addColumn("SimEndTick", dt::int64_t);
+    siminfo_tbl.addColumn("SimEndTick", dt::uint64_t);
     siminfo_tbl.setColumnDefaultValue("SimEndTick", -1);
     siminfo_tbl.disableAutoIncPrimaryKey();
 
@@ -107,7 +107,7 @@ void ReportStatsCollector::defineSchema(simdb::Schema& schema)
     // to which report.
     auto& desc_records_tbl = schema.addTable("DescriptorRecords");
     desc_records_tbl.addColumn("ReportDescID", dt::int32_t);
-    desc_records_tbl.addColumn("Tick", dt::int64_t);
+    desc_records_tbl.addColumn("Tick", dt::uint64_t);
     desc_records_tbl.addColumn("DataBlob", dt::blob_t);
     desc_records_tbl.createIndexOn("ReportDescID");
 
@@ -117,7 +117,7 @@ void ReportStatsCollector::defineSchema(simdb::Schema& schema)
     // the report/trigger was inactive.
     auto& csv_skip_annotations_tbl = schema.addTable("CsvSkipAnnotations");
     csv_skip_annotations_tbl.addColumn("ReportDescID", dt::int32_t);
-    csv_skip_annotations_tbl.addColumn("Tick", dt::int64_t);
+    csv_skip_annotations_tbl.addColumn("Tick", dt::uint64_t);
     csv_skip_annotations_tbl.addColumn("Annotation", dt::string_t);
     csv_skip_annotations_tbl.createIndexOn("ReportDescID");
 }


### PR DESCRIPTION
SimDB hasn't had great support for uint64 since SQLite doesn't natively support it. The only options are:

1. Use BLOBS (bad: can't read the values in a sql viewer, can't sort records based on uint64 columns)
2. Split the column into lower half and upper half columns (even worse)
3. Store as fixed-width TEXT (prefixed with zeros for comparability / sortability)

Option 3 has some extra overhead, but it preserves all the ORDER BY etc. functionality that users expect. And not much has to really change except python code. The details are all hidden when you are writing/reading to the database in C++.

The benchmark database size grew a bit to store the tick columns as text. It used to be 33% smaller than legacy, now it is 30% smaller. Runtime was not affected and remains 38% faster.