### PR TITLE
Allow more than one TreeNode root for checkpointers (#620)

### DIFF
--- a/sparta/sparta/memory/MemoryObject.hpp
+++ b/sparta/sparta/memory/MemoryObject.hpp
@@ -225,7 +225,7 @@ namespace sparta
                 return ArchData::getInitialValSize();
             }
 
-        }; // class DebugMemoryIF
+        }; // class MemoryObject
 
 
         /*!

--- a/sparta/sparta/serialization/checkpoint/DatabaseCheckpoint.hpp
+++ b/sparta/sparta/serialization/checkpoint/DatabaseCheckpoint.hpp
@@ -72,8 +72,7 @@ namespace sparta::serialization::checkpoint
     private:
 
         //! \brief Construction to be performed by friend class DatabaseCheckpointer
-        DatabaseCheckpoint(TreeNode& root,
-                           const std::vector<ArchData*>& dats,          
+        DatabaseCheckpoint(const std::vector<ArchData*>& dats,          
                            chkpt_id_t id,
                            tick_t tick,
                            DatabaseCheckpoint* prev,

--- a/sparta/sparta/serialization/checkpoint/DeltaCheckpoint.hpp
+++ b/sparta/sparta/serialization/checkpoint/DeltaCheckpoint.hpp
@@ -88,8 +88,7 @@ namespace sparta::serialization::checkpoint
          * Snapshot checkpoint can be restored without walking any checkpoint
          * chains
          */
