### PR TITLE
Added pkg-config support

### DIFF
--- a/sparta/CMakeLists.txt
+++ b/sparta/CMakeLists.txt
@@ -144,6 +144,19 @@ endif ()
 string (STRIP ${GIT_REPO_VERSION} GIT_REPO_VERSION)
 message (STATUS "Sparta Version: ${GIT_REPO_VERSION}")
 
+#pkg-config support
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sparta.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/sparta.pc
+  @ONLY
+)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/sparta.pc
+  DESTINATION lib/pkgconfig
+)
+
+
 # Use ccache if we've got it.
 find_program (CCACHE_PROGRAM ccache)
 if (CCACHE_PROGRAM)

--- a/sparta/cmake/sparta.pc.in
+++ b/sparta/cmake/sparta.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: sparta
+Description: High-performance C++ modeling framework
+Version: @GIT_REPO_VERSION@
+Requires: yaml-cpp sqlite3 hdf5
+Libs: -L${libdir} -lsparta -lboost_program_options -lboost_filesystem -lboost_system -lboost_timer -lboost_serialization -lz
+Cflags: -I${includedir} -std=c++17


### PR DESCRIPTION
This PR adds the support for `pkg-config`. 

After this we can do : 

```bash
jha@MAGICIAN:~/workspace$ pkg-config sparta --libs
-L/usr/local/lib -lsparta -lboost_program_options -lboost_filesystem -lboost_system -lboost_timer -lboost_serialization -lz -lyaml-cpp -lsqlite3 -L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5
jha@MAGICIAN:~/workspace$ pkg-config sparta --cflags
-I/usr/local/include -std=c++17 -I/usr/include/hdf5/serial
jha@MAGICIAN:~/workspace$
```

Here is the minimal CMakeList.txt to integrate `sparta` in your project : 

```
cmake_minimum_required(VERSION 3.20)
project(sparta_game_boy)
set(CMAKE_CXX_STANDARD 17)

find_package(PkgConfig REQUIRED)
pkg_check_modules(SPARTA REQUIRED sparta)

file(GLOB_RECURSE SOURCES sim/*.cpp core/*.cpp)

add_executable(sparta_game_boy ${SOURCES})

target_include_directories(sparta_game_boy PRIVATE
        ${SPARTA_INCLUDE_DIRS})

target_link_libraries(sparta_game_boy PRIVATE ${SPARTA_LINK_LIBRARIES} )

target_compile_options(sparta_game_boy PRIVATE ${SPARTA_CFLAGS_OTHER})
```

