### PR TITLE
Ensure we always throw for unread invalid params (#665)

### DIFF
--- a/sparta/src/Simulation.cpp
+++ b/sparta/src/Simulation.cpp
@@ -1868,7 +1868,7 @@ void Simulation::checkAllVirtualParamsRead_(const ParameterTree& pt)
             // is due to an extension never being created. We issue different
             // errors in that case.
             if(auto mgr = getExtensionManager(false)){
-                if(!ok && grandparent && grandparent->getParent()){
+                if(!ok && grandparent && grandparent->getParent() && grandparent->getName() == "extension"){
                     auto tn_loc = grandparent->getParent()->getPath();
                     auto ext_name = parent->getName();
                     if(!mgr->hasExtension(tn_loc, ext_name)){

--- a/sparta/src/SimulationConfiguration.cpp
+++ b/sparta/src/SimulationConfiguration.cpp
@@ -276,11 +276,11 @@ namespace app {
                 return true; // keep going
             }
 
-            auto & dest_ptree = path.find(".extension.") != std::string::npos ?
-                only_extensions : no_extensions;
-
+            auto for_extension = path.find(".extension.") != std::string::npos;
+            auto & dest_ptree = for_extension ? only_extensions : no_extensions;
+            auto value = for_extension ? leaf->getValue() : leaf->peekValue();
             auto n = dest_ptree.create(path, leaf->isRequired());
-            n->setValue(leaf->getValue(), leaf->isRequired(), leaf->getOrigin());
+            n->setValue(value, leaf->isRequired(), leaf->getOrigin());
 
             return true; // keep going
         });

--- a/sparta/test/TreeNodeExtensions/TreeNodeExtensions_test.cpp
+++ b/sparta/test/TreeNodeExtensions/TreeNodeExtensions_test.cpp
@@ -898,6 +898,23 @@ void TestFixesForReportedBugs()
         scheduler.reset();
         sim_config.reset();
     }
+
+    {
+        // Bug #3
+        // Pass in a bogus parameter and ensure that finalizeTree() throws
+        // due to nobody having read it
+        auto sim_config = std::make_unique<sparta::app::SimulationConfiguration>();
+        sim_config->processParameter("top.*.*.blah.nope", "true");
+        sim_config->copyTreeNodeExtensionsFromArchAndConfigPTrees();
+
+        auto scheduler = std::make_unique<sparta::Scheduler>();
+        auto sim = std::make_unique<TestSimulator>(*scheduler);
+
+        sim->configure(0, nullptr, sim_config.get(), false);
+        sim->buildTree();
+        sim->configureTree();
+        EXPECT_THROW(sim->finalizeTree());
+    }
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Cherry-picked `4c4aca99441628b54c048bb643cc69964198b15d`