-        DeltaCheckpoint(TreeNode& root,
-                        const std::vector<ArchData*>& dats,
+        DeltaCheckpoint(const std::vector<ArchData*>& dats,
                         chkpt_id_t id,
                         tick_t tick,
                         DeltaCheckpoint* prev_delta,
@@ -98,7 +97,6 @@ namespace sparta::serialization::checkpoint
             deleted_id_(UNIDENTIFIED_CHECKPOINT),
             is_snapshot_(is_snapshot)
         {
-            (void) root;
             if(nullptr == prev_delta){
                 if(is_snapshot == false){
                     throw CheckpointError("Cannot create a DeltaCheckpoint id=")

--- a/sparta/sparta/serialization/checkpoint/PersistentFastCheckpointer.hpp
+++ b/sparta/sparta/serialization/checkpoint/PersistentFastCheckpointer.hpp
@@ -154,6 +154,30 @@ namespace sparta::serialization::checkpoint
         { }
 
         /*!
+         * \brief PersistentFastCheckpointer Constructor
+         *
+         * \param roots TreeNodes at which checkpoints will be taken.
+         *              This cannot be changed later. These do not
+         *              necessarily need to be RootTreeNodes. Before
+         *              the first checkpoint is taken, these nodes must
+         *              be finalized (see
+         *              sparta::TreeNode::isFinalized). At this point,
+         *              the nodes do not need to be finalized
+         *
+         * \param sched Scheduler whose current cycle will be read
+         *              when taking checkpoints and restored when
+         *              restoring checkpoints. See
+         *              sparta::serialization::Checkpoint::Checkpoint
+         *              for details
+         */
+        PersistentFastCheckpointer(const std::vector<sparta::TreeNode*>& roots,
+                                   sparta::Scheduler* sched=nullptr) :
+            FastCheckpointer(roots, sched),
+            prefix_("chkpt"),
+            suffix_("data")
+        { }
+
+        /*!
          * \brief Destructor
          *
          */

--- a/sparta/src/DatabaseCheckpoint.cpp
+++ b/sparta/src/DatabaseCheckpoint.cpp
@@ -11,8 +11,7 @@ using chkpt_id_t = typename CheckpointBase::chkpt_id_t;
 using checkpoint_type = DatabaseCheckpoint;
 using checkpoint_ptr = std::shared_ptr<DatabaseCheckpoint>;
 
-DatabaseCheckpoint::DatabaseCheckpoint(TreeNode& root,
-                                       const std::vector<ArchData*>& dats,          
+DatabaseCheckpoint::DatabaseCheckpoint(const std::vector<ArchData*>& dats,          
                                        chkpt_id_t id,
                                        tick_t tick,
                                        DatabaseCheckpoint* prev,
@@ -23,7 +22,6 @@ DatabaseCheckpoint::DatabaseCheckpoint(TreeNode& root,
     , is_snapshot_(is_snapshot)
     , checkpointer_(checkpointer)
 {
-    (void)root;
     if (prev_id_ == UNIDENTIFIED_CHECKPOINT) {
         if (is_snapshot == false) {
             throw CheckpointError("Cannot create a DatabaseCheckpoint id=")

--- a/sparta/test/DatabaseCheckpoint/DatabaseCheckpoint_test.cpp
+++ b/sparta/test/DatabaseCheckpoint/DatabaseCheckpoint_test.cpp
@@ -92,7 +92,7 @@ void RunCheckpointerTest(uint64_t initial_tick = 0)
     simdb::AppManager app_mgr(&db_mgr);
 
     // Setup...
-    app_mgr.getAppFactory<DatabaseCheckpointer>()->setArchDataRoot(0, root);
+    app_mgr.getAppFactory<DatabaseCheckpointer>()->setArchDataRoots(0, {&root});
     app_mgr.getAppFactory<DatabaseCheckpointer>()->setScheduler(sched);
     app_mgr.enableApp(DatabaseCheckpointer::NAME);
     app_mgr.createEnabledApps();
@@ -555,7 +555,7 @@ void RunStepStepStepLoadTest()
     simdb::AppManager app_mgr(&db_mgr);
 
     // Setup...
-    app_mgr.getAppFactory<DatabaseCheckpointer>()->setArchDataRoot(0, root);
+    app_mgr.getAppFactory<DatabaseCheckpointer>()->setArchDataRoots(0, {&root});
     app_mgr.getAppFactory<DatabaseCheckpointer>()->setScheduler(sched);
     app_mgr.enableApp(DatabaseCheckpointer::NAME);
     app_mgr.createEnabledApps();
@@ -646,7 +646,7 @@ void ProfileLoadCheckpoint(DatabaseCheckpointer::chkpt_id_t load_id)
     simdb::AppManager app_mgr(&db_mgr);
 
     // Setup...
-    app_mgr.getAppFactory<DatabaseCheckpointer>()->setArchDataRoot(0, root);
+    app_mgr.getAppFactory<DatabaseCheckpointer>()->setArchDataRoots(0, {&root});
     app_mgr.getAppFactory<DatabaseCheckpointer>()->setScheduler(sched);
     app_mgr.enableApp(DatabaseCheckpointer::NAME);
     app_mgr.createEnabledApps();

--- a/sparta/test/FastCheckpoint/FastCheckpoint_test.cpp
+++ b/sparta/test/FastCheckpoint/FastCheckpoint_test.cpp
@@ -971,7 +971,7 @@ int main()
 
     std::unique_ptr<sparta::log::Tap> warn_file(new sparta::log::Tap(sparta::TreeNode::getVirtualGlobalNode(),
                                                                  sparta::log::categories::WARN,
-                                                                 "warnings.log"));
+                                                                 "fast-checkpointer-warnings.log"));
 
     generalTest();
     stackTest();

--- a/sparta/test/FastCheckpoint/PersistentFastCheckpoint/PersistentFastCheckpoint_test.cpp
+++ b/sparta/test/FastCheckpoint/PersistentFastCheckpoint/PersistentFastCheckpoint_test.cpp
@@ -223,7 +223,7 @@ int main() {
 
     std::unique_ptr<sparta::log::Tap> warn_file(new sparta::log::Tap(sparta::TreeNode::getVirtualGlobalNode(),
                                                                  sparta::log::categories::WARN,
-                                                                 "warnings.log"));
+                                                                 "persistent-fast-checkpointer-warnings.log"));
 
     generalTest();
 

--- a/sparta/test/SimDB/SimDB_test.cpp
+++ b/sparta/test/SimDB/SimDB_test.cpp
@@ -16,7 +16,7 @@ int main()
     table.addColumn("TheInt", dt::int32_t);
     table.addColumn("TheString", dt::string_t);
 
-    simdb::DatabaseManager db_mgr("test.db", true);
+    simdb::DatabaseManager db_mgr("simdb-test.db", true);
     db_mgr.appendSchema(schema);
 
     auto record = db_mgr.INSERT(


### PR DESCRIPTION
Each Pegasus hart gets its own checkpointer which already captures all memory/registers under e.g. top.core0.hart0

But the PegasusSystem (top.system) has its own MemoryObject's (ArchData) which also have to be added to the checkpointers or else we can't checkpoint those ArchData's.

Adding "top.system" to the checkpointers brings up the CoSim ISA test pass rate to 96%.