### PR TITLE
Fix clang build failure

### DIFF
--- a/sparta/sparta/extensions/TreeNodeExtensionManager.hpp
+++ b/sparta/sparta/extensions/TreeNodeExtensionManager.hpp
@@ -193,8 +193,7 @@ public:
         }
 
         std::shared_ptr<ExtensionsBase> ext(new ExtensionT(std::forward<Args>(args)...));
-        ext->setParameters(std::make_unique<ParameterSet>(nullptr));
-        ext->postCreate();
+        doPostCreate_(ext.get());
 
         live_extensions_[loc][ExtensionT::NAME] = ext;
         return dynamic_cast<ExtensionT*>(ext.get());
@@ -368,6 +367,12 @@ private:
 
         return inner_it->second.get();
     }
+
+    /*!
+     * \brief Called when an extension is created via addExtension().
+     * Implemented in the cpp file to avoid circular includes.
+     */
+    void doPostCreate_(ExtensionsBase* extension) const;
 
     /*!
      * \brief Check if the given tree node location was configured

--- a/sparta/src/TreeNodeExtensionManager.cpp
+++ b/sparta/src/TreeNodeExtensionManager.cpp
@@ -2,6 +2,7 @@
 #include "sparta/simulation/ParameterTree.hpp"
 #include "sparta/simulation/RootTreeNode.hpp"
 #include "sparta/simulation/Parameter.hpp"
+#include "sparta/simulation/ParameterSet.hpp"
 #include "sparta/app/ConfigApplicators.hpp"
 
 #include <boost/algorithm/string.hpp>
@@ -680,6 +681,12 @@ void TreeNodeExtensionManager::checkAllYamlExtensionsCreated(
             throw SpartaException(err_oss.str());
         }
     }
+}
+
+void TreeNodeExtensionManager::doPostCreate_(ExtensionsBase* extension) const
+{
+    extension->setParameters(std::make_unique<ParameterSet>(nullptr));
+    extension->postCreate();
 }
 
 bool TreeNodeExtensionManager::inYamlConfig_(


### PR DESCRIPTION
Seems that gcc let this issue slide but clang does not. Even without calling `addExtension<T>()`, clang can fail to build our internal simulators since `ParameterSet` is not defined in `TreeNodeExtensionManager.hpp` where `make_unique<ParameterSet>()` is called.

Note also the circular include which prevents `ParameterSet.hpp` from being included by `TreeNodeExtensionManager.hpp`:

```
TreeNode.hpp
--> TreeNodeExtensionManager.hpp
----> ParameterSet.hpp
------> TreeNode.hpp
```