### PR TITLE
TreeNode extensions bug fixes

### DIFF
--- a/sparta/example/CoreModel/CMakeLists.txt
+++ b/sparta/example/CoreModel/CMakeLists.txt
@@ -142,6 +142,7 @@ sparta_named_test(sparta_core_example_arch_with_extensions sparta_core_example -
 # The old behavior of Sparta allowed extensions to be optional by default.  Now they are an error
 #sparta_named_test(sparta_core_example_indiv_tree_node_extensions sparta_core_example -i 10k -p top.cpu.core0.lsu.extension.dog.language_ woof --extension-file tree_node_extensions.yaml -p top.cpu.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
 sparta_named_test(sparta_core_example_indiv_tree_node_extensions sparta_core_example -i 10k --extension-file tree_node_extensions.yaml -p top.cpu.core0.lsu.extension.cat.language_ meow --write-final-config final.yaml)
+sparta_named_test(sparta_core_example_final_cfg_implicit_extensions sparta_core_example -i 10k --extension-file tree_node_extensions.yaml --extension-file never_explicitly_instantiated.yaml --write-final-config final_cfg_with_implicit_extensions.yaml --no-run)
 #sparta_named_test(sparta_core_example_custom_histogram_stats sparta_core_example -i 100k --report multireport_r3.yaml)
 sparta_named_test(sparta_core_example_arch_report_simple sparta_core_example -i 10k --arch simple --arch-search-dir . --report top arch_report.yaml 1)
 sparta_named_test(sparta_core_example_arch_report_default sparta_core_example -i 10k --report top arch_report.yaml 1)

--- a/sparta/example/CoreModel/never_explicitly_instantiated.yaml
+++ b/sparta/example/CoreModel/never_explicitly_instantiated.yaml
@@ -1,0 +1,5 @@
+top.cpu.core0.extension:
+  never_explicitly_instantiated:
+    foo_: 4
+    bar_: 5
+    # value_ parameter is set in postCreate() with default value

--- a/sparta/example/CoreModel/src/ExampleSimulation.cpp
+++ b/sparta/example/CoreModel/src/ExampleSimulation.cpp
@@ -86,9 +86,6 @@ namespace sparta {
 class CircleExtensions : public sparta::ExtensionsParamsOnly
 {
 public:
-    CircleExtensions() : sparta::ExtensionsParamsOnly() {}
-    virtual ~CircleExtensions() {}
-
     void doSomethingElse() const {
         std::cout << "Invoking a method that is unknown to the sparta::TreeNode object, "
                      "even though 'this' object was created by, and currently owned by, "
@@ -96,7 +93,6 @@ public:
     }
 
 private:
-
     // Note: this parameter is NOT in the yaml config file,
     // but subclasses can provide any parameter type supported
     // by sparta::Parameter<T> which may be too complicated to
@@ -106,11 +102,23 @@ private:
     // The base class will clobber together whatever parameter values it
     // found in the yaml file, and give us a chance to add custom parameters
     // to the same set
-    virtual void postCreate() override {
+    void postCreate() override {
         sparta::ParameterSet * ps = getParameters();
         degrees_.reset(new sparta::Parameter<double>(
             "degrees_", 360.0, "Number of degrees in a circle", ps));
     }
+};
+
+class NeverExplicitlyInstantiated : public sparta::ExtensionsParamsOnly
+{
+private:
+    void postCreate() override {
+        sparta::ParameterSet * ps = getParameters();
+        value_.reset(new sparta::Parameter<int>(
+            "value_", 555, "Dummy value", ps));
+    }
+
+    std::unique_ptr<sparta::Parameter<int>> value_;
 };
 
 double calculateAverageOfInternalCounters(
@@ -142,6 +150,7 @@ ExampleSimulator::ExampleSimulator(const std::string& topology,
     //      to their tree node extension, and/or for those that want to extend node
     //      parameter sets with more complicated sparta::Parameter<T> data types
     addTreeNodeExtensionFactory_("circle", [](){return new CircleExtensions;});
+    addTreeNodeExtensionFactory_("never_explicitly_instantiated", [](){return new NeverExplicitlyInstantiated;});
 
     // Initialize example simulation controller
     controller_.reset(new ExampleSimulator::ExampleController(this));

--- a/sparta/sparta/simulation/ParameterTree.hpp
+++ b/sparta/sparta/simulation/ParameterTree.hpp
@@ -740,6 +740,42 @@ namespace sparta
             }
 
             /*!
+             * \brief Recursively find all nodes that have a given name.
+             */
+            void recursFindPTreeNodesNamed(
+                const std::string & name,
+                std::vector<Node*> & matching_nodes)
+            {
+                if (getName() == name) {
+                    matching_nodes.emplace_back(this);
+                    return;
+                }
+
+                const auto children = getChildren();
+                for (ParameterTree::Node * child : children) {
+                    child->recursFindPTreeNodesNamed(name, matching_nodes);
+                }
+            }
+
+            /*!
+             * \brief Recursively find all nodes that have a given name.
+             */
+            void recursFindPTreeNodesNamed(
+                const std::string & name,
+                std::vector<const Node*> & matching_nodes) const
+            {
+                if (getName() == name) {
+                    matching_nodes.emplace_back(this);
+                    return;
+                }
+
+                const auto children = getChildren();
+                for (const ParameterTree::Node * child : children) {
+                    child->recursFindPTreeNodesNamed(name, matching_nodes);
+                }
+            }
+
+            /*!
              * \brief Recursively print
              */
             void recursePrint(std::ostream& o, uint32_t indent=0, bool print_user_data=true) const {

--- a/sparta/sparta/simulation/TreeNode.hpp
+++ b/sparta/sparta/simulation/TreeNode.hpp
@@ -1894,6 +1894,8 @@ namespace sparta
             virtual void setParameters(std::unique_ptr<ParameterSet> params) = 0;
             virtual ParameterSet * getParameters() const = 0;
             virtual ParameterSet * getYamlOnlyParameters() const = 0;
+            virtual ParameterSet * getParameters() = 0;
+            virtual ParameterSet * getYamlOnlyParameters() = 0;
             virtual void addParameter(std::unique_ptr<ParameterBase> param) = 0;
             virtual void postCreate() {}
 

--- a/sparta/sparta/simulation/TreeNodeExtensions.hpp
+++ b/sparta/sparta/simulation/TreeNodeExtensions.hpp
@@ -30,6 +30,8 @@ public:
     virtual void addParameter(std::unique_ptr<ParameterBase> param) override final;
     virtual ParameterSet * getParameters() const override final;
     virtual ParameterSet * getYamlOnlyParameters() const override final;
+    virtual ParameterSet * getParameters() override final;
+    virtual ParameterSet * getYamlOnlyParameters() override final;
 
 private:
     class Impl;

--- a/sparta/src/CommandLineSimulator.cpp
+++ b/sparta/src/CommandLineSimulator.cpp
@@ -2111,20 +2111,150 @@ void CommandLineSimulator::populateSimulation_(Simulation* sim)
 
         sim->finalizeTree();
 
+        auto wrap_up_final_config = [&](const sparta::ParameterTree & orig_ptree,
+                                        const std::string & filename,
+                                        bool show_descriptions)
+        {
+            sparta::ParameterTree ptree(orig_ptree);
+
+            // Ensure that default extension parameter values get added to the ParameterTree.
+            // Users expect any parameter added in postCreate() to be written to the final
+            // config file, and there is no guarantee that anybody calls getExtension() or
+            // createExtension() to instantiate the extensions. Repro steps for the reported
+            // bug:
+            //
+            //    ./sim --write-final-config final.yaml --arch small_core.yaml --no-run
+            //
+            // Where small_core.yaml specifies:
+            //
+            //    top.cpu.core0.extension.core_extensions:
+            //        exe_pipe_rename:
+            //          ["exe0", "alu0_pipe"],
+            //            ["exe1", "fpu0_pipe"],
+            //            ["exe2", "br_pipe"],
+            //            ["exe3", "vint_pipe"]
+            //          ]
+            //
+            // But in CoreExtensions::postCreate() we have:
+            //
+            //    sparta::ParameterSet* ps = getParameters();
+            //
+            //    // Add parameter not found in any extension/arch/config file
+            //    foo_param_.reset(new sparta::Parameter<int>("foo", 555, "Foo Param", ps));
+            //
+            // The bug is in final.yaml where the default "Foo Param" value of 555 is
+            // not listed in the YAML file if this extension was never created.
+            std::vector<ParameterTree::Node*> extension_nodes;
+            ptree.getRoot()->recursFindPTreeNodesNamed("extension", extension_nodes);
+
+            for (auto node : extension_nodes) {
+                auto children = node->getChildren();
+                for (auto child : children) {
+                    auto parent = node->getParent();
+                    sparta_assert(parent != nullptr);
+                    auto path = parent->getPath();
+
+                    // Note that the ParameterTree path might contain wildcards
+                    std::vector<TreeNode*> tree_nodes;
+                    sim->getRoot()->getSearchScope()->findChildren(path, tree_nodes);
+
+                    auto extension_name = child->getName();
+                    for (auto tree_node : tree_nodes) {
+                        // Use the const getExtension() to see if this extension was
+                        // already created.
+                        auto is_user_created_ext = const_cast<const TreeNode*>(tree_node)->
+                            getExtension(extension_name) != nullptr;
+
+                        // We are calling the non-const getExtension() so we can force
+                        // factory-registered extensions to be created.
+                        auto extension = tree_node->getExtension(extension_name);
+                        if (!extension) {
+                            continue;
+                        }
+
+                        auto ps = extension->getParameters();
+                        std::vector<ParameterBase*> params;
+                        ps->getChildrenOfType<ParameterBase>(params);
+
+                        for (auto p : params) {
+                            if (child->getChild(p->getName())) {
+                                // Parameter already exists in ptree
+                                continue;
+                            }
+
+                            // Add parameter to the ptree
+                            auto n = child->create(p->getName(), false /*not required*/);
+                            n->setValue(p->getValueAsString(), false /*not required*/);
+                        }
+
+                        // Now that the ParameterTree is updated, remove the extension
+                        // we just created with the non-const getExtension() call.
+                        if (!is_user_created_ext) {
+                            auto root = sim->getRoot();
+                            auto & exts_ptree = root->getExtensionsUnboundParameterTree();
+                            auto n = exts_ptree.tryGet(tree_node->getLocation(), false /*must_be_leaf*/);
+                            auto success = n->clearUserData(extension_name);
+                            sparta_assert(success);
+                        }
+                    }
+                }
+            }
+
+            // Now look for all extensions in the tree, starting from root. Add any extensions
+            // and their parameters to the ptree.
+            using TreeNodeExtensions = std::map<std::string /*ext name*/, const TreeNode::ExtensionsBase* /*ext*/>;
+            using AllTreeNodeExtensions = std::map<const TreeNode* /*owning node*/, TreeNodeExtensions /*node exts*/>;
+            std::function<void(const TreeNode*, AllTreeNodeExtensions&)> recurse_find_exts;
+
+            recurse_find_exts = [&](const TreeNode* node, AllTreeNodeExtensions & extensions)
+            {
+                for (const auto & [ext_name, ext] : node->getAllExtensions()) {
+                    extensions[node][ext_name] = ext;
+                }
+                for (const auto child : node->getChildren()) {
+                    recurse_find_exts(child, extensions);
+                }
+            };
+
+            AllTreeNodeExtensions all_extensions;
+            recurse_find_exts(sim->getRoot(), all_extensions);
+
+            for (const auto & [tn, tn_exts] : all_extensions) {
+                for (const auto & [ext_name, ext] : tn_exts) {
+                    auto tmp_tn_loc = tn->getLocation();
+                    if (tmp_tn_loc.back() == '.') {
+                        tmp_tn_loc.pop_back();
+                    }
+
+                    const auto ptree_path_to_ext = tmp_tn_loc + ".extension." + ext_name;
+                    auto ptree_node = ptree.create(ptree_path_to_ext, false /*not required*/);
+
+                    auto ps = ext->getParameters();
+                    std::vector<ParameterBase*> params;
+                    ps->getChildrenOfType<ParameterBase>(params);
+
+                    for (auto p : params) {
+                        auto p_name = p->getName();
+                        auto p_value = p->getValueAsString();
+                        ptree_node->create(p_name, false /*not required*/)->setValue(p_value);
+                    }
+                }
+            }
+
+            sparta::ConfigEmitter::YAML param_out(filename, show_descriptions);
+            param_out.addParameters(sim->getRoot()->getSearchScope(), &ptree, sim_config_.verbose_cfg);
+        };
+
         // Store final config file(s) after finalization so that all dynamic parameters are built
         //! \todo Print configuration if finalizeTree fails with exception then rethrow
         if(final_config_file_ != ""){
-            sparta::ConfigEmitter::YAML param_out(final_config_file_,
-                                                  false); // Hide descriptions
             const auto& ptree = sim->getSimulationConfiguration()->getExtensionsUnboundParameterTree();
-            param_out.addParameters(sim->getRoot()->getSearchScope(), &ptree, sim_config_.verbose_cfg);
+            wrap_up_final_config(ptree, final_config_file_, false /*Hide descriptions*/);
         }
 
         if(final_config_file_verbose_ != ""){
-            sparta::ConfigEmitter::YAML param_out(final_config_file_verbose_,
-                                                  true); // Show descriptions
             const auto& ptree = sim->getSimulationConfiguration()->getExtensionsUnboundParameterTree();
-            param_out.addParameters(sim->getRoot()->getSearchScope(), &ptree, sim_config_.verbose_cfg);
+            wrap_up_final_config(ptree, final_config_file_verbose_, true /*Show descriptions*/);
         }
 
         if(sim_config_.pipeline_collection_file_prefix != NoPipelineCollectionStr)

--- a/sparta/src/SimulationConfiguration.cpp
+++ b/sparta/src/SimulationConfiguration.cpp
@@ -213,50 +213,6 @@ namespace app {
     }
 
     //! Local helper method that recurses down through a ParameterTree,
-    //! collecting all the nodes that have a given name.
-    void recursFindPTreeNodesNamed(
-        const std::string & name,
-        ParameterTree::Node * this_node,
-        std::vector<ParameterTree::Node*> & matching_nodes)
-    {
-        if (this_node == nullptr) {
-            return;
-        }
-
-        if (this_node->getName() == name) {
-            matching_nodes.emplace_back(this_node);
-            return;
-        }
-
-        const auto children = this_node->getChildren();
-        for (ParameterTree::Node * child : children) {
-            recursFindPTreeNodesNamed(name, child, matching_nodes);
-        }
-    }
-
-    //! Local helper method that recurses down through a ParameterTree,
-    //! collecting all the nodes that have a given name.
-    void recursFindPTreeNodesNamed(
-        const std::string & name,
-        const ParameterTree::Node * this_node,
-        std::vector<const ParameterTree::Node*> & matching_nodes)
-    {
-        if (this_node == nullptr) {
-            return;
-        }
-
-        if (this_node->getName() == name) {
-            matching_nodes.emplace_back(this_node);
-            return;
-        }
-
-        const auto children = this_node->getChildren();
-        for (const ParameterTree::Node * child : children) {
-            recursFindPTreeNodesNamed(name, child, matching_nodes);
-        }
-    }
-
-    //! Local helper method that recurses down through a ParameterTree,
     //! starting at a particular node in that tree, and collects all
     //! nodes that it finds during the traversal whose hasValue()==true
     void recursFindPTreeNodesWithValue(
@@ -284,8 +240,8 @@ namespace app {
         //"extension". This is a reserved keyword - a ParameterTree::Node with
         //this name is definitely for tree node extensions.
         std::vector<ParameterTree::Node*> extension_nodes;
-        recursFindPTreeNodesNamed("extension", arch_ptree_.getRoot(), extension_nodes);
-        recursFindPTreeNodesNamed("extension", ptree_.getRoot(),      extension_nodes);
+        arch_ptree_.getRoot()->recursFindPTreeNodesNamed("extension", extension_nodes);
+        ptree_.getRoot()->recursFindPTreeNodesNamed("extension", extension_nodes);
 
         if (extension_nodes.empty()) {
             return;
@@ -329,7 +285,7 @@ namespace app {
     bool SimulationConfiguration::hasTreeNodeExtensions() const
     {
         std::vector<const ParameterTree::Node*> extension_nodes;
-        recursFindPTreeNodesNamed("extension", extensions_ptree_.getRoot(), extension_nodes);
+        extensions_ptree_.getRoot()->recursFindPTreeNodesNamed("extension", extension_nodes);
         return !extension_nodes.empty();
     }
 

--- a/sparta/src/TreeNodeExtensions.cpp
+++ b/sparta/src/TreeNodeExtensions.cpp
@@ -59,6 +59,16 @@ public:
         return yaml_parameter_set_.get();
     }
 
+    ParameterSet * getParameters()
+    {
+        return parameters_.get();
+    }
+
+    ParameterSet * getYamlOnlyParameters()
+    {
+        return yaml_parameter_set_.get();
+    }
+
     void addParameter(std::unique_ptr<ParameterBase> param)
     {
         user_parameters_.emplace_back(std::move(param));
@@ -91,6 +101,16 @@ ParameterSet * ExtensionsParamsOnly::getParameters() const
 }
 
 ParameterSet * ExtensionsParamsOnly::getYamlOnlyParameters() const
+{
+    return impl_->getYamlOnlyParameters();
+}
+
+ParameterSet * ExtensionsParamsOnly::getParameters()
+{
+    return impl_->getParameters();
+}
+
+ParameterSet * ExtensionsParamsOnly::getYamlOnlyParameters()
 {
     return impl_->getYamlOnlyParameters();
 }


### PR DESCRIPTION
This follow-up PR fixes the backwards compatibility issue discussed here:

https://github.com/sparcians/map/issues/621

The source of the bug boils down to this:
- specify extensions in extension/arch/config file
- run the simulation with `--write-final-config`
- at runtime, register an extension factory
- then create the extension with `getExtension()` (implicit) or `createExtension()` (explicit)
- extension subclass `postCreate()` method is called
- in `postCreate()`, add some more parameters with default values

The bug as reported is that the final config YAML file only has the extension parameters that were given in the input YAML files. The default values added in `postCreate()` do not appear in the final config YAML file. This is different than the first extensions implementation where all parameters are written to the final config regardless.

These changes have been tested against Olympia and all regressions pass with no changes required to the Olympia source code. I also manually verified that all parameters show up the same way as before in the final config using the ticket's repro command:

`./olympia --write-final-config baseline.yaml --no-run`

This was also qualified against internal simulators with the only source changes outlined in an internal ticket.

I'll assign the ticket back to Zen to qualify/close it when this PR is merged.